### PR TITLE
docs: Update Hono examples

### DIFF
--- a/www/src/content/docs/docs/start/aws/hono.mdx
+++ b/www/src/content/docs/docs/start/aws/hono.mdx
@@ -197,7 +197,7 @@ const app = new Hono()
 Let's try uploading a file from your project root. Make sure to use your API URL.
 
 ```bash
-curl --upload-file package.json "$(curl https://gyrork2ll35rsuml2yr4lifuqu0tsjft.lambda-url.us-east-1.on.aws)"
+curl -H "Content-Type: application/json" -T "package.json" "$(curl https://gyrork2ll35rsuml2yr4lifuqu0tsjft.lambda-url.us-east-1.on.aws)"
 ```
 
 Now head over to `https://gyrork2ll35rsuml2yr4lifuqu0tsjft.lambda-url.us-east-1.on.aws/latest` in your browser and it'll download the file you just uploaded.
@@ -370,7 +370,7 @@ Let's update the `/` route.
 ```ts title="index.ts"
 if (url.pathname === "/" && req.method === "GET") {
   const counter = await redis.incr("counter");
-  return new Response(`Hit counter: ${counter}`);
+  return c.text(`Hit counter: ${counter}`);
 }
 ```
 

--- a/www/src/content/docs/docs/start/cloudflare/hono.mdx
+++ b/www/src/content/docs/docs/start/cloudflare/hono.mdx
@@ -106,7 +106,7 @@ const app = new Hono()
         contentType: c.req.header("content-type"),
       },
     });
-    return new Response(`Object created with key: ${key}`);
+    return c.text(`Object created with key: ${key}`);
   });
 
 export default app;
@@ -177,7 +177,7 @@ This will give you the URL of your API.
 Let's try uploading a file from your project root. Make sure to use your API URL.
 
 ```bash
-curl --upload-file package.json https://my-hono-api-jayair-honoscript.sst-15d.workers.dev
+curl -H "Content-Type: application/json" -T "package.json" https://my-hono-api-jayair-honoscript.sst-15d.workers.dev
 ```
 
 Now head over to `https://my-hono-api-jayair-honoscript.sst-15d.workers.dev` in your browser and it'll load the file you just uploaded.


### PR DESCRIPTION
Update the examples:

- Swapped `Response` with `c.text()` [as recommended in Hono docs](https://hono.dev/docs/api/context#body).
- Added `Content-Type` for the upload operation so that it's actually retrieved when hitting the `/` route with GET method.