### PR TITLE
Postgres-V1: update postgres-v1 to allow scale to zero

### DIFF
--- a/platform/src/components/aws/postgres-v1.ts
+++ b/platform/src/components/aws/postgres-v1.ts
@@ -20,7 +20,7 @@ function parseACU(acu: ACU) {
 export interface PostgresArgs {
   /**
    * The Postgres engine version. Check out the [available versions in your region](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.ServerlessV2.html#Concepts.Aurora_Fea_Regions_DB-eng.Feature.ServerlessV2.apg).
-   * @default `"15.5"`
+   * @default `"15.7"`
    * @example
    * ```js
    * {
@@ -48,9 +48,9 @@ export interface PostgresArgs {
    * is used for both writes and reads. The instance can scale from the minimum number of ACUs
    * to the maximum number of ACUs.
    *
-   * :::caution
-   * Aurora Serverless v2 does not scale down to 0. The minimum cost of a Postgres cluster
-   * per month is roughly `0.5 * $0.12 per ACU hour * 24 hrs * 30 days = $43.20`.
+   * :::warning
+   * Aurora Serverless v2 supports scale to 0 for PostgresSQL 13.15+, 14.12+, 15.7+ and 16.3+.
+   * However, the minimum cost of a Postgres cluster with 0.5 ACU per month is roughly `0.5 * $0.12 per ACU hour * 24 hrs * 30 days = $43.20`.
    * :::
    *
    * An ACU or Aurora Capacity Unit is a combination of CPU and RAM. The cost of an Aurora Serverless v2 cluster is based on the ACU hours
@@ -60,20 +60,20 @@ export interface PostgresArgs {
    * Each ACU is roughly equivalent to 2 GB of memory. So pick the minimum and maximum
    * based on the baseline and peak memory usage of your app.
    *
-   * @default `{min: "0.5 ACU", max: "4 ACU"}`
+   * @default `{min: "0 ACU", max: "4 ACU"}`
    */
   scaling?: Input<{
     /**
-     * The minimum number of ACUs, ranges from 0.5 to 128, in increments of 0.5.
+     * The minimum number of ACUs, ranges from 0 to 128, in increments of 0.5.
      *
-     * For your production workloads, setting a minimum of 0.5 ACUs might not be a great idea due
+     * For your production workloads, setting a minimum of 0 ACUs might not be a great idea due
      * to the following reasons, you can also [read more here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.setting-capacity.incompatible_parameters).
      * - It takes longer to scale from a low number of ACUs to a much higher number.
      * - Query performance depends on the buffer cache. So if frequently accessed data cannot
      *   fit into the buffer cache, you might see uneven performance.
      * - The max connections for a 0.5 ACU Postgres instance is capped at 2000.
      *
-     * @default `0.5 ACU`
+     * @default `0 ACU`
      * @example
      * ```js
      * {
@@ -278,13 +278,13 @@ export class Postgres extends Component implements Link.Linkable {
 
     function normalizeScaling() {
       return output(args.scaling).apply((scaling) => ({
-        minCapacity: parseACU(scaling?.min ?? "0.5 ACU"),
+        minCapacity: parseACU(scaling?.min ?? "0 ACU"),
         maxCapacity: parseACU(scaling?.max ?? "4 ACU"),
       }));
     }
 
     function normalizeVersion() {
-      return output(args.version).apply((version) => version ?? "15.5");
+      return output(args.version).apply((version) => version ?? "15.7");
     }
 
     function normalizeDatabaseName() {


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-aurora-serverless-v2-scaling-zero-capacity/