### PR TITLE
feat: Add `ComponentResourceOptions` arg on cluster `addService` and `addTask`

### DIFF
--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -2663,7 +2663,7 @@ export class Cluster extends Component {
    *
    * This is useful for running sidecar containers.
    */
-  public addService(name: string, args?: ClusterServiceArgs) {
+  public addService(name: string, args?: ClusterServiceArgs, opts?: Omit<ComponentResourceOptions, "provider">) {
     // Do not prefix the service to allow `Resource.MyService` to work.
     return new Service(
       name,
@@ -2672,7 +2672,7 @@ export class Cluster extends Component {
         vpc: this.vpc,
         ...args,
       },
-      { provider: this.constructorOpts.provider },
+      { ...opts, provider: this.constructorOpts.provider },
     );
   }
 
@@ -2712,7 +2712,7 @@ export class Cluster extends Component {
    *
    * This is useful for running sidecar containers.
    */
-  public addTask(name: string, args?: ClusterTaskArgs) {
+  public addTask(name: string, args?: ClusterTaskArgs, opts?: Omit<ComponentResourceOptions, "provider">) {
     // Do not prefix the task to allow `Resource.MyTask` to work.
     return new Task(
       name,
@@ -2721,7 +2721,7 @@ export class Cluster extends Component {
         vpc: this.vpc,
         ...args,
       },
-      { provider: this.constructorOpts.provider },
+      { ...opts, provider: this.constructorOpts.provider },
     );
   }
 

--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -2677,7 +2677,7 @@ export class Cluster extends Component {
         vpc: this.vpc,
         ...args,
       },
-      { ...opts, provider: this.constructorOpts.provider },
+      { provider: this.constructorOpts.provider, ...opts },
     );
   }
 
@@ -2731,7 +2731,7 @@ export class Cluster extends Component {
         vpc: this.vpc,
         ...args,
       },
-      { ...opts, provider: this.constructorOpts.provider },
+      { provider: this.constructorOpts.provider, ...opts },
     );
   }
 

--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -2611,7 +2611,8 @@ export class Cluster extends Component {
    * Add a service to the cluster.
    *
    * @param name Name of the service.
-   * @param args Configure the service.
+   * @param args? Configure the service.
+   * @param opts? Resource options.
    *
    * @example
    *
@@ -2663,7 +2664,11 @@ export class Cluster extends Component {
    *
    * This is useful for running sidecar containers.
    */
-  public addService(name: string, args?: ClusterServiceArgs, opts?: Omit<ComponentResourceOptions, "provider">) {
+  public addService(
+    name: string,
+    args?: ClusterServiceArgs,
+    opts?: ComponentResourceOptions,
+  ) {
     // Do not prefix the service to allow `Resource.MyService` to work.
     return new Service(
       name,
@@ -2680,7 +2685,8 @@ export class Cluster extends Component {
    * Add a task to the cluster.
    *
    * @param name Name of the task.
-   * @param args Configure the task.
+   * @param args? Configure the task.
+   * @param opts? Resource options.
    *
    * @example
    *
@@ -2712,7 +2718,11 @@ export class Cluster extends Component {
    *
    * This is useful for running sidecar containers.
    */
-  public addTask(name: string, args?: ClusterTaskArgs, opts?: Omit<ComponentResourceOptions, "provider">) {
+  public addTask(
+    name: string,
+    args?: ClusterTaskArgs,
+    opts?: ComponentResourceOptions,
+  ) {
     // Do not prefix the task to allow `Resource.MyTask` to work.
     return new Task(
       name,


### PR DESCRIPTION
Add an optional `ComponentResourceOptions` on both `addService` and `addTask` methods of a cluster.
This can be useful to add dependency to other ressources for example.