### PR TITLE
Fix: Include Rust SDK metadata

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,6 +2,13 @@
 name = "sst_sdk"
 version = "0.1.0"
 edition = "2021"
+description = "Rust SDK for SST"
+documentation = "https://sst.dev/docs"
+readme = "../../README.md"
+repository = "https://github.com/sst/sst"
+license = "MIT"
+keywords = ["aws", "sst"]
+authors = ["Rohan Godha <hi@rohangodha.com>"]
 
 [dependencies]
 aes-gcm = "0.10.3"


### PR DESCRIPTION
needed some extra metadata to publish the package. I can obviously transfer the sst_sdk crate to sst team if you guys would prefer that!

https://crates.io/crates/sst_sdk