### PR TITLE
feat: allow transformation of fck-nat tags and instance

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -922,22 +922,25 @@ export class Vpc extends Component implements Link.Linkable {
           ([zones, publicSubnets, keyPair, bastion]) =>
             zones.map((_, i) => {
               return new ec2.Instance(
-                `${name}NatInstance${i + 1}`,
-                {
-                  instanceType: nat.ec2.instance,
-                  ami,
-                  subnetId: publicSubnets[i].id,
-                  vpcSecurityGroupIds: [sg.id],
-                  iamInstanceProfile: instanceProfile.name,
-                  sourceDestCheck: false,
-                  keyName: keyPair?.keyName,
-                  tags: {
-                    Name: `${name} NAT Instance`,
-                    "sst:is-nat": "true",
-                    ...(bastion && i === 0 ? { "sst:is-bastion": "true" } : {}),
+                ...transform(
+                  args.transform?.natInstance,
+                  `${name}NatInstance${i + 1}`,
+                  {
+                    instanceType: nat.ec2.instance,
+                    ami,
+                    subnetId: publicSubnets[i].id,
+                    vpcSecurityGroupIds: [sg.id],
+                    iamInstanceProfile: instanceProfile.name,
+                    sourceDestCheck: false,
+                    keyName: keyPair?.keyName,
+                    tags: {
+                      Name: `${name} NAT Instance`,
+                      "sst:is-nat": "true",
+                      ...(bastion && i === 0 ? { "sst:is-bastion": "true" } : {}),
+                    },
                   },
-                },
-                { parent: self },
+                  { parent: self },
+                )
               );
             }),
         );


### PR DESCRIPTION
i'm unable to customize the tags of the nat instances created by fck-nat

i believe is missing the `transform` fn on resource creation

```ts
    const vpc = new sst.aws.Vpc("vpc", {
      az: 2,
      nat: "ec2",
      transform: {
        vpc: {
          tags: {
            Name: `${RESOURCE_PREFIX}-vpc`,
          },
        },
        natInstance: {
          tags: {
            Name: `${RESOURCE_PREFIX}-fck-nat`,
          },
        },
      },
    });
```

![CleanShot 2024-12-15 at 13 25 01](https://github.com/user-attachments/assets/092a9d98-d6fd-440e-a935-cfa42bf9db7d)
