### PR TITLE
fix: allow false when true is excepted

### DIFF
--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -155,7 +155,7 @@ export interface ApiGatewayWebSocketRouteArgs {
     /**
      * Enable IAM authorization for a given API route. When IAM auth is enabled, clients need to use Signature Version 4 to sign their requests with their AWS credentials.
      */
-    iam?: Input<true>;
+    iam?: Input<boolean>;
   }>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying

--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -153,7 +153,9 @@ export interface ApiGatewayWebSocketRouteArgs {
    */
   auth?: Input<{
     /**
-     * Enable IAM authorization for a given API route. When IAM auth is enabled, clients need to use Signature Version 4 to sign their requests with their AWS credentials.
+     * Enable IAM authorization for a given API route. When IAM auth is enabled, clients need
+     * to use Signature Version 4 to sign their requests with their AWS credentials.
+     * @default `false`
      */
     iam?: Input<boolean>;
   }>;
@@ -174,7 +176,8 @@ export interface ApiGatewayWebSocketRouteArgs {
 }
 
 /**
- * The `ApiGatewayWebSocket` component lets you add an [Amazon API Gateway WebSocket API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html) to your app.
+ * The `ApiGatewayWebSocket` component lets you add an [Amazon API Gateway WebSocket API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html)
+ * to your app.
  *
  * @example
  *

--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -449,7 +449,7 @@ export interface ApiGatewayV1RouteArgs {
          *
          * When IAM auth is enabled, clients need to use Signature Version 4 to sign their requests with their AWS credentials.
          */
-        iam?: Input<true>;
+        iam?: Input<boolean>;
         /**
          * Enable custom Lambda authorization for a given API route. Pass in the authorizer ID.
          * @example

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -524,7 +524,7 @@ export interface ApiGatewayV2RouteArgs {
         /**
          * Enable IAM authorization for a given API route. When IAM auth is enabled, clients need to use Signature Version 4 to sign their requests with their AWS credentials.
          */
-        iam?: Input<true>;
+        iam?: Input<boolean>;
         /**
          * Enable JWT or JSON Web Token authorization for a given API route. When JWT auth is enabled, clients need to include a valid JWT in their requests.
          *

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -165,7 +165,7 @@ export interface BucketArgs {
    * Bucket versioning enables you to store multiple versions of an object, protecting
    * against accidental deletion or overwriting.
    *
-   * @default Versioning disabled
+   * @default `false`
    * @example
    * ```js
    * {
@@ -408,21 +408,23 @@ export class Bucket extends Component implements Link.Linkable {
     }
 
     function createVersioning() {
-      if (!args.versioning) return;
+      return output(args.versioning).apply((versioning) => {
+        if (!versioning) return;
 
-      return new s3.BucketVersioningV2(
-        ...transform(
-          args.transform?.versioning,
-          `${name}Versioning`,
-          {
-            bucket: bucket.bucket,
-            versioningConfiguration: {
-              status: "Enabled",
+        return new s3.BucketVersioningV2(
+          ...transform(
+            args.transform?.versioning,
+            `${name}Versioning`,
+            {
+              bucket: bucket.bucket,
+              versioningConfiguration: {
+                status: "Enabled",
+              },
             },
-          },
-          { parent },
-        ),
-      );
+            { parent },
+          ),
+        );
+      });
     }
 
     function createPublicAccess() {

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -173,7 +173,7 @@ export interface BucketArgs {
    * }
    * ```
    */
-  versioning?: Input<true>;
+  versioning?: Input<boolean>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -235,7 +235,7 @@ export interface CognitoUserPoolArgs {
   /**
    * Enable software token MFA for the User Pool.
    *
-   * @default Software token MFA is disabled.
+   * @default `false`
    * @example
    *
    * ```ts
@@ -543,9 +543,11 @@ export class CognitoUserPool extends Component implements Link.Linkable {
             ),
             smsAuthenticationMessage: args.smsAuthenticationMessage,
             smsConfiguration: args.sms,
-            softwareTokenMfaConfiguration: args.softwareToken && {
-              enabled: true,
-            },
+            softwareTokenMfaConfiguration: output(args.softwareToken).apply(
+              (v) => ({
+                enabled: v ?? false,
+              }),
+            ),
             lambdaConfig:
               triggers &&
               triggers.apply((triggers) => {

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -244,7 +244,7 @@ export interface CognitoUserPoolArgs {
    * }
    * ```
    */
-  softwareToken?: Input<true>;
+  softwareToken?: Input<boolean>;
   /**
    * Configure triggers for this User Pool
    * @default No triggers

--- a/platform/src/components/aws/dynamo.ts
+++ b/platform/src/components/aws/dynamo.ts
@@ -212,7 +212,7 @@ export interface DynamoArgs {
    * }
    * ```
    */
-  deletionProtection?: Input<true>;
+  deletionProtection?: Input<boolean>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -967,7 +967,7 @@ export interface FunctionArgs {
   /**
    * Enable versioning for the function.
    *
-   * @default Versioning disabled
+   * @default `false`
    * @example
    * ```js
    * {

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -975,7 +975,7 @@ export interface FunctionArgs {
    * }
    * ```
    */
-  versioning?: Input<true>;
+  versioning?: Input<boolean>;
   /**
    * A list of Lambda layer ARNs to add to the function.
    *

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -113,7 +113,7 @@ export interface PostgresArgs {
    * }
    * ```
    */
-  proxy?: Input<true>;
+  proxy?: Input<boolean>;
   /**
    * @internal
    */

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -118,7 +118,7 @@ export interface VpcArgs {
    *
    * You can learn more about [`sst tunnel`](/docs/reference/cli#tunnel).
    *
-   * @default Bastion is not created
+   * @default `false`
    * @example
    * ```ts
    * {
@@ -428,32 +428,38 @@ export class Vpc extends Component implements Link.Linkable {
     }
 
     function createKeyPair() {
-      if (!args?.bastion) return {};
+      const ret = output(args?.bastion).apply((bastion) => {
+        if (!bastion) return {};
 
-      const tlsPrivateKey = new PrivateKey(
-        `${name}TlsPrivateKey`,
-        {
-          algorithm: "RSA",
-          rsaBits: 4096,
-        },
-        { parent },
-      );
+        const tlsPrivateKey = new PrivateKey(
+          `${name}TlsPrivateKey`,
+          {
+            algorithm: "RSA",
+            rsaBits: 4096,
+          },
+          { parent },
+        );
 
-      new ssm.Parameter(`${name}PrivateKey`, {
-        name: interpolate`/sst/vpc/${vpc.id}/private-key`,
-        type: ssm.ParameterType.SecureString,
-        value: tlsPrivateKey.privateKeyOpenssh,
+        new ssm.Parameter(`${name}PrivateKey`, {
+          name: interpolate`/sst/vpc/${vpc.id}/private-key`,
+          type: ssm.ParameterType.SecureString,
+          value: tlsPrivateKey.privateKeyOpenssh,
+        });
+
+        const keyPair = new ec2.KeyPair(
+          `${name}KeyPair`,
+          {
+            publicKey: tlsPrivateKey.publicKeyOpenssh,
+          },
+          { parent },
+        );
+
+        return { keyPair, privateKeyValue: tlsPrivateKey.privateKeyOpenssh };
       });
-
-      const keyPair = new ec2.KeyPair(
-        `${name}KeyPair`,
-        {
-          publicKey: tlsPrivateKey.publicKeyOpenssh,
-        },
-        { parent },
-      );
-
-      return { keyPair, privateKeyValue: tlsPrivateKey.privateKeyOpenssh };
+      return {
+        keyPair: output(ret.keyPair),
+        privateKeyValue: output(ret.privateKeyValue),
+      };
     }
 
     function createInternetGateway() {
@@ -612,26 +618,27 @@ export class Vpc extends Component implements Link.Linkable {
           { parent },
         );
 
-        return all([zones, publicSubnets]).apply(([zones, publicSubnets]) =>
-          zones.map((_, i) => {
-            return new ec2.Instance(
-              `${name}NatInstance${i + 1}`,
-              {
-                instanceType: nat.ec2.instance,
-                ami: ami.id,
-                subnetId: publicSubnets[i].id,
-                vpcSecurityGroupIds: [sg.id],
-                iamInstanceProfile: instanceProfile.name,
-                sourceDestCheck: false,
-                keyName: keyPair?.keyName,
-                tags: {
-                  Name: `${name} NAT Instance`,
-                  "sst:lookup-type": "nat",
+        return all([zones, publicSubnets, keyPair]).apply(
+          ([zones, publicSubnets, keyPair]) =>
+            zones.map((_, i) => {
+              return new ec2.Instance(
+                `${name}NatInstance${i + 1}`,
+                {
+                  instanceType: nat.ec2.instance,
+                  ami: ami.id,
+                  subnetId: publicSubnets[i].id,
+                  vpcSecurityGroupIds: [sg.id],
+                  iamInstanceProfile: instanceProfile.name,
+                  sourceDestCheck: false,
+                  keyName: keyPair?.keyName,
+                  tags: {
+                    Name: `${name} NAT Instance`,
+                    "sst:lookup-type": "nat",
+                  },
                 },
-              },
-              { parent },
-            );
-          }),
+                { parent },
+              );
+            }),
         );
       });
     }
@@ -757,99 +764,101 @@ export class Vpc extends Component implements Link.Linkable {
     }
 
     function createBastion() {
-      if (!args?.bastion) return undefined;
+      return all([args?.bastion, natInstances, keyPair]).apply(
+        ([bastion, natInstances, keyPair]) => {
+          if (!bastion) return undefined;
 
-      return natInstances.apply((natInstances) => {
-        if (natInstances.length) return natInstances[0];
+          if (natInstances.length) return natInstances[0];
 
-        const sg = new ec2.SecurityGroup(
-          `${name}BastionSecurityGroup`,
-          {
-            vpcId: vpc.id,
-            ingress: [
-              {
-                protocol: "tcp",
-                fromPort: 22,
-                toPort: 22,
-                cidrBlocks: ["0.0.0.0/0"],
-              },
-            ],
-            egress: [
-              {
-                protocol: "-1",
-                fromPort: 0,
-                toPort: 0,
-                cidrBlocks: ["0.0.0.0/0"],
-              },
-            ],
-          },
-          { parent },
-        );
-
-        const role = new iam.Role(
-          `${name}BastionRole`,
-          {
-            assumeRolePolicy: iam.getPolicyDocumentOutput({
-              statements: [
+          const sg = new ec2.SecurityGroup(
+            `${name}BastionSecurityGroup`,
+            {
+              vpcId: vpc.id,
+              ingress: [
                 {
-                  actions: ["sts:AssumeRole"],
-                  principals: [
-                    {
-                      type: "Service",
-                      identifiers: ["ec2.amazonaws.com"],
-                    },
-                  ],
+                  protocol: "tcp",
+                  fromPort: 22,
+                  toPort: 22,
+                  cidrBlocks: ["0.0.0.0/0"],
                 },
               ],
-            }).json,
-            managedPolicyArns: [
-              "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-            ],
-          },
-          { parent },
-        );
-        const instanceProfile = new iam.InstanceProfile(
-          `${name}BastionProfile`,
-          { role: role.name },
-          { parent },
-        );
-        const ami = ec2.getAmiOutput(
-          {
-            owners: ["amazon"],
-            filters: [
-              {
-                name: "name",
-                // The AMI has the SSM agent pre-installed
-                values: ["al2023-ami-2023.5.*"],
-              },
-              {
-                name: "architecture",
-                values: ["arm64"],
-              },
-            ],
-            mostRecent: true,
-          },
-          { parent },
-        );
-        return new ec2.Instance(
-          ...transform(
-            args?.transform?.bastionInstance,
-            `${name}BastionInstance`,
-            {
-              instanceType: "t4g.nano",
-              ami: ami.id,
-              subnetId: publicSubnets.apply((v) => v[0].id),
-              vpcSecurityGroupIds: [sg.id],
-              iamInstanceProfile: instanceProfile.name,
-              keyName: keyPair?.keyName,
-              tags: {
-                "sst:lookup-type": "bastion",
-              },
+              egress: [
+                {
+                  protocol: "-1",
+                  fromPort: 0,
+                  toPort: 0,
+                  cidrBlocks: ["0.0.0.0/0"],
+                },
+              ],
             },
             { parent },
-          ),
-        );
-      });
+          );
+
+          const role = new iam.Role(
+            `${name}BastionRole`,
+            {
+              assumeRolePolicy: iam.getPolicyDocumentOutput({
+                statements: [
+                  {
+                    actions: ["sts:AssumeRole"],
+                    principals: [
+                      {
+                        type: "Service",
+                        identifiers: ["ec2.amazonaws.com"],
+                      },
+                    ],
+                  },
+                ],
+              }).json,
+              managedPolicyArns: [
+                "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            },
+            { parent },
+          );
+          const instanceProfile = new iam.InstanceProfile(
+            `${name}BastionProfile`,
+            { role: role.name },
+            { parent },
+          );
+          const ami = ec2.getAmiOutput(
+            {
+              owners: ["amazon"],
+              filters: [
+                {
+                  name: "name",
+                  // The AMI has the SSM agent pre-installed
+                  values: ["al2023-ami-2023.5.*"],
+                },
+                {
+                  name: "architecture",
+                  values: ["arm64"],
+                },
+              ],
+              mostRecent: true,
+            },
+            { parent },
+          );
+          return new ec2.Instance(
+            ...transform(
+              args?.transform?.bastionInstance,
+              `${name}BastionInstance`,
+              {
+                instanceType: "t4g.nano",
+                ami: ami.id,
+                subnetId: publicSubnets.apply((v) => v[0].id),
+                vpcSecurityGroupIds: [sg.id],
+                iamInstanceProfile: instanceProfile.name,
+                keyName: keyPair?.keyName,
+                tags: {
+                  "sst:lookup-type": "bastion",
+                },
+              },
+              { parent },
+            ),
+          );
+        },
+      );
     }
 
     function createCloudmapNamespace() {

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -126,7 +126,7 @@ export interface VpcArgs {
    * }
    * ```
    */
-  bastion?: Input<true>;
+  bastion?: Input<boolean>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.


### PR DESCRIPTION
This pr changes ```Input<true>``` to ```Input<boolean>```

## Reason

Writing conditional is weird when only true is accepted, for example:

```
deletionProtection: isFeatureDeployment ? undefined : false,

```

or 

```
const extraValues = isFeatureDeployment ? {} : {deletionProtection: true}


// Later in code
{
...extraValues
}
```

instead of doing something like:

```
deletionProtection: !isFeatureDeployment
```

## Why this might be a bad idea?

There might be a reason why false is not allowed…