### PR TITLE
Add new removal policy forbid

### DIFF
--- a/cmd/sst/remove.go
+++ b/cmd/sst/remove.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"strings"
-
+	"github.com/sst/ion/internal/util"
 	"github.com/sst/ion/cmd/sst/cli"
 	"github.com/sst/ion/cmd/sst/mosaic/ui"
 	"github.com/sst/ion/pkg/bus"
@@ -17,6 +18,10 @@ func CmdRemove(c *cli.Cli) error {
 		return err
 	}
 	defer p.Cleanup()
+
+	if p.App().Removal == "forbid" {
+		return util.NewReadableError(nil, fmt.Sprintf(`Removing this project is forbidden for the stage "%s". Please update the removal policy and try again.`, p.App().Stage))
+	}
 
 	target := []string{}
 	if c.String("target") != "" {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -228,8 +228,8 @@ console.log("~j" + JSON.stringify(mod.app({
 				}
 			}
 
-			if proj.app.Removal != "remove" && proj.app.Removal != "retain" && proj.app.Removal != "retain-all" {
-				return nil, fmt.Errorf("Removal must be one of: remove, retain, retain-all")
+			if proj.app.Removal != "remove" && proj.app.Removal != "retain" && proj.app.Removal != "retain-all" && proj.app.Removal != "forbid" {
+				return nil, fmt.Errorf("Removal must be one of: remove, retain, retain-all", "forbid")
 			}
 			continue
 		}

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -135,6 +135,7 @@ export interface App {
    * - `remove`: Remove all your resources on remove.
    * - `retain`: Retains S3 buckets and DynamoDB tables, and remove all other resources.
    * - `retain-all`: Retains all your resources on remove.
+   * - `forbid`: Aborts `sst remove` before removing any resources.
    *
    * :::tip
    * If you change your removal policy, you'll need to deploy your app once for it to take effect.

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -149,7 +149,7 @@ export interface App {
    * }
    * ```
    */
-  removal?: "remove" | "retain" | "retain-all";
+  removal?: "remove" | "retain" | "retain-all" | "forbid";
   /**
    * The providers that are being used in this app. This allows you to use the resources from
    * these providers in your app.

--- a/platform/src/global.d.ts
+++ b/platform/src/global.d.ts
@@ -55,7 +55,7 @@ interface $APP
     /**
      * The removal policy for the current stage. If `removal` was not set in the `sst.config.ts`, this will be return its default value, `retain`.
      */
-    removal: "remove" | "retain" | "retain-all";
+    removal: "remove" | "retain" | "retain-all" | "forbid";
     /**
      * The providers currently being used in the app.
      */


### PR DESCRIPTION
what do you think of adding a guard rail option to [removal](https://sst.dev/docs/reference/config#removal) ?
{
  removal: input.stage === "production" ? "forbid" : "remove"
}

the idea is to prevent accidental resource removal in production environments. for example, if I mistakenly run a removal command targeting production, i’d prefer the operation to fail and crash, rather than proceed to remove all resources except S3 and DynamoDB. the crash could include a message about updating the removal policy to proceed. i think using retain-all keeps all resources, but i then need to do extra work to sync those resources back into sst. a guard rail could simplify this by preventing the issue in the first place.