### PR TITLE
DRAFT: feat: extended api gateway v1 to have configurable cors headers

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -262,7 +262,20 @@ export interface ApiGatewayV1Args {
    * }
    * ```
    */
-  cors?: Input<boolean>;
+  cors?: Input<{
+    /**
+     * Specify and allow the response headers.
+     *
+     * @default ```js
+     *  {
+     *   "Access-Control-Allow-Headers": "*",
+     *   "Access-Control-Allow-Methods":  "OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD",
+     *   "Access-Control-Allow-Origin": "*"
+     *  }
+     * ```
+     */
+    responseHeaders?: Input<Record<string, string>>;
+  }>;
   /**
    * Configure the [API Gateway logs](https://docs.aws.amazon.com/apigateway/latest/developerguide/view-cloudwatch-log-events-in-cloudwatch-console.html) in CloudWatch. By default, access logs are enabled and kept for 1 month.
    * @default `{retention: "1 month"}`
@@ -1175,7 +1188,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
       );
 
       return all([args.cors, resourceIds]).apply(([cors, resourceIds]) => {
-        if (cors === false) return [];
+        if (!cors) return [];
 
         // filter unique resource ids
         const uniqueResourceIds = [...new Set(resourceIds)];
@@ -1193,6 +1206,23 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
             { parent },
           );
 
+
+          let methodResponseParametersOverride = {};
+          let integrationResponseParametersOverride = {};
+
+          if(cors.responseHeaders) {
+            methodResponseParametersOverride = Object.keys(cors.responseHeaders).reduce((acc, key) => {
+              acc[`method.response.header.${key}`] = true;
+              return acc;
+            }, {});
+
+
+            integrationResponseParametersOverride = Object.keys(cors.responseHeaders).reduce((acc, key) => {
+              acc[`integration.response.header.${key}`] = `'${cors.responseHeaders[key]}'`;
+              return acc;
+            }, {});
+          }
+
           const methodResponse = new apigateway.MethodResponse(
             `${name}CorsMethodResponse${resourceId}`,
             {
@@ -1204,6 +1234,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
                 "method.response.header.Access-Control-Allow-Headers": true,
                 "method.response.header.Access-Control-Allow-Methods": true,
                 "method.response.header.Access-Control-Allow-Origin": true,
+                ...methodResponseParametersOverride,
               },
             },
             { parent },
@@ -1235,6 +1266,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
                 "method.response.header.Access-Control-Allow-Methods":
                   "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
                 "method.response.header.Access-Control-Allow-Origin": "'*'",
+                ...integrationResponseParametersOverride,
               },
             },
             { parent, dependsOn: [integration] },


### PR DESCRIPTION
# Why
I would like to specify the headers returned by my gateway, this makes setting up a gateway much easier.

# What
I changed the `cors`  property to be a config object and added the "responseHeaders" field.

# Note
I know at the moment, this would be a breaking change for the API of that component, but this is rather a concept PR.
Is this according to how you want to design your API or should this be solved differently.

I thought before I put more work into this topic, I ask about the plans on how something like that should be done in SST.

(First time contributing here I hope I did this correctly)