### PR TITLE
Allow `conditions` in Linkable include `sst.aws.permission`

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -81,7 +81,7 @@ export type FunctionPermissionArgs = {
 	 */
 	resources: Input<string>[];
 	/**
-	 * Conditions the request has to meet in order to match.
+	 * [Conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) the request has to meet in order to match.
 	 * @example
 	 * ```js
 	 * [{

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -49,37 +49,53 @@ import { Efs } from "./efs.js";
 export type FunctionArn = `arn:${string}` & {};
 
 export type FunctionPermissionArgs = {
-  /**
-   * Configures whether the permission is allowed or denied.
-   * @default `"allow"`
-   * @example
-   * ```ts
-   * {
-   *   effect: "deny"
-   * }
-   * ```
-   */
-  effect?: "allow" | "deny";
-  /**
-   * The [IAM actions](https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html#actions_table) that can be performed.
-   * @example
-   * ```js
-   * {
-   *   actions: ["s3:*"]
-   * }
-   * ```
-   */
-  actions: string[];
-  /**
-   * The resourcess specified using the [IAM ARN format](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html).
-   * @example
-   * ```js
-   * {
-   *   resources: ["arn:aws:s3:::my-bucket/*"]
-   * }
-   * ```
-   */
-  resources: Input<string>[];
+	/**
+	 * Configures whether the permission is allowed or denied.
+	 * @default `"allow"`
+	 * @example
+	 * ```ts
+	 * {
+	 *   effect: "deny"
+	 * }
+	 * ```
+	 */
+	effect?: "allow" | "deny";
+	/**
+	 * The [IAM actions](https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html#actions_table) that can be performed.
+	 * @example
+	 * ```js
+	 * {
+	 *   actions: ["s3:*"]
+	 * }
+	 * ```
+	 */
+	actions: string[];
+	/**
+	 * The resourcess specified using the [IAM ARN format](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html).
+	 * @example
+	 * ```js
+	 * {
+	 *   resources: ["arn:aws:s3:::my-bucket/*"]
+	 * }
+	 * ```
+	 */
+	resources: Input<string>[];
+	/**
+	 * Conditions the request has to meet in order to match.
+	 * @example
+	 * ```js
+	 * [{
+	 *   test: "StringLike",
+	 *   variable: "s3:prefix",
+	 *   values: ["home/${aws:username}/*"]
+	 * }]
+	 * ```
+	 */
+	conditions?: Input<{
+		test: string;
+		variable: string;
+		values: Input<string>[];
+	}>[];
 };
 
 interface FunctionUrlCorsArgs {
@@ -1759,44 +1775,45 @@ export class Function extends Component implements Link.Linkable {
         );
       }
 
-      const policy = all([args.permissions || [], linkPermissions, dev]).apply(
-        ([argsPermissions, linkPermissions, dev]) =>
-          iam.getPolicyDocumentOutput({
-            statements: [
-              ...argsPermissions,
-              ...linkPermissions,
-              ...(dev
-                ? [
-                    {
-                      effect: "allow",
-                      actions: ["appsync:*"],
-                      resources: ["*"],
-                    },
-                    {
-                      effect: "allow",
-                      actions: ["iot:*"],
-                      resources: ["*"],
-                    },
-                    {
-                      effect: "allow",
-                      actions: ["s3:*"],
-                      resources: [
-                        interpolate`arn:${partition}:s3:::${bootstrapData.asset}`,
-                        interpolate`arn:${partition}:s3:::${bootstrapData.asset}/*`,
-                      ],
-                    },
-                  ]
-                : []),
-            ].map((item) => ({
-              effect: (() => {
-                const effect = item.effect ?? "allow";
-                return effect.charAt(0).toUpperCase() + effect.slice(1);
-              })(),
-              actions: item.actions,
-              resources: item.resources,
-            })),
-          }),
-      );
+			const policy = all([args.permissions || [], linkPermissions, dev]).apply(
+				([argsPermissions, linkPermissions, dev]) =>
+					iam.getPolicyDocumentOutput({
+						statements: [
+							...argsPermissions,
+							...linkPermissions,
+							...(dev
+								? [
+									{
+										effect: "allow",
+										actions: ["appsync:*"],
+										resources: ["*"],
+									},
+									{
+										effect: "allow",
+										actions: ["iot:*"],
+										resources: ["*"],
+									},
+									{
+										effect: "allow",
+										actions: ["s3:*"],
+										resources: [
+											interpolate`arn:${partition}:s3:::${bootstrapData.asset}`,
+											interpolate`arn:${partition}:s3:::${bootstrapData.asset}/*`,
+										],
+									},
+								]
+								: []),
+						].map((item) => ({
+							effect: (() => {
+								const effect = item.effect ?? "allow";
+								return effect.charAt(0).toUpperCase() + effect.slice(1);
+							})(),
+							actions: item.actions,
+							resources: item.resources,
+							...item.conditions && { conditions: item.conditions },
+						})),
+					}),
+			);
 
       return new iam.Role(
         ...transform(


### PR DESCRIPTION
This change allows to add `conditions` inside of `sst.aws.permission`

```typescript
actions: ["dynamodb:GetItem"],
resources: [dynamoTable.arn],
conditions: [{
  test: "ForAllValues:StringEquals",
  variable: "dynamodb:LeadingKeys",
  values: [$app.stage],
}],
```

This is primarily done so that a Linkable instance can be used to easily add a permission to all ApiGatewayV2 routes handlers, which will grant conditional read access to a shared config table, where the leading key is used to differentiate between the various stages.

```typescript
const configTable = new sst.Linkable("DynamoConfigTable", {
  properties: {
    arn: DynamoConfigTable.arn,
    name: DynamoConfigTable.name,
  },
  include: [
    sst.aws.permission({
      actions: ["dynamodb:GetItem"],
      resources: [DynamoConfigTable.arn],
      conditions: [{
        test: "ForAllValues:StringEquals",
        variable: "dynamodb:LeadingKeys",
        values: [$app.stage],
      }],
    }),
  ],
});

// ...

export const restApi = new sst.aws.ApiGatewayV2("restApi", {
	domain: config.restAPI.domainName,

	link: [configTable, /* ... */],
});

```

The result will be that each handler's role document will include 
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "dynamodb:GetItem",
      "Condition": {
        "ForAllValues:StringEquals": {
          "dynamodb:LeadingKeys": "dev"
      }
    },
    "Effect": "Allow",
    "Resource": "***"
  }
...
```