### PR TITLE
fix(sst.cloudflare.Worker): include "define" property in esbuild options

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -109,6 +109,7 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		Loader:            loader,
 		KeepNames:         true,
 		Bundle:            true,
+		Define:            build.ESBuild.Define,
 		Splitting:         build.Splitting,
 		Metafile:          true,
 		Write:             true,


### PR DESCRIPTION
When building a Cloudflare Worker using the `sst.cloudflare.Worker` component, it appears that the `define` option in ESBuild is not being passed along correctly. This also causes the `sst.cloudflare.StaticSite` component to fail in production — see #5241 for details.

This one-line change seems to fix it — I've tested the Worker component with and without.

Edit: Confirmed that this fixes the StaticSite component as well!