### PR TITLE
Fix Router construct race condition for routes

### DIFF
--- a/platform/src/components/aws/router-base-route.ts
+++ b/platform/src/components/aws/router-base-route.ts
@@ -17,6 +17,10 @@ export interface RouterBaseRouteArgs {
    * The pattern to match.
    */
   pattern: Input<string>;
+  /**
+   * Optional dependency on previous route updates.
+   */
+  dependsOn?: Input<any>;
 }
 
 export function parsePattern(pattern: string) {
@@ -78,6 +82,6 @@ export function updateKvRoutes(
       key: "routes",
       entry: [routeType, routeNs, pattern.host, pattern.path].join(","),
     },
-    { parent },
+    { parent, dependsOn: args.dependsOn },
   );
 }

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1063,6 +1063,7 @@ export class Router extends Component implements Link.Linkable {
   private constructorName: string;
   private constructorOpts: ComponentResourceOptions;
   private cdn: Output<Cdn>;
+  private lastRouteUpdate: Output<any> | undefined;
   private kvStoreArn?: Output<string>;
   private kvNamespace?: Output<string>;
   private hasInlineRoutes?: Output<boolean>;
@@ -1770,7 +1771,7 @@ async function handler(event) {
             "Cannot use both `routes` and `.route()` function to add routes.",
           );
 
-        new RouterUrlRoute(
+        const route = new RouterUrlRoute(
           `${this.constructorName}Route${pattern}`,
           {
             store: this.kvStoreArn!,
@@ -1778,9 +1779,12 @@ async function handler(event) {
             pattern,
             url,
             routeArgs: args,
+            dependsOn: this.lastRouteUpdate,
           },
           { provider: this.constructorOpts.provider },
         );
+
+        this.lastRouteUpdate = output(route);
       },
     );
   }
@@ -1852,7 +1856,7 @@ async function handler(event) {
             "Cannot use both `routes` and `.routeBucket()` function to add routes.",
           );
 
-        new RouterBucketRoute(
+        const route = new RouterBucketRoute(
           `${this.constructorName}Route${pattern}`,
           {
             store: this.kvStoreArn!,
@@ -1860,9 +1864,12 @@ async function handler(event) {
             pattern,
             bucket,
             routeArgs: args,
+            dependsOn: this.lastRouteUpdate,
           },
           { provider: this.constructorOpts.provider },
         );
+
+        this.lastRouteUpdate = output(route);
       },
     );
   }
@@ -1933,7 +1940,7 @@ async function handler(event) {
           "Cannot use both `routes` and `.routeSite()` function to add routes.",
         );
 
-      new RouterSiteRoute(
+      const route = new RouterSiteRoute(
         `${this.constructorName}Route${pattern}`,
         {
           store: this.kvStoreArn!,
@@ -1941,9 +1948,12 @@ async function handler(event) {
           pattern,
           site,
           distributionId: this.distributionID,
+          dependsOn: this.lastRouteUpdate,
         },
         { provider: this.constructorOpts.provider },
       );
+
+      this.lastRouteUpdate = output(route);
     });
   }
 


### PR DESCRIPTION
This PR fixes a race condition in the Router construct where routes might not get registered in the CloudFront Key/Value store during deployment.

## Problem
When using the Router construct with multiple route registrations (e.g., `.route()`, `.routeSite()`, `.routeBucket()`), there's a race condition that can cause some routes to not be properly registered in the CloudFront Key/Value store. This happens because the route registrations are processed concurrently without any dependency between them.

## Solution
The fix ensures that route registrations happen sequentially by:
1. Adding a `lastRouteUpdate` property to track the most recent route update operation
2. Modifying the route methods (`route`, `routeSite`, `routeBucket`) to use this property as a dependency
3. Updating the `RouterBaseRouteArgs` interface to include the `dependsOn` parameter
4. Modifying the `updateKvRoutes` function to pass the dependency to the `KvRoutesUpdate` constructor

This creates a chain of dependencies where each route registration waits for the previous one to complete before proceeding.

## Testing
The fix has been tested by:
1. Creating a test project with multiple routes
2. Deploying the application multiple times
3. Verifying that all routes are consistently registered in the CloudFront Key/Value store

## Changes
- Modified `platform/src/components/aws/router.ts`:
  - Added `lastRouteUpdate` property to track route updates
  - Updated route methods to use sequential dependencies
- Modified `platform/src/components/aws/router-base-route.ts`:
  - Added `dependsOn` property to `RouterBaseRouteArgs`
  - Updated `updateKvRoutes` to use the dependency
Addresses [Issue 5604](https://github.com/sst/sst/issues/5604)