### PR TITLE
docs: Add quotes around $default route

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -786,7 +786,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
    *
    * ```js title="sst.config.ts"
    * api.route("GET /", "src/get.handler")
-   * api.route($default, "src/default.handler");
+   * api.route("$default", "src/default.handler");
    * ```
    *
    * Add a parameterized route.

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -1053,7 +1053,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    *
    * ```js title="sst.config.ts"
    * api.route("GET /", "src/get.handler")
-   * api.route($default, "src/default.handler");
+   * api.route("$default", "src/default.handler");
    * ```
    *
    * Add a parameterized route.


### PR DESCRIPTION
The route variable needs to be a string otherwise you get `ReferenceError: $default is not defined`.