### PR TITLE
Fix: realtime doesn't get correct endpoint when using a custom provider

### DIFF
--- a/platform/src/components/aws/realtime.ts
+++ b/platform/src/components/aws/realtime.ts
@@ -177,7 +177,7 @@ export class Realtime extends Component implements Link.Linkable {
     this.constructorOpts = opts;
     this.iotEndpoint = iot.getEndpointOutput({
       endpointType: "iot:Data-ATS",
-    }).endpointAddress;
+    }, { parent }).endpointAddress;
     this.constructorName = name;
     this.authHadler = authHadler;
     this.iotAuthorizer = iotAuthorizer;


### PR DESCRIPTION
When you create a realtime component using a custom provider (e.g. using a different region), the component is all correctly created, but. the output is incorrect / cannot be found. This is because the function iot.getEndpointOutput(), was missing the parent pulumi options. This fixes that