### PR TITLE
feat: prepend user banner to SST banner in worker runtime

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -121,10 +121,17 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		Format:            esbuild.FormatESModule,
 		MainFields:        []string{"module", "main"},
 		Banner: map[string]string{
-			"js": strings.Join([]string{
-				`import { createRequire as topLevelCreateRequire } from 'module';`,
-				`const require = topLevelCreateRequire("/");`,
-			}, "\n"),
+			"js": func() string {
+				defaultBanner := strings.Join([]string{
+					`import { createRequire as topLevelCreateRequire } from 'module';`,
+					`const require = topLevelCreateRequire("/");`,
+				}, "\n")
+				
+				if banner, ok := build.ESBuild.Banner["js"]; ok {
+					return banner + "\n" + defaultBanner
+				}
+				return defaultBanner
+			}(),
 		},
 	}
 


### PR DESCRIPTION
When using the worker runtime, any user-provided ESBuild are not being applied. This prevents users from adding their own banner code that needs to run before SST's require setup.

This change modifies the worker runtime to:
- Preserve user-provided banner options
- Prepend them before SST's default banner
- Maintain backward compatibility when no user banner is provided

Note: it's a simple change but currently untested