### PR TITLE
bug: update path for drizzle t3 link (Docs only update)

### DIFF
--- a/www/src/content/docs/docs/start/aws/drizzle.mdx
+++ b/www/src/content/docs/docs/start/aws/drizzle.mdx
@@ -18,7 +18,7 @@ Before you get started, make sure to [configure your AWS credentials](/docs/iam-
 
 We also have a few other Drizzle and Postgres examples that you can refer to.
 
-- [Use Next.js, Postgres, and Drizzle with the T3 Stack](docs/examples/#t3-stack-in-aws)
+- [Use Next.js, Postgres, and Drizzle with the T3 Stack](/docs/examples/#t3-stack-in-aws)
 - [Run Postgres in a local Docker container for dev](/docs/examples/#aws-postgres-local)
 
 ---


### PR DESCRIPTION
The current path of the t3 link [goes here](https://sst.dev/docs/start/aws/drizzle/docs/examples/#t3-stack-in-aws) which is a 404.

![image](https://github.com/user-attachments/assets/3cb27e9d-1868-4174-b067-96a2f06aef97)

This just adds a `/` fixing the link