### PR TITLE
cli: align install and upgrade with XDG spec

### DIFF
--- a/install
+++ b/install
@@ -35,7 +35,7 @@ case "$filename" in
     ;;
 esac
 
-INSTALL_DIR=$HOME/.sst/bin
+INSTALL_DIR=${XDG_BIN_HOME:-$HOME/.local/bin}
 mkdir -p "$INSTALL_DIR"
 
 if [ -z "$requested_version" ]; then

--- a/pkg/global/upgrade.go
+++ b/pkg/global/upgrade.go
@@ -78,16 +78,11 @@ func Upgrade(existingVersion string, nextVersion string) (string, error) {
 		return "", fmt.Errorf("unexpected HTTP status when downloading release: %s", resp.Status)
 	}
 
-	homeDir, err := os.UserHomeDir()
+	tmpReleaseDir, err := os.MkdirTemp("", "sst")
 	if err != nil {
 		return "", err
 	}
-
-	sstBinPath := filepath.Join(homeDir, ".sst", "bin")
-	os.RemoveAll(sstBinPath)
-	if err := os.MkdirAll(sstBinPath, os.ModePerm); err != nil {
-		return "", err
-	}
+	defer os.RemoveAll(tmpReleaseDir)
 
 	// Assuming we have a variable `resp` which is the response from a *http.Request
 	body, err := gzip.NewReader(resp.Body)
@@ -96,11 +91,29 @@ func Upgrade(existingVersion string, nextVersion string) (string, error) {
 	}
 	defer body.Close()
 
-	if err := untar(body, sstBinPath); err != nil {
+	if err := untar(body, tmpReleaseDir); err != nil {
 		return "", err
 	}
 
-	if err := os.Chmod(filepath.Join(sstBinPath, "sst"), 0755); err != nil {
+	binHome := os.Getenv("XDG_BIN_HOME")
+	if binHome == "" {
+		// Default to ~/.local/bin if $XDG_BIN_HOME not set
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		binHome = filepath.Join(homeDir, ".local", "bin")
+	}
+	if err := os.MkdirAll(binHome, os.ModePerm); err != nil {
+		return "", err
+	}
+	sstBinPath := filepath.Join(binHome, "sst")
+
+	if err := os.Rename(filepath.Join(tmpReleaseDir, "sst"), sstBinPath); err != nil {
+		return "", err
+	}
+
+	if err := os.Chmod(sstBinPath, 0755); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
https://github.com/sst/sst/issues/4666

---

- [x] **Implement:**
Modify install script to use $XDG_BIN_HOME as install dir and default to $HOME/.local/bin if $XDG_BIN_HOME doesn't exist
- [x] **Implement:**
Modify sst upgrade command to use the same logic for determining the install dir
- [x] **Test:** Run install script with
    - [x] $XDG_BIN_HOME set and already in $PATH
    - [x] $XDG_BIN_HOME set and not in $PATH
    - [x] $XDG_BIN_HOME not set

- [x] **Test:** Verify sst upgrade works as expected
    - [x] build sst executable and manually install
    - [x] run sst upgrade and verify it uses the $XDG_BIN_HOME dir
