### PR TITLE
fix: ensure pause after is only set with min ACU 0

### DIFF
--- a/platform/src/components/aws/aurora.ts
+++ b/platform/src/components/aws/aurora.ts
@@ -515,11 +515,23 @@ export class Aurora extends Component implements Link.Linkable {
 
     function normalizeScaling() {
       return output(args.scaling).apply((scaling) => {
-        return {
+        const min = scaling?.min ?? "0 ACU";
+        const normalizedScaling = {
           max: scaling?.max ?? "4 ACU",
-          min: scaling?.min ?? "0 ACU",
-          pauseAfter: scaling?.pauseAfter ?? "5 minutes",
+          min,
+          // Only set pauseAfter when min is 0 ACU
+          ...(min === "0 ACU" 
+            ? { pauseAfter: scaling?.pauseAfter ?? "5 minutes" }
+            : {}),
         };
+
+        if (scaling?.pauseAfter && normalizedScaling.min !== "0 ACU") {
+          throw new VisibleError(
+            `'pauseAfter' can only be specified when 'min' is "0 ACU". You specified min: "${normalizedScaling.min}"`
+          );
+        }
+
+        return normalizedScaling;
       });
     }
 

--- a/platform/src/components/aws/aurora.ts
+++ b/platform/src/components/aws/aurora.ts
@@ -515,11 +515,21 @@ export class Aurora extends Component implements Link.Linkable {
 
     function normalizeScaling() {
       return output(args.scaling).apply((scaling) => {
+        const max = scaling?.max ?? "4 ACU";
         const min = scaling?.min ?? "0 ACU";
+        const isAutoPauseEnabled = parseACU(min) === 0;
+        if (scaling?.pauseAfter && !isAutoPauseEnabled) {
+          throw new VisibleError(
+            `Cannot configure "pauseAfter" when the minimum ACU is not 0 for the "${name}" Aurora database.`,
+          );
+        }
+
         return {
-          max: scaling?.max ?? "4 ACU",
+          max,
           min,
-          pauseAfter: min === "0 ACU" ? scaling?.pauseAfter ?? "5 minutes" : undefined,
+          pauseAfter: isAutoPauseEnabled
+            ? scaling?.pauseAfter ?? "5 minutes"
+            : undefined,
         };
       });
     }
@@ -651,7 +661,9 @@ export class Aurora extends Component implements Link.Linkable {
             serverlessv2ScalingConfiguration: scaling.apply((scaling) => ({
               maxCapacity: parseACU(scaling.max),
               minCapacity: parseACU(scaling.min),
-              ...(scaling.pauseAfter && { secondsUntilAutoPause: toSeconds(scaling.pauseAfter) }),
+              secondsUntilAutoPause: scaling.pauseAfter
+                ? toSeconds(scaling.pauseAfter)
+                : undefined,
             })),
             skipFinalSnapshot: true,
             storageEncrypted: true,

--- a/platform/src/components/aws/aurora.ts
+++ b/platform/src/components/aws/aurora.ts
@@ -515,23 +515,28 @@ export class Aurora extends Component implements Link.Linkable {
 
     function normalizeScaling() {
       return output(args.scaling).apply((scaling) => {
+        // Normalize min and max capacity
         const min = scaling?.min ?? "0 ACU";
-        const normalizedScaling = {
-          max: scaling?.max ?? "4 ACU",
-          min,
-          // Only set pauseAfter when min is 0 ACU
-          ...(min === "0 ACU" 
-            ? { pauseAfter: scaling?.pauseAfter ?? "5 minutes" }
-            : {}),
-        };
-
-        if (scaling?.pauseAfter && normalizedScaling.min !== "0 ACU") {
+        const max = scaling?.max ?? "4 ACU";
+        
+        // If min is not 0 ACU, pauseAfter should not be set
+        if (min !== "0 ACU" && scaling?.pauseAfter) {
           throw new VisibleError(
-            `'pauseAfter' can only be specified when 'min' is "0 ACU". You specified min: "${normalizedScaling.min}"`
+            `'pauseAfter' can only be specified when 'min' is "0 ACU". You specified min: "${min}"`
           );
         }
 
-        return normalizedScaling;
+        // Only include pauseAfter in config when min is 0 ACU
+        const config: { min: `${number} ACU`; max: `${number} ACU`; pauseAfter?: string } = {
+          min,
+          max,
+        };
+
+        if (min === "0 ACU") {
+          config.pauseAfter = scaling?.pauseAfter ?? "5 minutes";
+        }
+
+        return config;
       });
     }
 

--- a/platform/src/components/aws/aurora.ts
+++ b/platform/src/components/aws/aurora.ts
@@ -514,11 +514,14 @@ export class Aurora extends Component implements Link.Linkable {
     }
 
     function normalizeScaling() {
-      return output(args.scaling).apply((scaling) => ({
-        max: scaling?.max ?? "4 ACU",
-        min: scaling?.min ?? "0 ACU",
-        pauseAfter: scaling?.pauseAfter,
-      }));
+      return output(args.scaling).apply((scaling) => {
+        const min = scaling?.min ?? "0 ACU";
+        return {
+          max: scaling?.max ?? "4 ACU",
+          min,
+          pauseAfter: min === "0 ACU" ? scaling?.pauseAfter ?? "5 minutes" : undefined,
+        };
+      });
     }
 
     function normalizeVpc() {


### PR DESCRIPTION
Fixes the following error:
```
  InvalidParameterValue: SecondsUntilAutoPause can only be specified when minimum capacity is 0.: provider=aws@6.66.2
```

The updated code checks whether the minimum capacity is 0.
- If `minimum_capacity === 0` then it uses the given `pauseAfter` duration or defaults to 5 minutes. 
- If `minimum_capacity > 0`, then `pauseAfter` isn't set.
