### PR TITLE
chore: add utf-8 encoding argument on all fs.readFile usages

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1943,7 +1943,7 @@ export class Function extends Component implements Link.Linkable {
 
           // Calculate hash of the zip file
           const hash = crypto.createHash("sha256");
-          hash.update(await fs.promises.readFile(zipPath));
+          hash.update(await fs.promises.readFile(zipPath, 'utf-8'));
           const hashValue = hash.digest("hex");
           const assetBucket = region.apply((region) =>
             bootstrap.forRegion(region).then((d) => d.asset),

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -536,7 +536,7 @@ export function createServersAndDistribution(
                 ...(await Promise.all(
                   files.map(async (file) => {
                     const source = path.resolve(outputPath, copy.from, file);
-                    const content = await fs.promises.readFile(source);
+                    const content = await fs.promises.readFile(source, 'utf-8');
                     const hash = crypto
                       .createHash("sha256")
                       .update(content)
@@ -1028,7 +1028,7 @@ async function handler(event) {
                 }).forEach((filePath) =>
                   hash.update(
                     fs.readFileSync(
-                      path.resolve(outputPath, item.from, filePath),
+                      path.resolve(outputPath, item.from, filePath), 'utf-8'
                     ),
                   ),
                 );

--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -760,7 +760,7 @@ export class StaticSite extends Component implements Link.Linkable {
             ...(await Promise.all(
               files.map(async (file) => {
                 const source = path.resolve(outputPath, file);
-                const content = await fs.promises.readFile(source);
+                const content = await fs.promises.readFile(source, 'utf-8');
                 const hash = crypto
                   .createHash("sha256")
                   .update(content)
@@ -942,7 +942,7 @@ async function handler(event) {
             follow: true,
             cwd: path.resolve(outputPath),
           }).forEach((filePath) =>
-            hash.update(fs.readFileSync(path.resolve(outputPath, filePath))),
+            hash.update(fs.readFileSync(path.resolve(outputPath, filePath), 'utf-8')),
           );
 
           return {

--- a/platform/src/components/cloudflare/ssr-site.ts
+++ b/platform/src/components/cloudflare/ssr-site.ts
@@ -132,7 +132,7 @@ export function createRouter(
               ...(await Promise.all(
                 files.map(async (file) => {
                   const source = path.resolve(outputPath, copy.from, file);
-                  const content = await fs.promises.readFile(source);
+                  const content = await fs.promises.readFile(source, 'utf-8');
                   const hash = crypto
                     .createHash("sha256")
                     .update(content)

--- a/platform/src/components/cloudflare/static-site.ts
+++ b/platform/src/components/cloudflare/static-site.ts
@@ -330,7 +330,7 @@ export class StaticSite extends Component implements Link.Linkable {
               ...(await Promise.all(
                 files.map(async (file) => {
                   const source = path.resolve(outputPath, file);
-                  const content = await fs.promises.readFile(source);
+                  const content = await fs.promises.readFile(source, 'utf-8');
                   const hash = crypto
                     .createHash("sha256")
                     .update(content)


### PR DESCRIPTION
This causes the the following typescript issue to not happen:

```
 Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BinaryLike'.
  Type 'Buffer<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBufferLike> | DataView<ArrayBufferLike>'.
    Type 'Buffer<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
      The types returned by 'slice(...).entries()' are incompatible between these types.
        Type 'IterableIterator<[number, number]>' is missing the following properties from type 'ArrayIterator<[number, number]>': map, filter, take, drop, and 9 more.
```        