### PR TITLE
fix: align Queue binding property with Cloudflare's API

### DIFF
--- a/platform/src/components/cloudflare/queue.ts
+++ b/platform/src/components/cloudflare/queue.ts
@@ -56,7 +56,7 @@ export class Queue extends Component implements Link.Linkable {
         binding({
           type: "queueBindings",
           properties: {
-            queue: this.queue.id,
+            queue: this.queue.name,
           },
         }),
       ],


### PR DESCRIPTION
According to the issue #3970 

Cloudflare's Worker bindings have inconsistencies in their API:
1. Binding name registration varies:
   - D1, KV, R2: uses 'name' property
   - Queue, Hyperdrive: uses 'binding' property

2. Resource identifier format varies:
   - KV, D1: requires resource ID
   - Queue, R2: requires resource name

Note: this pr only solves the binding, the queue subscription is something that I would only try doing after having some feedback from the SST team and their vision of the design

Reproduction sample (should be created locally, of course)
https://stackblitz.com/edit/stackblitz-starters-dxtpht?file=index.ts 

sst.config.ts
```ts
export default $config({
  app(input) {
    /* */
  },
  async run() {
    const queue = new sst.cloudflare.Queue('LogQueue');
    const worker = new sst.cloudflare.Worker('Worker', {
      url: true,
      link: [queue],
      handler: 'index.ts',
    });

    return {
      url: worker.url,
    };
  },
});
```

index.ts
```ts
export default {
  async fetch(request, env, ctx): Promise<Response> {
    let log = {  url: request.url,  method: request.method, headers: Object.fromEntries(request.headers) };
    await Resource.LogQueue.send(log);
    return new Response('Success!');
  },
  async queue(batch, env): Promise<void> {
    let messages = JSON.stringify(batch.messages);
    console.log(`consumed from our queue: ${messages}`);
  },
} satisfies ExportedHandler;
```