### PR TITLE
Fix compatibility with pulumi dynamic resources

### DIFF
--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -92,7 +92,7 @@ export class Component extends ComponentResource {
           // note: We are setting the default names here instead of inline when creating
           //       the resource is b/c the physical name is inferred from the logical name.
           //       And it's convenient to access the logical name here.
-          if (args.type.startsWith("sst:")) return;
+          if (args.type.startsWith("sst:") || args.type.startsWith("pulumi-nodejs:dynamic")) return;
           if (
             [
               // resources manually named
@@ -103,7 +103,6 @@ export class Component extends ComponentResource {
               "aws:servicediscovery/privateDnsNamespace:PrivateDnsNamespace",
               "aws:servicediscovery/service:Service",
               // resources not prefixed
-              "pulumi-nodejs:dynamic:Resource",
               "random:index/randomId:RandomId",
               "random:index/randomPassword:RandomPassword",
               "command:local:Command",
@@ -426,7 +425,7 @@ export function $transform<T, Args, Options>(
 ) {
   // @ts-expect-error
   const type = resource.__pulumiType;
-  if (type.startsWith("sst:")) {
+  if (type.startsWith("sst:") || type.startsWith("pulumi-nodejs:dynamic")) {
     let transforms = ComponentTransforms.get(type);
     if (!transforms) {
       transforms = [];


### PR DESCRIPTION
I was running into some issues using pulumi dynamic resources with sst giving:

```
In <parent> component, the physical name of <child resource> (pulumi-nodejs:dynamic/<name>:<Name>) is not prefixed
```

The sst `Component` class currently checks for the prefix `"sst:"` on Resources / Components. This works for internal sst resources, but Pulumi Dynamic Resources typically have a prefix of `pulumi-nodejs:dynamic`. See here:

https://github.com/pulumi/pulumi/blob/1106c93d2d2bf353dca141bdf51e317d5e6c7d45/sdk/nodejs/dynamic/index.ts#L305

There was a check for `"pulumi-nodejs:dynamic:Resource"` already, but it only works for dynamic resources without a specified `module` or `type`.

This PR updates the checks in the file to check for both `sst:` and `pulumi-nodejs:dynamic` which fixes the issue. It also updates the `$transform`-related logic so that it works for dynamic resources as well.
