### PR TITLE
add(sst init nextjs): disable eslint on reference line in sst.config.ts

### DIFF
--- a/cmd/sst/init.go
+++ b/cmd/sst/init.go
@@ -228,6 +228,26 @@ func CmdInit(cli *cli.Cli) error {
 		spin.Stop()
 	}
 
+	if template == "nextjs" {
+		hasEslint := slices.ContainsFunc(hints, func(s string) bool {
+			return strings.Contains(strings.ToLower(s), "eslint")
+		})
+
+		if hasEslint {
+			configFile := "sst.config.ts"
+			content, err := os.ReadFile(configFile)
+			if err != nil {
+				return err
+			}
+
+			newContent := "// eslint-disable-next-line @typescript-eslint/triple-slash-reference\n" + string(content)
+			err = os.WriteFile(configFile, []byte(newContent), 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	spin.Stop()
 
 	if len(instructions) == 0 {


### PR DESCRIPTION
When you create a new nextjs application with `npx create-next-app` it will by default add `eslint.config.mjs` to the project with the rule [triple-slash-reference](https://typescript-eslint.io/rules/triple-slash-reference/) turned on as error. 

This PR will check if the template == `nextjs` and if the directory contains a file `*eslint*`. If so it will add a disable eslint above the top reference line.