### PR TITLE
Fixing minor typo in bun.mdx

### DIFF
--- a/www/src/content/docs/docs/start/aws/bun.mdx
+++ b/www/src/content/docs/docs/start/aws/bun.mdx
@@ -3,7 +3,7 @@ title: Bun on AWS with SST
 description: Create and deploy a Bun app to AWS with SST.
 ---
 
-We are going to build an app with Bun, add an S4 Bucket for file uploads, and deploy it to AWS in a container with SST.
+We are going to build an app with Bun, add an S3 Bucket for file uploads, and deploy it to AWS in a container with SST.
 
 :::tip[View source]
 You can [view the source](https://github.com/sst/sst/tree/dev/examples/aws-bun) of this example in our repo.


### PR DESCRIPTION
The intro paragraph had a reference to `S4` not `S3`. Cleaned it up.