### PR TITLE
Add confirmation before running `sst dev` on a non-local stage

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/charmbracelet/huh"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -43,6 +44,27 @@ func CmdMosaic(c *cli.Cli) error {
 		if err != nil {
 			return err
 		}
+
+		personalStage := project.LoadPersonalStage(cfgPath)
+		if personalStage != "" && stage != personalStage {
+			var confirmed bool
+			err := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("It seems like you are about to run dev mode in \"%s\". Are you sure you want to continue?", stage)).
+						Description("Running dev mode in a non-local stage could result in resources being deleted.").
+						Value(&confirmed),
+				),
+			).WithTheme(huh.ThemeCatppuccin()).Run()
+
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+		}
+
 		url, err := server.Discover(cfgPath, stage)
 		if err != nil {
 			return err


### PR DESCRIPTION
The other day, I accidentally ran `sst dev --stage production` instead of `sst tunnel --stage production`. I don't know if it was because I panicked and canceled it, but it messed with the Pulumi state to the point that I had to create a new AWS account to make my life easier.

I don't know if there is even a use case for running `sst dev` on a specific stage, but I figured it would make sense to have a confirmation before running it if the stage is not the personal one.

![CleanShot 2024-11-23 at 09 37 15@2x](https://github.com/user-attachments/assets/75517463-7248-4809-87f6-e49be3d32ca2)
