### PR TITLE
Support `provided.al2` runtime

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -300,6 +300,7 @@ export interface FunctionArgs {
     | "nodejs22.x"
     | "go"
     | "rust"
+    | "provided.al2"
     | "provided.al2023"
     | "python3.9"
     | "python3.10"


### PR DESCRIPTION
This runtime is still supported by AWS and requirred by some lambda layers

In particular the bref.sh lambda layers require this runtime. This allows SST to use this runtime and enable older code to benefit from SST v3 functionality.