### PR TITLE
Update AWS Python example config

### DIFF
--- a/examples/aws-python/src/pyproject.toml
+++ b/examples/aws-python/src/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
 requires-python = ">=3.11,<3.12"
 
 [tool.uv.sources]
-# TODO: Before merging this PR, replace with SST's own source
-sst = { git = "https://github.com/walln/ion.git", subdirectory = "sdk/python", branch = "walln/python-fixes" }
+sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
 
 [tool.setuptools]
 py-modules = []


### PR DESCRIPTION
- Update aws-python example's `pyproject.toml` to point to SST's `dev` branch instead of `walln/python-fixes`

CC: @walln 