### PR TITLE
fix: Remove package.json dependency of deprecated crypto package

### DIFF
--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -70,7 +70,6 @@
     "archiver": "^5.3.0",
     "chalk": "^4.1.0",
     "cross-spawn": "^7.0.3",
-    "crypto": "^1.0.1",
     "esbuild": "^0.12.20",
     "eslint": "^7.16.0",
     "fs-extra": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,11 +6660,6 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 css.escape@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"


### PR DESCRIPTION
The `crypto` package is built in to Node.js, with the npm published package explicitly recommending use of the internal module.

This caused me a world of pain with my bundler and took a great deal of effort to track down the issue being this innocuous dependency being utilised. 