### PR TITLE
Prefer `/usr/bin/env bash` over `/bin/bash`

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 APP=sst
 

--- a/platform/scripts/build
+++ b/platform/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORIGINAL_DIR=$(pwd)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"

--- a/scripts/release
+++ b/scripts/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git fetch --force --tags
 


### PR DESCRIPTION
Hello, while setting up SST locally on my nixos computer, I noticed that some of the shebangs in some of the scripts were explicit to using the `/bin/bash` path for bash. For non-FHS compliant OSes like nixos, this is problematic. I'm proposing a solution to use `/usr/bin/env bash` instead. This method is often [preferred because more portable](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang).

There are a few other areas in the codebase that still have `/bin/bash` that I did not touch because they seem to be example code, but I could update these too:

* examples/hetzner/sst.config.ts:28:10
* examples/aws-rails/bin/docker-entrypoint:1:1
* examples/aws-ec2-pulumi/sst.config.ts:42:23
* examples/hetzner-minecraft/sst.config.ts:34:10
* examples/internal/aws-ai-video-generation/sst.config.ts:96:1
* www/src/content/docs/docs/aws-accounts.mdx:231:4
* www/src/content/docs/docs/examples.mdx:997:19
