### PR TITLE
fix: pass through nodePaths to esbuild

### DIFF
--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -141,6 +141,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 				properties.Banner,
 			}, "\n"),
 		},
+		NodePaths: properties.ESBuild.NodePaths,
 	}
 
 	if !isESM {


### PR DESCRIPTION
Resolves https://github.com/sst/sst/issues/4973
Was able to build and deploy the function with this added.