### PR TITLE
Pin the open-next build command to a specific version

### DIFF
--- a/.changeset/stale-snakes-kiss.md
+++ b/.changeset/stale-snakes-kiss.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: pin minor OpenNext version

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -76,7 +76,7 @@ export class NextjsSite extends SsrSite {
 
   constructor(scope: Construct, id: string, props?: NextjsSiteProps) {
     super(scope, id, {
-      buildCommand: "npx --yes open-next@0.8.0 build",
+      buildCommand: "npx --yes open-next@^0.8.0 build",
       ...props,
     });
   }


### PR DESCRIPTION
By default, the build command in the NextjsSite construct uses the latest version of open-next.

This is unsafe as the latest version of open-next may not be compatible with the current version of SST and can cause production failures even when pinning down the version of SST.

Users already have the option to manually override the build command via the `buildCommand` prop. It's still not great that the default behaviour of the construct is unsafe.