### PR TITLE
fix: updated bastion ami to 2023.6

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1132,7 +1132,7 @@ export class Vpc extends Component implements Link.Linkable {
                 {
                   name: "name",
                   // The AMI has the SSM agent pre-installed
-                  values: ["al2023-ami-2023.5.*"],
+                  values: ["al2023-ami-2023.6.*"],
                 },
                 {
                   name: "architecture",


### PR DESCRIPTION
Resolves #5277 

Updates the bastion ami to use 2023.6 rather than 2023.5 that is no longer available on the AWS community AMIs.