### PR TITLE
Fix `sst stage list` showing deleted stages

### DIFF
--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/sst/sst/v3/internal/util"
+	"github.com/sst/sst/v3/pkg/state"
 
 	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -726,7 +727,16 @@ func (a *AwsHome) listStages(app string) ([]string, error) {
 		filename := path.Base(*obj.Key)
 		if strings.HasSuffix(filename, ".json") {
 			stageName := strings.TrimSuffix(filename, ".json")
-			stages = append(stages, stageName)
+
+			data, err := a.getData("app", app, stageName)
+			if err != nil {
+				continue
+			}
+
+			checkpoint, err := state.UnmarshalCheckpoint(data)
+			if state.HasResources(checkpoint) {
+				stages = append(stages, stageName)
+			}
 		}
 	}
 

--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/sst/sst/v3/internal/util"
-	"github.com/sst/sst/v3/pkg/state"
 
 	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -727,14 +726,7 @@ func (a *AwsHome) listStages(app string) ([]string, error) {
 		filename := path.Base(*obj.Key)
 		if strings.HasSuffix(filename, ".json") {
 			stageName := strings.TrimSuffix(filename, ".json")
-
-			data, err := a.getData("app", app, stageName)
-			if err != nil {
-				continue
-			}
-
-			checkpoint, err := state.UnmarshalCheckpoint(data)
-			if state.HasResources(checkpoint) {
+			if hasResources(a, app, stageName) {
 				stages = append(stages, stageName)
 			}
 		}

--- a/pkg/project/provider/cloudflare.go
+++ b/pkg/project/provider/cloudflare.go
@@ -16,7 +16,6 @@ import (
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/sst/sst/v3/internal/util"
-	"github.com/sst/sst/v3/pkg/state"
 )
 
 type CloudflareProvider struct {
@@ -221,19 +220,8 @@ func (c *CloudflareHome) listStages(app string) ([]string, error) {
 	for _, obj := range response.Result {
 		segments := strings.Split(obj.Key, "/")
 		stageName := segments[len(segments)-1]
-
-		file, err := c.getData("app", app, stageName)
-		if err != nil {
-			continue
-		}
-
-		checkpoint, err := state.UnmarshalCheckpoint(file)
-		if err != nil {
-			continue
-		}
-
-		if state.HasResources(checkpoint) {
-			stages = append(stages, segments[len(segments)-1])
+		if hasResources(c, app, stageName) {
+			stages = append(stages, stageName)
 		}
 	}
 

--- a/pkg/project/provider/cloudflare.go
+++ b/pkg/project/provider/cloudflare.go
@@ -16,6 +16,7 @@ import (
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/sst/sst/v3/internal/util"
+	"github.com/sst/sst/v3/pkg/state"
 )
 
 type CloudflareProvider struct {
@@ -219,7 +220,21 @@ func (c *CloudflareHome) listStages(app string) ([]string, error) {
 
 	for _, obj := range response.Result {
 		segments := strings.Split(obj.Key, "/")
-		stages = append(stages, segments[len(segments)-1])
+		stageName := segments[len(segments)-1]
+
+		file, err := c.getData("app", app, stageName)
+		if err != nil {
+			continue
+		}
+
+		checkpoint, err := state.UnmarshalCheckpoint(file)
+		if err != nil {
+			continue
+		}
+
+		if state.HasResources(checkpoint) {
+			stages = append(stages, segments[len(segments)-1])
+		}
 	}
 
 	return stages, nil

--- a/pkg/project/provider/local.go
+++ b/pkg/project/provider/local.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sst/sst/v3/internal/util"
 	"github.com/sst/sst/v3/pkg/global"
+	"github.com/sst/sst/v3/pkg/state"
 )
 
 type LocalHome struct {
@@ -99,10 +100,19 @@ func (a *LocalHome) listStages(app string) ([]string, error) {
 
 	var stages []string
 	for _, entry := range entries {
-		if !entry.IsDir() {
-			filename := entry.Name()
-			if strings.HasSuffix(filename, ".json") {
-				stageName := strings.TrimSuffix(filename, ".json")
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			stageName := strings.TrimSuffix(entry.Name(), ".json")
+			file, err := a.getData("app", app, stageName)
+			if err != nil {
+				continue
+			}
+
+			checkpoint, err := state.UnmarshalCheckpoint(file)
+			if err != nil {
+				continue
+			}
+
+			if state.HasResources(checkpoint) {
 				stages = append(stages, stageName)
 			}
 		}

--- a/pkg/project/provider/local.go
+++ b/pkg/project/provider/local.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sst/sst/v3/internal/util"
 	"github.com/sst/sst/v3/pkg/global"
-	"github.com/sst/sst/v3/pkg/state"
 )
 
 type LocalHome struct {
@@ -102,17 +101,7 @@ func (a *LocalHome) listStages(app string) ([]string, error) {
 	for _, entry := range entries {
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
 			stageName := strings.TrimSuffix(entry.Name(), ".json")
-			file, err := a.getData("app", app, stageName)
-			if err != nil {
-				continue
-			}
-
-			checkpoint, err := state.UnmarshalCheckpoint(file)
-			if err != nil {
-				continue
-			}
-
-			if state.HasResources(checkpoint) {
+			if hasResources(a, app, stageName) {
 				stages = append(stages, stageName)
 			}
 		}

--- a/pkg/project/provider/provider.go
+++ b/pkg/project/provider/provider.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/sst/sst/v3/internal/util"
 	"github.com/sst/sst/v3/pkg/flag"
 	"github.com/sst/sst/v3/pkg/id"
@@ -319,6 +321,25 @@ func ListStages(backend Home, app string) ([]string, error) {
 func Info(backend Home) (util.KeyValuePairs[string], error) {
 	slog.Info("fetching backend configuration info")
 	return backend.info()
+}
+
+func hasResources(backend Home, app, stage string) bool {
+	data, err := backend.getData("app", app, stage)
+	if err != nil {
+		return false
+	}
+
+	bytes, err := io.ReadAll(data)
+	if err != nil {
+		return false
+	}
+
+	checkpoint, _, _, err := stack.UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	if err != nil {
+		return false
+	}
+
+	return checkpoint != nil && checkpoint.Latest != nil && len(checkpoint.Latest.Resources) > 0
 }
 
 func putData(backend Home, key, app, stage string, encrypt bool, data interface{}) error {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,9 +1,12 @@
 package state
 
 import (
+	"io"
 	"slices"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -116,4 +119,22 @@ func Repair(checkpoint *apitype.CheckpointV3) []Mutation {
 		}
 	}
 	return result
+}
+
+func UnmarshalCheckpoint(reader io.Reader) (*apitype.CheckpointV3, error) {
+	bytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	checkpoint, err := stack.UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkpoint, nil
+}
+
+func HasResources(checkpoint *apitype.CheckpointV3) bool {
+	return checkpoint != nil && checkpoint.Latest != nil && len(checkpoint.Latest.Resources) > 0
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,12 +1,9 @@
 package state
 
 import (
-	"io"
 	"slices"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -119,22 +116,4 @@ func Repair(checkpoint *apitype.CheckpointV3) []Mutation {
 		}
 	}
 	return result
-}
-
-func UnmarshalCheckpoint(reader io.Reader) (*apitype.CheckpointV3, error) {
-	bytes, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpoint, err := stack.UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return checkpoint, nil
-}
-
-func HasResources(checkpoint *apitype.CheckpointV3) bool {
-	return checkpoint != nil && checkpoint.Latest != nil && len(checkpoint.Latest.Resources) > 0
 }


### PR DESCRIPTION
When a stage is removed using `sst remove`, the resources are stripped from the state file, but the file remains in the backend. This PR reads the state file for each stage to check whether it contains any resources before including in the list.

This has the potential to become pretty unwieldy for users that create a lot of stages (PR stages, for example), but I don't think there's any other way of getting this info. I guess the main question is: should the state file be removed altogether when a user removes a stage? If yes, this PR isn't needed 🙂

Fixes #5566, #5567. Tested for local, aws and cloudflare backends.