### PR TITLE
fix(cli): ensure sst upgrade only replaces entry in package.json dependencies

### DIFF
--- a/pkg/global/upgrade.go
+++ b/pkg/global/upgrade.go
@@ -122,7 +122,9 @@ func UpgradeNode(existingVersion string, nextVersion string) (map[string]string,
 	if err != nil {
 		return result, err
 	}
-	re := regexp.MustCompile(`"sst": "[^"]+"`)
+
+	// Ensure we only replace an existing "sst" entry in dependencies/devDependencies of package.json
+	re := regexp.MustCompile(`(("dependencies"|"devDependencies")\s*:\s*{[^}]*"sst"\s*:\s*)"[^"]*"`)
 	for _, file := range files {
 		if strings.HasPrefix(file, ".sst") {
 			continue
@@ -138,7 +140,7 @@ func UpgradeNode(existingVersion string, nextVersion string) (map[string]string,
 		if len(matches) == 0 {
 			continue
 		}
-		data = re.ReplaceAll(data, []byte(`"sst": "`+nextVersion+`"`))
+		data = re.ReplaceAll(data, []byte(`${1}"`+nextVersion+`"`))
 		err = os.WriteFile(file, data, 0666)
 		if err != nil {
 			return result, err


### PR DESCRIPTION
Fixes #5098 

Tested the following scenarios leave the `"sst"` entry in `scripts` untouched when running `sst upgrade` with a local cli binary after this change:

```json
	"scripts": {
		"sst": "echo \"hello\""
	},
	"dependencies": {
		"sst": "3.3.27"
	}
```

```json
	"scripts": {
		"sst": "echo \"hello\""
	},
	"dependencies": {
		"sst": "latest"
	}
```

```json
	"scripts": {
		"sst": "echo \"hello\""
	},
	"devDependencies": {
		"sst": "3.3.27"
	}
```