### PR TITLE
Fix: copyFiles in Function used $dev instead of dev

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1794,7 +1794,7 @@ export class Function extends Component implements Link.Linkable {
           args.transform?.role,
           `${name}Role`,
           {
-            assumeRolePolicy: !$dev
+            assumeRolePolicy: !dev
               ? iam.assumeRolePolicyForPrincipal({
                   Service: "lambda.amazonaws.com",
                 })

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1982,7 +1982,7 @@ export class Function extends Component implements Link.Linkable {
             }
 
             // Add copyFiles into the zip
-            if (!$dev) {
+            if (!dev) {
               for (const entry of copyFiles) {
                 entry.isDir
                   ? archive.directory(entry.from, entry.to, {


### PR DESCRIPTION
You accidentally used the $dev variable instead of dev variable in this commit 2caabf2 to prevent copy files in dev