### PR TITLE
Change how aws-lambda-ric module is resolved and spawned

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://serverless-stack.com",
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "2.15.0-alpha.0",
-    "@serverless-stack/aws-lambda-ric": "^2.0.12",
     "@serverless-stack/core": "^0.69.3",
     "@serverless-stack/resources": "^0.69.3",
     "aws-cdk": "2.15.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@serverless-stack/aws-lambda-ric": "^2.0.12",
     "@trpc/server": "^9.16.0",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "async-retry": "^1.3.3",


### PR DESCRIPTION
**Problem**

The live lambda development functionality spawns the `aws-lambda-ric` module using `npx` command to run the `aws-lambda-ric` script. The `npx` command expects to find the `aws-lambda-ric` script in the `node_modules/.bin/` folder. This doesn't work properly with PNPM as it doesn't install the `aws-lambda-ric` script in the expected location due to it not being a top level dependency but a dependency of `@serverless-stack/cli`.

**Details**

The following error is shown when running `pnpm start` and making a request that will call the lambda.

```
Debug session started. Listening for requests...
9fa9bc5b-7f98-4861-af22-0e7e00300cdb REQUEST dev-rest-api-my-stack-ApiLambdaGETB1714EF3-YVjrJ16SAUyF [src/lambda.handler] invoked by API GET /
2022-03-31T08:34:54.795Z    undefined   INFO    Executing '/Users/user/sst-pnpm/.sst/artifacts/dev-rest-api-my-stack-Api-Lambda_GET_-/src/lambda.handler' in function directory '/Users/user/sst-pnpm'
- /Users/user/.npm/_npx/53765/lib/node_modules/aws-lambda-ric/bin/index.jslient/index.jslient.jse-client.node'
```

**Workaround**

Adding the `aws-lambda-ric` dependency to the project's package.json will make the script available in `node_modules/.bin/` where `npx` can find it.

**Proposed fix**

Find the `aws-lambda-ric` module using `require.resolve()` and spawn it using `node` instead of `npx`. This is the same way as `cdk` is spawned in PR https://github.com/serverless-stack/serverless-stack/pull/1582.

Move the `aws-lambda-ric` dependency from `@serverless-stack/cli` to `@serverless-stack/core` as this dependency is used from core and not cli.
