### PR TITLE
docs: Add tip for WSL login

### DIFF
--- a/www/src/content/docs/docs/aws-accounts.mdx
+++ b/www/src/content/docs/docs/aws-accounts.mdx
@@ -222,6 +222,20 @@ All you need is a single configuration file for the AWS CLI, SST, or any random 
 
    This'll open your browser and prompt you to allow access. The sessions will last 12 hours, as we had configured previously.
 
+   :::tip
+   If you're working on Windows with WSL, you can open the login browser of the host machine like so:
+   
+   ```login.sh
+   #!/bin/bash
+
+   if grep -q WSL /proc/version; then
+      export BROWSER=wslview
+   fi
+
+   aws sso login --sso-session=acme
+   ```
+   :::
+
 4. Optionally, for Node.js projects, it can be helpful to add this to a `package.json` script so your team can just run `npm run sso` to login.
 
    ```json title="package.json"


### PR DESCRIPTION
In windows the browser via WSL is clunky, so I figured out a way to open it in the native browser of the host machine.