### PR TITLE
Expose ECS service scaling target

### DIFF
--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -1000,8 +1000,9 @@ export interface ClusterServiceArgs {
   permissions?: FunctionArgs["permissions"];
   /**
    * Configure the service to automatically scale up or down based on the CPU or memory
-   * utilization of a container. By default, scaling is disabled and the service will run
+   * utilization of a container. By default, autoscaling is disabled and the service will run
    * in a single container.
+   * A scaling target is always created for the service, alongside CPU and memory scaling policies.
    *
    * @default `{ min: 1, max: 1 }`
    *

--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -83,6 +83,7 @@ export class Service extends Component implements Link.Linkable {
   private readonly taskRole: iam.Role;
   private readonly taskDefinition?: Output<ecs.TaskDefinition>;
   private readonly loadBalancer?: lb.LoadBalancer;
+  private readonly scalingTarget?: appautoscaling.Target;
   private readonly domain?: Output<string | undefined>;
   private readonly _url?: Output<string>;
   private readonly devUrl?: Output<string>;
@@ -128,7 +129,7 @@ export class Service extends Component implements Link.Linkable {
     const { loadBalancer, targets } = createLoadBalancer();
     const cloudmapService = createCloudmapService();
     const service = createService();
-    createAutoScaling();
+    const scalingTarget = createAutoScaling();
     createDnsRecords();
 
     this._service = service;
@@ -136,6 +137,7 @@ export class Service extends Component implements Link.Linkable {
     this.executionRole = executionRole;
     this.taskDefinition = taskDefinition;
     this.loadBalancer = loadBalancer;
+    this.scalingTarget = scalingTarget;
     this.domain = lbArgs?.domain
       ? lbArgs.domain.apply((domain) => domain?.name)
       : output(undefined);
@@ -939,6 +941,8 @@ export class Service extends Component implements Link.Linkable {
         },
         { parent: self },
       );
+
+      return target;
     }
 
     function createDnsRecords() {
@@ -1072,6 +1076,16 @@ export class Service extends Component implements Link.Linkable {
           );
         return self.cloudmapService!;
       },
+      /**
+       * The Amazon Application Auto Scaling target.
+       */
+      get scalingTarget() {
+        if (self.dev)
+          throw new VisibleError(
+            "Cannot access `nodes.scalingTarget` in dev mode.",
+          );
+        return self.scalingTarget!;
+      }
     };
   }
 


### PR DESCRIPTION
Services in ECS can only have a single auto-scaling target, and one is created by SST's `Service` on
initialization. There's currently no simple
way to get a reference to this target, in order
to configure more complex scaling policies, such
as based on a SQS queue's depth.
This change enables this functionality, by exposing the default scaling target.