### PR TITLE
add "support" to exotic environments in `tunnel install`

### DIFF
--- a/pkg/tunnel/tunnel_linux.go
+++ b/pkg/tunnel/tunnel_linux.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log/slog"
@@ -43,6 +44,26 @@ func (p *linuxPlatform) install() error {
 	}
 	err = os.Chmod(BINARY_PATH, 0755)
 	user := os.Getenv("SUDO_USER")
+
+	if isNixOS() {
+		slog.Info("NixOS detected")
+		command := BINARY_PATH + " tunnel start *"
+		fmt.Println("For NixOS users you will also need to declare the following sudo configuration to complete the setup:")
+		fmt.Println("")
+		fmt.Println("  security.sudo.extraRules = [")
+		fmt.Println("    {")
+		fmt.Println("      users = [\"" + user + "\"]; # Your user")
+		fmt.Println("      commands = [")
+		fmt.Println("        {")
+		fmt.Println("          command = \"" + command + "\";")
+		fmt.Println("          options = [\"NOPASSWD\" \"SETENV\"];")
+		fmt.Println("        }")
+		fmt.Println("      ];")
+		fmt.Println("    }")
+		fmt.Println("  ];")
+		return nil
+	}
+
 	sudoersPath := "/etc/sudoers.d/sst-" + strings.ReplaceAll(user, ".", "")
 	slog.Info("creating sudoers file", "path", sudoersPath)
 	command := BINARY_PATH + " tunnel start *"
@@ -95,4 +116,19 @@ func (p *linuxPlatform) destroy() error {
 
 func resolveInterface() string {
 	return "sst"
+}
+
+func isNixOS() bool {
+	file, err := os.Open("/etc/os-release")
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "ID=nixos") {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This is a fix/workaround to #3962.

Not all systems work with `/etc/sudoers.d/*` files (such as NixOS), and this PR acknowledges that.

Beware I don't trust my skills with GO and therefore you need to test my changes before accepting them.