### PR TITLE
docs: Add docs for cluster dev gotcha

### DIFF
--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -1193,6 +1193,12 @@ export interface ClusterServiceArgs {
  *
  * console.log(Resource.MyBucket.name);
  * ```
+ * 
+ * #### Running in dev
+ * 
+ * When running `sst dev` the cluster service will not be created.
+ * Use the `dev.command` argument to start a local docker container.
+ * 
  */
 export class Cluster extends Component {
   private constructorArgs: ClusterArgs;


### PR DESCRIPTION
I didn't see https://github.com/sst/ion/pull/1327 in the docs so adding here again, maybe because the repo changed.