### PR TITLE
Add `parent` to API Gateway V1 route configuration.

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -874,7 +874,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
     args: ApiGatewayV1RouteArgs = {},
   ) {
     const { method, path } = this.parseRoute(route);
-    this.createResource(path);
+    this.createResource(path, args);
 
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
@@ -1009,7 +1009,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
     return `${this.constructorName}Route${suffix}`;
   }
 
-  private createResource(path: string) {
+  private createResource(path: string, args: ApiGatewayV1RouteArgs = {}) {
     const pathParts = path.replace(/^\//, "").split("/");
     for (let i = 0, l = pathParts.length; i < l; i++) {
       const parentPath = "/" + pathParts.slice(0, i).join("/");
@@ -1024,7 +1024,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
             restApi: this.api.id,
             parentId:
               parentPath === "/"
-                ? this.constructorArgs.pathParentId ?? this.api.rootResourceId
+                ? args.pathParentId ?? this.api.rootResourceId
                 : this.resources[parentPath],
             pathPart: pathParts[i],
           },

--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -542,6 +542,15 @@ export interface ApiGatewayV1RouteArgs {
      */
     integration?: Transform<apigateway.IntegrationArgs>;
   };
+
+  /**
+   * The id of the parent resource that the path is relative to.
+   * By default, it is the id of the root resource of this api.
+   *
+   * When adding routes to other API, you need to set this to the id of the parent resource to
+   * avoid conflicts.
+   */
+  pathParentId?: Input<string>;
 }
 
 export interface ApiGatewayV1IntegrationArgs {
@@ -1015,7 +1024,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
             restApi: this.api.id,
             parentId:
               parentPath === "/"
-                ? this.api.rootResourceId
+                ? this.constructorArgs.pathParentId ?? this.api.rootResourceId
                 : this.resources[parentPath],
             pathPart: pathParts[i],
           },


### PR DESCRIPTION
This enables attaching the route to a different root.

Use case: adding a route to an existing API with parent path already exists.

Example usage:
```ts
const existingRouteResource = await aws.apigateway.getResource({
  restApiId: "..."
  path: '/existing/route/path'
});

api.route('new-path', {parent: existingRouteResource});
```

Example runs:
```
> createResource("/");
// this.resources = { '/': 'root-id' }

> createResource("/one/two");
// new resource { parentId: 'root-id', id: 'Bdrwse', pathPart: 'one' }
// new resource { parentId: 'Bdrwse', id: 'Xtuefu', pathPart: 'two' }
// this.resources = { '/': 'root-id', '/one': 'Bdrwse', '/one/two': 'Xtuefu' }

> createResource("/", {parent: {id: "parent-id", path: "/{some_id}"}});
// this.resources = { '/': 'root-id', '/{some_id}/': 'parent-id' }

> createResource("/one", {parent: {id: "parent-id", path: "/{some_id}"}});
// new resource { parentId: 'parent-id', id: 'Ttnccd', pathPart: 'one' }
// this.resources = { '/': 'root-id', '/{some_id}/one': 'Ttnccd' }

> createResource("/one/two", {parent: { id: "parent-id", path: "/{some_id}" }});
// new resource { parentId: 'parent-id', id: 'Ttnccd', pathPart: 'one' }
// new resource { parentId: 'Ttnccd', id: 'Fovtfn', pathPart: 'two' }
// this.resources = {
//   '/': 'root-id',
//   '/{some_id}/one': 'Ttnccd',
//   '/{some_id}/one/two': 'Fovtfn'
// }

> createResource("/one/two", {parent: { id: "parent-id", path: "/{some_id}/items/{item_id}" }});
// { '/': 'root-id', '/{some_id}/items/{item_id}/': 'parent-id' }
```