### PR TITLE
WebSocketApi: fix AuthorizerResultTtlInSeconds cannot be set for WEBSOCKET protocol Apis

### DIFF
--- a/packages/cli/test/playground/lib/api-stack.ts
+++ b/packages/cli/test/playground/lib/api-stack.ts
@@ -23,5 +23,7 @@ export class MainStack extends sst.Stack {
       Endpoint: api.url || "no-url",
       CustomEndpoint: api.customDomainUrl || "no-custom-url",
     });
+
+    this.exportValue(api.url);
   }
 }

--- a/packages/cli/test/playground/lib/index.ts
+++ b/packages/cli/test/playground/lib/index.ts
@@ -9,20 +9,21 @@ import { MainStack as ApiStack } from "./api-stack";
 //import { MainStack as AnotherStack } from "./topic-to-queue-stack";
 //import { MainStack as AnotherStack } from "./app-sync-api-stack";
 //import { MainStack as AnotherStack } from "./api-with-lambda-authorizer";
-//import { MainStack as AnotherStack } from "./websocket-api-stack";
+import { MainStack as WebsocketStack } from "./websocket-api-stack";
 //import { MainStack as AnotherStack } from "./kinesis-stream";
 //import { MainStack as AnotherStack } from "./apiv1-stack";
 //import { MainStack as AnotherStack } from "./step-functions-stack";
 //import { MainStack as AnotherStack } from "./static-site-stack";
 //import { MainStack as SiteStack } from "./react-static-site-stack";
-import { MainStack as NextjsStack } from "./nextjs-site-stack";
-import { MainStack as ScriptStack } from "./script-stack";
+//import { MainStack as NextjsStack } from "./nextjs-site-stack";
+//import { MainStack as ScriptStack } from "./script-stack";
 import * as sst from "@serverless-stack/resources";
 
 export default async function main(app: sst.App): void {
   const apiStack = new ApiStack(app, "api");
+  new WebsocketStack(app, "websocket");
   //new SiteStack(app, "site", { api: apiStack.api });
-  new NextjsStack(app, "nextjs", { api: apiStack.api });
+  //new NextjsStack(app, "nextjs", { api: apiStack.api });
   //new ScriptStack(app, "script", { api: apiStack.api });
 }
 

--- a/packages/cli/test/playground/package.json
+++ b/packages/cli/test/playground/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "1.125.0",
+    "@aws-cdk/aws-apigatewayv2-authorizers": "1.125.0",
     "@aws-cdk/aws-appsync": "1.125.0",
     "@aws-cdk/aws-cloudfront": "1.125.0",
     "@aws-cdk/aws-s3": "1.125.0",


### PR DESCRIPTION
Closes #905 