### PR TITLE
Returning primaryEndpointAddress if Redis/Valkey cluster mode is disabled

### DIFF
--- a/platform/src/components/aws/redis.ts
+++ b/platform/src/components/aws/redis.ts
@@ -458,7 +458,11 @@ Listening on "${dev.host}:${dev.port}"...`,
   public get host() {
     return this.dev
       ? this.dev.host
-      : this.cluster!.configurationEndpointAddress;
+      : this.cluster!.clusterMode.apply((mode) => {
+        return mode === "disabled"
+          ? this.cluster!.primaryEndpointAddress
+          : this.cluster!.configurationEndpointAddress
+    });
   }
 
   /**


### PR DESCRIPTION
When you set cluster mode to "disabled" in Elasticache, the configuration endpoint becomes empty the the "Primary endpoint" should be used instead.

```ts
const redis = new sst.aws.Redis('SST-Laravel-Cache', {
  vpc,
  transform: {
    cluster: {
      automaticFailoverEnabled: false,
      clusterMode: 'disabled',
    },
  }
});
```

![Screenshot 2025-02-19 at 08 37 29](https://github.com/user-attachments/assets/d91589e7-5c19-4db7-8faf-ca86af004bd3)
