### PR TITLE
fix: allow either `name` or `nameId` for `ApiGatewayV1DomainArgs`

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -68,7 +68,7 @@ export interface ApiGatewayV1DomainArgs {
    * }
    * ```
    */
-  name: Input<string>;
+  name?: Input<string>;
   /**
    * The base mapping for the custom domain. This adds a suffix to the URL of the API.
    *
@@ -1556,7 +1556,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
           return new DnsValidatedCertificate(
             `${name}Ssl`,
             {
-              domainName: domain.name,
+              domainName: domain.name!,
               dns: domain.dns!,
             },
             {
@@ -1587,7 +1587,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
               args.transform?.domainName,
               `${name}DomainName`,
               {
-                domainName: domain?.name,
+                domainName: domain.name!,
                 endpointConfiguration: { types: endpointType },
                 ...(endpointType === "REGIONAL"
                   ? {
@@ -1612,7 +1612,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
         domain.dns.createAlias(
           name,
           {
-            name: domain.name,
+            name: domain.name!,
             aliasName: endpointType.apply((v) =>
               v === "EDGE"
                 ? apigDomain.cloudfrontDomainName


### PR DESCRIPTION
I ran into this TS issue today when I began learning how to use SST.

I've simply mirrored these changes from `ApiGatewayV2`'s use of its domain args type and implementation!

Allows for the intended use case without TS errors;

```typescript
export const api = new sst.aws.ApiGatewayV1("Api", {
  domain: {
    nameId: "example.com",
  }
});
```