### PR TITLE
Add effect property to FunctionPermissionArgs

### DIFF
--- a/platform/src/components/aws/permission.ts
+++ b/platform/src/components/aws/permission.ts
@@ -22,7 +22,9 @@ export interface InputArgs extends Prettify<FunctionPermissionArgs> { }
 export function permission(input: InputArgs) {
   return {
     type: "aws.permission" as const,
-    ...input,
+    effect: input.effect ?? "allow",
+    actions: input.actions,
+    resources: input.resources,
   };
 }
 


### PR DESCRIPTION
Add support for `effect` property in `FunctionPermissionArgs` with default value `allow`.

* Update `permission` function to include `effect` property with default value `allow`.
* Modify `permission` function to handle `actions` and `resources` properties.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sst/sst/pull/5334?shareId=1aa26678-f151-40d0-8a84-9707e964cdbc).