### PR TITLE
Fixed message format in nextjs realtime example

### DIFF
--- a/examples/aws-realtime-nextjs/components/chat.tsx
+++ b/examples/aws-realtime-nextjs/components/chat.tsx
@@ -48,7 +48,7 @@ export default function Chat(
       {connection && messages.length > 0 &&
         <div className={styles.messages}>
           {messages.map((msg, i) => (
-            <div key={i}>{msg}</div>
+            <div key={i}>{JSON.parse(msg).message}</div>
           ))}
         </div>
       }
@@ -59,7 +59,7 @@ export default function Chat(
 
           const input = (e.target as HTMLFormElement).message;
 
-          connection!.publish(topic, input.value, { qos: 1 });
+          connection!.publish(topic, JSON.stringify({ message: input.value }), { qos: 1 });
           input.value = "";
         }}
       >


### PR DESCRIPTION
The Next.js Realtime example is publishing messages as a string from input resulting in this error: 

![Screenshot 2025-01-17 at 11 05 36](https://github.com/user-attachments/assets/eb3f2daf-ec88-496f-ad51-bbabbbed6a9b)

Fixed by wrapping the payload in an object.