### PR TITLE
Update auth.ts

### DIFF
--- a/platform/src/components/aws/auth.ts
+++ b/platform/src/components/aws/auth.ts
@@ -220,6 +220,12 @@ export class Auth extends Component implements Link.Linkable {
     );
   }
 
+  public get tableName() {
+    return (
+      this._table.name
+    );
+  }
+
   /**
    * The underlying [resources](/docs/components/#nodes) this component creates.
    */
@@ -245,6 +251,7 @@ export class Auth extends Component implements Link.Linkable {
     return {
       properties: {
         url: this.url,
+        tableName: this.tableName
       },
       include: [
         env({


### PR DESCRIPTION
`tableName` is missing in the Auth component that's needed by the authoriser function to use with `DynamoStorage`. 

This change adds `tableName` which makes linking easier.