### PR TITLE
Add missing config values to sst.config.ts in aws-accounts.mdx

### DIFF
--- a/www/src/content/docs/docs/aws-accounts.mdx
+++ b/www/src/content/docs/docs/aws-accounts.mdx
@@ -261,7 +261,7 @@ Next, let's configure SST to use these profiles.
 
 In your `sst.config.ts` file check which stage you are deploying to and return the right profile.
 
-```ts title="sst.config.ts" {7}
+```ts title="sst.config.ts" {8}
 export default $config({
   app(input) {
     return {
@@ -274,9 +274,8 @@ export default $config({
       }
     };
   },
-
   async run() {
-    // your app's resources
+    // Your resources
   }
 });
 ```

--- a/www/src/content/docs/docs/aws-accounts.mdx
+++ b/www/src/content/docs/docs/aws-accounts.mdx
@@ -266,12 +266,17 @@ export default $config({
   app(input) {
     return {
       name: "my-sst-app",
+      home: "aws",
       providers: {
         aws: {
           profile: input.stage === "production" ? "acme-production" : "acme-dev"
         }
       }
     };
+  },
+
+  async run() {
+    // your app's resources
   }
 });
 ```


### PR DESCRIPTION
I'm setting up a new SST project and noticed that following the instructions in aws-accounts.mdx results in this error when running `sst deploy`:

```
✕  You must specify a "home" provider in the project configuration file.
```

This adds additional config values from the sst.config.ts reference and includes them in the example. I'm open to feedback on a more helpful comment to include inside the `run` function.