### PR TITLE
feat: expose default cache policy prop builder

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -8,6 +8,7 @@ import { Function } from "./function.js";
 import {
   Plan,
   SsrSiteArgs,
+  buildDefaultServerCachePolicyProps,
   createBucket,
   createDevServer,
   createServersAndDistribution,
@@ -401,10 +402,22 @@ export interface NextjsArgs extends SsrSiteArgs {
    * @default A new cache policy is created
    *
    * @example
+   *
+   * Pass the ID of an existing policy
+   *
    * ```js
    * {
    *   cachePolicy: "658327ea-f89d-4fab-a63d-7e88639e58f6"
    * }
+   * ```
+   *
+   * Create a server cache policy to be shared across multiple deployments
+   *
+   * ```js title="sst.config.ts"
+   * const policy = new aws.cloudfront.CachePolicy('WebCachePolicy', Nextjs.buildDefaultServerCachePolicyProps());
+   *
+   * new sst.aws.Nextjs("MyWeb", { cachePolicy: policy.id });
+   * new sst.aws.Nextjs("MyWebTwo", { cachePolicy: policy.id });
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
@@ -1424,6 +1437,14 @@ if(event.request.headers["cloudfront-viewer-longitude"]) {
        */
       revalidationFunction: this.revalidationFunction,
     };
+  }
+
+  public static buildDefaultServerCachePolicyProps() {
+    return buildDefaultServerCachePolicyProps({
+      serverCachePolicy: {
+        allowedHeaders: DEFAULT_CACHE_POLICY_ALLOWED_HEADERS,
+      },
+    });
   }
 
   /** @internal */

--- a/platform/src/components/aws/ssr-site-new.ts
+++ b/platform/src/components/aws/ssr-site-new.ts
@@ -771,33 +771,9 @@ export function createResources(
       (serverCachePolicy) =>
         new cloudfront.CachePolicy(
           `${name}ServerCachePolicy`,
-          {
-            comment: "SST server response cache policy",
-            defaultTtl: 0,
-            maxTtl: 31536000, // 1 year
-            minTtl: 0,
-            parametersInCacheKeyAndForwardedToOrigin: {
-              cookiesConfig: {
-                cookieBehavior: "none",
-              },
-              headersConfig:
-                (serverCachePolicy?.allowedHeaders ?? []).length > 0
-                  ? {
-                      headerBehavior: "whitelist",
-                      headers: {
-                        items: serverCachePolicy?.allowedHeaders,
-                      },
-                    }
-                  : {
-                      headerBehavior: "none",
-                    },
-              queryStringsConfig: {
-                queryStringBehavior: "all",
-              },
-              enableAcceptEncodingBrotli: true,
-              enableAcceptEncodingGzip: true,
-            },
-          },
+          buildDefaultServerCachePolicyProps({
+            serverCachePolicy,
+          }),
           { parent },
         ),
     );
@@ -1159,4 +1135,36 @@ if (event.request.headers.host.value.includes('cloudfront.net')) {
   };
 }`;
   }
+}
+
+export function buildDefaultServerCachePolicyProps(
+  plan: Pick<Plan, "serverCachePolicy"> = {},
+) {
+  return {
+    comment: "SST server response cache policy",
+    defaultTtl: 0,
+    maxTtl: 31536000, // 1 year
+    minTtl: 0,
+    parametersInCacheKeyAndForwardedToOrigin: {
+      cookiesConfig: {
+        cookieBehavior: "none",
+      },
+      headersConfig:
+        (plan.serverCachePolicy?.allowedHeaders ?? []).length > 0
+          ? {
+              headerBehavior: "whitelist",
+              headers: {
+                items: plan.serverCachePolicy?.allowedHeaders,
+              },
+            }
+          : {
+              headerBehavior: "none",
+            },
+      queryStringsConfig: {
+        queryStringBehavior: "all",
+      },
+      enableAcceptEncodingBrotli: true,
+      enableAcceptEncodingGzip: true,
+    },
+  };
 }

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -961,33 +961,7 @@ async function handler(event) {
         singletonCachePolicy ??
         new cloudfront.CachePolicy(
           `${name}ServerCachePolicy`,
-          {
-            comment: "SST server response cache policy",
-            defaultTtl: 0,
-            maxTtl: 31536000, // 1 year
-            minTtl: 0,
-            parametersInCacheKeyAndForwardedToOrigin: {
-              cookiesConfig: {
-                cookieBehavior: "none",
-              },
-              headersConfig:
-                (plan.serverCachePolicy?.allowedHeaders ?? []).length > 0
-                  ? {
-                      headerBehavior: "whitelist",
-                      headers: {
-                        items: plan.serverCachePolicy?.allowedHeaders,
-                      },
-                    }
-                  : {
-                      headerBehavior: "none",
-                    },
-              queryStringsConfig: {
-                queryStringBehavior: "all",
-              },
-              enableAcceptEncodingBrotli: true,
-              enableAcceptEncodingGzip: true,
-            },
-          },
+          buildDefaultServerCachePolicyProps(plan),
           { parent },
         );
       return singletonCachePolicy;
@@ -1196,6 +1170,38 @@ async function handler(event) {
       );
     }
   });
+}
+
+export function buildDefaultServerCachePolicyProps(
+  plan: Pick<Plan, "serverCachePolicy"> = {},
+) {
+  return {
+    comment: "SST server response cache policy",
+    defaultTtl: 0,
+    maxTtl: 31536000, // 1 year
+    minTtl: 0,
+    parametersInCacheKeyAndForwardedToOrigin: {
+      cookiesConfig: {
+        cookieBehavior: "none",
+      },
+      headersConfig:
+        (plan.serverCachePolicy?.allowedHeaders ?? []).length > 0
+          ? {
+              headerBehavior: "whitelist",
+              headers: {
+                items: plan.serverCachePolicy?.allowedHeaders,
+              },
+            }
+          : {
+              headerBehavior: "none",
+            },
+      queryStringsConfig: {
+        queryStringBehavior: "all",
+      },
+      enableAcceptEncodingBrotli: true,
+      enableAcceptEncodingGzip: true,
+    },
+  };
 }
 
 export function useCloudFrontFunctionHostHeaderInjection() {


### PR DESCRIPTION
This PR implements the `buildDefaultServerCachePolicyProps` function that existed in previous versions of SST. It exposes the default properties used to build a cache policy for `Nextjs` + other `SsrSite` components for situations where users are hitting the 20 quota limit.

Like #3886, we've just copied the default properties from the SST source code into our `sst.config.ts`, but I thought I'd open this PR in case it's useful for others. This means if the default policy config changes moving forward, users can inherit the changes for free.

Changes in this PR: 

1. Logic to build out the server cache policy props has been extracted to an exposed function called `buildDefaultServerCachePolicyProps()` in both `ssr-site.ts` + `ssr-site-new.ts`
2. Logic to build out the Next.js server cache policy consumes this new function and passes in the default allowed headers, then exposes this as a static function on the `Nextjs` component. I've only included this for Next.js as this is the only sub-component to have specific allowed headers.

Please feel free to amend / discard this PR as needed. I followed the old legacy name for the function, but happy to amend or shift around if there's a more modern or better name and location for this 🙂