### PR TITLE
build: fix docker build warnings for bridge-task

### DIFF
--- a/platform/support/bridge-task/Dockerfile
+++ b/platform/support/bridge-task/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4 as builder
+FROM golang:1.23.4 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o main
 
 FROM alpine
-LABEL org.opencontainers.image.source https://github.com/sst/sst
+LABEL org.opencontainers.image.source=https://github.com/sst/sst
 WORKDIR /app
 COPY --from=builder /app/main /app/main
-CMD /app/main
+CMD ["/app/main"]


### PR DESCRIPTION
Fix the following warnings seen when building the bridge-task:

```
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
- LegacyKeyValueFormat: "LABEL key=value" should be used instead of
  legacy "LABEL key value" format (line 10)
- JSONArgsRecommended: JSON arguments recommended for CMD to prevent
  unintended behavior related to OS signals (line 13)
```