### PR TITLE
docs: add linking rds sample in drizzle-nextjs-rds setup

### DIFF
--- a/www/src/content/docs/docs/start/aws/drizzle.mdx
+++ b/www/src/content/docs/docs/start/aws/drizzle.mdx
@@ -92,6 +92,15 @@ async run() {
 
 The `proxy` option configures an RDS Proxy behind the scenes making it ideal for serverless applications.
 
+Make sure to [link](/docs/linking/) your RDS to your Next.js component to access your Postgres database. This eliminates the need to use .env files.
+
+```ts title="sst.config.ts" {3}
+new sst.aws.Nextjs("MyWeb", {
+   vpc,
+   link: [rds]
+ });
+```
+
 :::tip
 The RDS Proxy allows serverless environments to reliably connect to RDS.
 :::


### PR DESCRIPTION
### Summary
This pull request adds a missing rds link to the Next.js application stack configuration, ensuring consistency with the [SST documentation example](https://sst.dev/docs/examples/#t3-stack-in-aws). Personally experienced the proxy issue when following the [Drizzle with Amazon RDS and SST](https://sst.dev/docs/start/aws/drizzle) example.

### Problem
Without linking the RDS instance, an error occurs during the creation of the RDS Proxy. Specifically, the following exception is thrown:

```
| MyPostgres sst:aws:Postgres → MyPostgresProxy aws:rds:Proxysdk-v2/provider2.go:520: sdk.helper_schema: creating RDS DB Proxy (xxxx-mypostgresproxy): operation error RDS: CreateDBProxy, https response error StatusCode: 400, RequestID: bdb1afe0-07a1-44a5-bbac-ba3d13a86e12, api error InvalidParameterValue: RDS is not authorized to assume service-linked role arn:aws:iam::043309365216:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS (Service: AWSSecurityTokenService; Status Code: 403; Error Code: AccessDenied; Request ID: 91ee22ab-1497-4046-b904-8ac27a16e625; Proxy: null). Check your RDS service-linked role and try again.: provider=aws@6.65.
```

### Cause
When the RDS instance is not linked, SST’s deployment sequence does not properly trigger the creation or usage of the necessary service-linked role for the RDS Proxy.

### Solution
By adding the `link: [rds]` configuration, we align with the official SST examples and ensure that the RDS Proxy is created successfully. This change also addresses the issue documented in [SST Issue #3940](https://github.com/sst/sst/issues/3940).

### References
- [Drizzle with Amazon RDS and SST](https://sst.dev/docs/start/aws/drizzle)
- [SST Documentation Example](https://sst.dev/docs/examples/#t3-stack-in-aws)
- [Issue #3940](https://github.com/sst/sst/issues/3940)