### PR TITLE
docs(apigateway): Mention that VPC AZ's need to support VPC or deploy will FAIL

### DIFF
--- a/examples/aws-cluster-vpclink/sst.config.ts
+++ b/examples/aws-cluster-vpclink/sst.config.ts
@@ -29,7 +29,14 @@ export default $config({
     };
   },
   async run() {
-    const vpc = new sst.aws.Vpc("MyVpc");
+    const vpc = new sst.aws.Vpc("MyVpc", {
+      // VPC links (created by `api.routePrivate()`) are not supported in all availability zones.
+      // Here is the list of AZ's that support VPC link: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vpc-links.html
+      // You still need to map these AZ ID's to your account's AZ's by executing `aws ec2 describe-availability-zones`.
+      // Only include AZ's that support VPC link to prevent the following error:
+      // "operation error ApiGatewayV2: BadRequestException: Subnet is in Availability Zone 'euw3-az2' where service is not available"
+      // az: ["eu-west-3a", "eu-west-3c"],
+    });
     const cluster = new sst.aws.Cluster("MyCluster", { vpc });
     const service = cluster.addService("MyService", {
       serviceRegistry: {

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -1178,7 +1178,10 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    * Adds a private route to the API Gateway HTTP API.
    *
    * To add private routes, you need to have a VPC link. Make sure to pass in a `vpc`.
-   * Learn more about [adding private routes](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html).
+   * Learn more about [adding private routes](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-private.html). Your VPC's availability zones must support VPC link.
+   * See the list of supported availability zones in the [aws docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vpc-links.html). 
+   * You can set your VPC's availability zones using its `az` argument: `az: ["eu-west-3a", "eu-west-3c"]`. 
+   * To do this you have to map your AWS account's availability zones to their AZ IDs by running `aws ec2 describe-availability-zones`.
    *
    * :::tip
    * You need to pass `vpc` to add a private route.

--- a/www/src/content/docs/docs/examples.mdx
+++ b/www/src/content/docs/docs/examples.mdx
@@ -710,7 +710,7 @@ const service = cluster.addService("MyService", {
 });
 ```
 
-Your API Gateway HTTP API also needs to be in the same VPC as the service.
+Your API Gateway HTTP API also needs to be in the same VPC as the service. You also need to verify that your VPC's availability zones support VPC link. More info in the [ApiGatewayV2 docs](https://sst.dev/docs/component/aws/apigatewayv2/#routeprivate).
 ```ts title="sst.config.ts"
 const vpc = new sst.aws.Vpc("MyVpc");
 const cluster = new sst.aws.Cluster("MyCluster", { vpc });


### PR DESCRIPTION
I lost quite a bit of time debugging the following error trying to use ApiGateway's `routePrivate()`:

```shell
creating API Gateway v2 VPC Link (nextjs-app-production-TestApiVpcLink): operation error ApiGatewayV2:
CreateVpcLink, https response error StatusCode: 400, RequestID: bccc43a2-256c-4274-80f8-1c925c2f06c1,
BadRequestException: Subnet is in Availability Zone 'euw3-az2' where service is not available: provider=aws@6.66.2
```

I learned that
- VPC link is not supported in all AZ's: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vpc-links.html
- You need to map supported AZ ID's to your AWS Account's AZ's using `aws ec2 describe-availability-zones`. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#az-ids

I wanted to at least mention this in the docs so SST users that come after me can be set on the right track. I made some proposed changes to the docs and the example. I wanted to be as thorough as can be but feel free to rewrite or eliminate of course.
