### PR TITLE
Update lambda to allow Python 3.13 runtime

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -269,6 +269,7 @@ export interface FunctionArgs {
     | "python3.10"
     | "python3.11"
     | "python3.12"
+    | "python3.13"
   >;
   /**
    * Path to the source code directory for the function. By default, the handler is


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2024/11/aws-lambda-support-python-313/