### PR TITLE
docs: Typo in output filename

### DIFF
--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -1246,10 +1246,10 @@ export interface Config {
    * bucket: bucket-jOaikGu4rla
    * ```
    *
-   * These outputs are also written to a `.sst/output.json` file after every successful deploy.
+   * These outputs are also written to a `.sst/outputs.json` file after every successful deploy.
    * It contains the above outputs in JSON.
    *
-   * ```json title=".sst/output.json"
+   * ```json title=".sst/outputs.json"
    * {"bucket": "bucket-jOaikGu4rla"}
    * ```
    */


### PR DESCRIPTION
Should be `outputs.json` instead of `output.json` ([implementation writing the file](pkg/project/run.go)).