### PR TITLE
Correct include path in tsconfig

### DIFF
--- a/packages/create-serverless-stack/templates/typescript/tsconfig.json
+++ b/packages/create-serverless-stack/templates/typescript/tsconfig.json
@@ -19,5 +19,5 @@
     "strictPropertyInitialization": false,
     "typeRoots": ["./node_modules/@types"]
   },
-  "include": ["lib","src"]
+  "include": ["stacks", "src"]
 }


### PR DESCRIPTION
Noticed that the include array in tsconfig.json still referenced lib instead of stacks so this is a minor fix to correct that.