### PR TITLE
docs: updates for Cloudflare API tokens and AWS quota increase

### DIFF
--- a/www/src/content/docs/docs/console.mdx
+++ b/www/src/content/docs/docs/console.mdx
@@ -73,7 +73,11 @@ Currently the Console only supports apps **deployed to AWS**.
 
    > Resource handler returned message: "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value
 
-   This happens because AWS has been limiting the concurrency of Lambda functions for new accounts. It's a good idea to increase this limit before you go to production anyway. To do so, you can [request a quota increase](https://repost.aws/knowledge-center/lambda-concurrency-limit-increase) to the default value of 1000.
+   This happens because AWS has been limiting the concurrency of Lambda functions for new accounts. It's a good idea to increase this limit before you go to production anyway. To do so, you can [request a quota increase](https://repost.aws/knowledge-center/lambda-concurrency-limit-increase) to the default value of 1000. If you want to expedite the request:
+    1. Submit the request
+    2. Click the "Quota request history" link in the sidebar
+    3. Click on "AWS Support Center Case" to open your request case details
+    4. Hit the "Reply" button and select "Chat" to chat with an AWS representative to expedite it.
 
 3. **Invite your team**
 

--- a/www/src/content/docs/docs/custom-domains.mdx
+++ b/www/src/content/docs/docs/custom-domains.mdx
@@ -136,6 +136,12 @@ If your domains are hosted on [Cloudflare](https://developers.cloudflare.com/dns
 
    To get your API tokens, head to the [API Tokens section](https://dash.cloudflare.com/profile/api-tokens) of your Cloudflare dashboard and create one with the **Edit zone DNS** policy.
 
+
+     :::note
+      The Cloudflare Pulumi providers need the proper credentials above to deploy your app in the first place, which means they won't be initially accessible via SST Secrets. Instead, you can use SST Console's [`autodeploy`](console.mdx#autodeploy) feature to set these 2 environment variables there to avoid this issue.
+      :::
+
+
 3. Use the [`sst.cloudflare.dns`](/docs/component/cloudflare/dns/) adapter.
 
    ```js


### PR DESCRIPTION
- clarification to explain that using the Cloudflare adapter requires a different way other than SST Secrets to add those environment variables (rephrasing of issue from user "grameens" in the discord)

- notes to help folks expedite increased AWS Lambda quota for SST Console