### PR TITLE
Disable exporting of uv dev dependencies

### DIFF
--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -224,7 +224,7 @@ func (r *PythonRuntime) CreateBuildAsset(ctx context.Context, input *runtime.Bui
 	if err != nil {
 		return nil, fmt.Errorf("failed to get package name: %v", err)
 	}
-	exportCmd := process.CommandContext(ctx, "uv", "export", "--package="+packageName, "--output-file="+outputRequirementsFile, "--no-emit-workspace")
+	exportCmd := process.CommandContext(ctx, "uv", "export", "--package="+packageName, "--output-file="+outputRequirementsFile, "--no-emit-workspace", "--no-dev")
 	exportCmd.Dir = workingDir
 	err = exportCmd.Run()
 	if err != nil {


### PR DESCRIPTION
Right now, when building a Python lambda all dev dependencies will be included in the zip/container as dev dependencies are exported by default. This change disables that behaviour.