### PR TITLE
fix: SolidStart Nitro AppConfig AWS Lambda streaming

### DIFF
--- a/platform/src/components/aws/solid-start.ts
+++ b/platform/src/components/aws/solid-start.ts
@@ -384,7 +384,7 @@ export class SolidStart extends Component implements Link.Linkable {
       const nitro = JSON.parse(
         fs.readFileSync(path.join(output, ".output/nitro.json")).toString(),
       );
-      if (!["aws-lambda", "aws-lambda"].includes(nitro.preset)) {
+      if (nitro.preset !== "aws-lambda") {
         throw new VisibleError(
           `SolidStart's app.config.ts must be configured to use the "aws-lambda" preset. It is currently set to "${nitro.preset}".`,
         );
@@ -456,7 +456,7 @@ export class SolidStart extends Component implements Link.Linkable {
             description: "Server handler for Solid",
             handler: "index.handler",
             bundle: path.join(outputPath, ".output", "server"),
-            streaming: nitro?.config?.streaming === true,
+            streaming: nitro?.config?.awsLambda?.streaming === true,
           };
 
           return validatePlan({


### PR DESCRIPTION
The PR is doing the following: 
- Cleaned the SolidStart `aws-lambda` nitro preset check up.
- Fixed the configuration for enabling streaming via `app.config.ts`.

Note: This should also resolve the issues from #4235 