### PR TITLE
NextjsSite: allow using existing CloudFront cache policies

### DIFF
--- a/packages/resources/src/NextjsSite.ts
+++ b/packages/resources/src/NextjsSite.ts
@@ -50,14 +50,13 @@ export interface NextjsSiteFunctionProps {
   permissions?: Permissions;
 }
 
-export type NextjsSiteDomainProps = BaseSiteDomainProps;
-
 export interface NextjsSiteCachePolicyProps {
-  staticsCachePolicy?: cloudfront.ICachePolicy;
+  staticCachePolicy?: cloudfront.ICachePolicy;
   imageCachePolicy?: cloudfront.ICachePolicy;
   lambdaCachePolicy?: cloudfront.ICachePolicy;
 }
 
+export type NextjsSiteDomainProps = BaseSiteDomainProps;
 export type NextjsSiteCdkDistributionProps = BaseSiteCdkDistributionProps;
 
 export class NextjsSite extends cdk.Construct {
@@ -757,8 +756,8 @@ export class NextjsSite extends cdk.Construct {
     ];
 
     // Build cache policy
-    const staticsCachePolicy =
-      cfCachePolicies?.staticsCachePolicy ??
+    const staticCachePolicy =
+      cfCachePolicies?.staticCachePolicy ??
       this.createCloudFrontStaticCachePolicy();
     const imageCachePolicy =
       cfCachePolicies?.imageCachePolicy ??
@@ -802,7 +801,8 @@ export class NextjsSite extends cdk.Construct {
             this,
             "ImageOriginRequest",
             {
-              queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
+              queryStringBehavior:
+                cloudfront.OriginRequestQueryStringBehavior.all(),
             }
           ),
           edgeLambdas: [
@@ -827,7 +827,7 @@ export class NextjsSite extends cdk.Construct {
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           compress: true,
-          cachePolicy: staticsCachePolicy,
+          cachePolicy: staticCachePolicy,
         },
         [this.pathPattern("static/*")]: {
           viewerProtocolPolicy,
@@ -835,7 +835,7 @@ export class NextjsSite extends cdk.Construct {
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           compress: true,
-          cachePolicy: staticsCachePolicy,
+          cachePolicy: staticCachePolicy,
         },
         [this.pathPattern("api/*")]: {
           viewerProtocolPolicy,

--- a/packages/resources/test/NextjsSite.test.ts
+++ b/packages/resources/test/NextjsSite.test.ts
@@ -795,10 +795,10 @@ test("constructor: cfCachePolicies props override", async () => {
         "LambdaCachePolicy",
         "lambdaCachePolicyId"
       ),
-      staticsCachePolicy: cf.CachePolicy.fromCachePolicyId(
+      staticCachePolicy: cf.CachePolicy.fromCachePolicyId(
         stack,
-        "StaticsCachePolicy",
-        "staticsCachePolicyId"
+        "StaticCachePolicy",
+        "staticCachePolicyId"
       ),
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/www/docs/constructs/NextjsSite.md
+++ b/www/docs/constructs/NextjsSite.md
@@ -268,6 +268,24 @@ site.attachPermissions(["sns"]);
 
 An instance of `NextjsSite` contains the following properties.
 
+### _static_ staticCachePolicyProps
+
+_Type_ : [`cloudfront.CachePolicyProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.CachePolicyProps.html)
+
+The default CloudFront cache policy properties for static pages.
+
+### _static_ imageCachePolicyProps
+
+_Type_ : [`cloudfront.CachePolicyProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.CachePolicyProps.html)
+
+The default CloudFront cache policy properties for images.
+
+### _static_ lambdaCachePolicyProps
+
+_Type_ : [`cloudfront.CachePolicyProps`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.CachePolicyProps.html)
+
+The default CloudFront cache policy properties for Lambda@Edge.
+
 ### url
 
 _Type_: `string`
@@ -388,6 +406,12 @@ _Type_: [`NextjsSiteCdkDistributionProps`](#nextjssitecdkdistributionprops)
 
 Pass in a `NextjsSiteCdkDistributionProps` value to override the default settings this construct uses to create the CDK `Distribution` internally.
 
+### cfCachePolicies?
+
+_Type_: [`NextjsSiteCachePolicyProps`](#nextjssitecachepolicyprops)
+
+Pass in a `NextjsSiteCachePolicyProps` value to override the default CloudFront cache policies created internally.
+
 ### defaultFunctionProps?
 
 _Type_: [`NextjsSiteFunctionProps`](#nextjssitefunctionprops), _defaults to_ `{}`
@@ -459,6 +483,26 @@ The amount of memory in MB allocated to this Lambda@Edge function.
 _Type_ : [`Permissions`](../util/Permissions.md), _defaults to_ `[]`
 
 Attaches the given list of [permissions](../util/Permissions.md) to the function.
+
+## NextjsSiteCachePolicyProps
+
+### staticCachePolicy?
+
+_Type_ : [`cloudfront.ICachePolicy`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.ICachePolicy.html), _defaults to created using [`staticCachePolicyProps`](#static-staticcachepolicyprops)_
+
+CloudFront cache policy for static pages.
+
+### imageCachePolicy?
+
+_Type_ : [`cloudfront.ICachePolicy`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.ICachePolicy.html), _defaults to created using [`imageCachePolicyProps`](#static-imagecachepolicyprops)_
+
+CloudFront cache policy for images.
+
+### lambdaCachePolicy?
+
+_Type_ : [`cloudfront.ICachePolicy`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudfront.ICachePolicy.html), _defaults to created using [`lambdaCachePolicyProps`](#static-lambdacachepolicyprops)_
+
+CloudFront cache policy for Lambda@Edge.
 
 ## NextjsSiteCdkDistributionProps
 


### PR DESCRIPTION
Resolves #899 

- Allows for access to the `CachePolicyProps` used in all three cases for the `Distribution` through static props on the `NextjsSite` class.
  - This is how you would create the cache policies outside the construct.
- Created a new prop named `cachePolicies` on `NextjsSiteCdkDistributionProps` that allows for the use of cachePolicies that are created outside the construct.
- The construct will now use the outside policies if they exist, or otherwise use existing behavior, ensuring backwards compatability.

This PR is a proposal, and includes no testing, but can be added once a decision is made.