### PR TITLE
Clarify Postgres `storage` docs

### DIFF
--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -88,8 +88,11 @@ export interface PostgresArgs {
   /**
    * The maximum storage limit for the database.
    *
-   * :::tip
-   * You are only billed for the storage you use, not the maximum limit. RDS will autoscale your storage to match your usage up to the limit.
+   * RDS will autoscale your storage to match your usage up to the given limit. 
+   * You are not billed for the maximum storage limit, You are only billed for the storage you use.
+   *
+   * :::note
+   * You are only billed for the storage you use, not the maximum limit.
    * :::
    *
    * By default, [gp3 storage volumes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage.GeneralSSD)

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -86,7 +86,11 @@ export interface PostgresArgs {
    */
   instance?: Input<string>;
   /**
-   * The amount of storage to use for the database.
+   * The maximum storage limit for the database.
+   *
+   * :::tip
+   * You are only billed for the storage you use, not the maximum limit.
+   * :::
    *
    * By default, [gp3 storage volumes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage.GeneralSSD)
    * are used without additional provisioned IOPS. This provides a good baseline performance

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -89,7 +89,7 @@ export interface PostgresArgs {
    * The maximum storage limit for the database.
    *
    * :::tip
-   * You are only billed for the storage you use, not the maximum limit.
+   * You are only billed for the storage you use, not the maximum limit. RDS will autoscale your storage to match your usage up to the limit.
    * :::
    *
    * By default, [gp3 storage volumes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage.GeneralSSD)


### PR DESCRIPTION
The current `storage` option for the `Postgres` component [sets the `maxAllocatedStorage`](https://github.com/vimtor/sst/blob/e5f4b6ce8c2c7ba44307091df7e5683e05e148fa/platform/src/components/aws/postgres.ts#L463-L463) not the [`allocatedStorage`](https://www.pulumi.com/registry/packages/aws/api-docs/rds/instance/#allocatedstorage_nodejs)

I thought the docs could be a bit more explicit about that.