### PR TITLE
Cloudflare: fix `WorkerArgs.build.esbuild.platform` being ignored

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -88,7 +88,7 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	}
 
 	options := esbuild.BuildOptions{
-		Platform: esbuild.PlatformNode,
+		Platform: build.ESBuild.Platform,
 		Stdin: &esbuild.StdinOptions{
 			Contents: fmt.Sprintf(`
       import handler from "%s"


### PR DESCRIPTION
Ref: #5178

Example of fixing documented `build.esbuild.platform` option. It's the only one I need to unblock my work, but can take a pass at more if this is a direction y'all are interested in