### PR TITLE
Fix postgres.get passing opts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Pulumi.yaml
 .netlify
 .env
 tmp
+
+# Editor
+.idea

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -695,11 +695,15 @@ export class Postgres extends Component implements Link.Linkable {
       $cli.state.version[name] = tags?.["sst:component-version"]
         ? parseInt(tags["sst:component-version"])
         : $cli.state.version[name];
-      return new Postgres(name, {
-        ref: true,
-        instance,
-        proxyId: args.proxyId,
-      } as unknown as PostgresArgs);
+      return new Postgres(
+        name,
+        {
+          ref: true,
+          instance,
+          proxyId: args.proxyId,
+        } as unknown as PostgresArgs,
+        opts,
+      );
     });
   }
 }


### PR DESCRIPTION
If postgres is created with a provider in a different region, it will fail to find `proxySecret`. 