### PR TITLE
docs: update CLI command to `sst shell`

### DIFF
--- a/www/src/content/docs/blog/testing-in-sst.mdx
+++ b/www/src/content/docs/blog/testing-in-sst.mdx
@@ -10,14 +10,14 @@ pagefind: false
 
 import { YouTube } from '@astro-community/astro-embed-youtube';
 
-You can write tests for your SST apps using the new `sst load-config` CLI. It auto-loads secrets and config for your tests.
+You can write tests for your SST apps using the new `sst shell` CLI. It auto-loads secrets and config for your tests.
 
 Meaning that it'll load the `Config` of your app, but for your tests.
 
 So for example, this command loads your `Config` and runs your tests using [Vitest](https://vitest.dev).
 
 ```bash
-$ sst load-config -- vitest run
+$ sst shell -- vitest run
 ```
 
 Also, make sure to check out our launch announcement for `Config` in case you missed it.
@@ -25,7 +25,7 @@ Also, make sure to check out our launch announcement for `Config` in case you mi
 We updated the `create sst` GraphQL starter to include the updated `npm test` script.
 
 ```js
-"test": "sst load-config -- vitest run"
+"test": "sst shell -- vitest run"
 ```
 
 We also have a new chapter in our docs dedicated to testing. It includes how to write tests for the different parts of your app:
@@ -47,7 +47,7 @@ The video is timestamped and here's roughly what we covered.
 3. Testing domain code
 4. Testing APIs
 5. Testing stacks
-6. Deep dive into `sst load-config`
+6. Deep dive into `sst shell`
 7. Q&A
    1. How to test asynchronous workflow?
    2. How to run tests in parallel?


### PR DESCRIPTION
Update testing docs to replace `sst load-config` with `sst shell`

The `sst load-config` command is no longer available, as it's been replaced by `sst shell`.