### PR TITLE
chore: bump OpenNext version to latest 

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -1,11 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { globSync } from "glob";
 import {
   ComponentResourceOptions,
   Output,
   all,
-  interpolate,
   output,
 } from "@pulumi/pulumi";
 import { Size } from "../size.js";
@@ -18,7 +16,7 @@ import { isALteB } from "../../util/compare-semver.js";
 import { SsrSite, SsrSiteArgs } from "./ssr-site.js";
 import { Bucket } from "./bucket.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.4.1";
+const DEFAULT_OPEN_NEXT_VERSION = "3.5.3";
 
 type BaseFunction = {
   handler: string;


### PR DESCRIPTION
There was some important fixes to make Next `15.2` work properly with page router.  It also includes a fix for removing the new native packages from `sharp` that is under the namespace `@img`

Reference: [#754](https://github.com/opennextjs/opennextjs-aws/issues/754)