### PR TITLE
feat: Add watch configuration for dev

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -158,7 +158,10 @@ func CmdMosaic(c *cli.Cli) error {
 
 	wg.Go(func() error {
 		defer c.Cancel()
-		return watcher.Start(c.Context, p.PathRoot())
+		return watcher.Start(c.Context, watcher.WatchConfig{
+			Root:  p.PathRoot(),
+			Watch: p.App().Watch,
+		})
 	})
 
 	server, err := server.New()
@@ -349,7 +352,6 @@ func CmdMosaic(c *cli.Cli) error {
 	err = wg.Wait()
 	slog.Info("done mosaic", "err", err)
 	return err
-
 }
 
 func diff(a map[string]string, b map[string]string) bool {

--- a/cmd/sst/mosaic/watcher/watcher.go
+++ b/cmd/sst/mosaic/watcher/watcher.go
@@ -16,46 +16,69 @@ type FileChangedEvent struct {
 	Path string
 }
 
-func Start(ctx context.Context, root string) error {
+type WatchConfig struct {
+	Root  string
+	Watch []string
+}
+
+func Start(ctx context.Context, config WatchConfig) error {
 	log := slog.Default().With("service", "watcher")
 	defer log.Info("done")
-	log.Info("starting watcher", "root", root)
+	log.Info("starting watcher", "root", config.Root)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
 	}
-	err = watcher.AddWith(root)
+
+	err = watcher.AddWith(config.Root)
 	if err != nil {
 		return err
 	}
-	ignoreSubstrings := []string{"node_modules"}
 
-	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			if strings.HasPrefix(info.Name(), ".") {
-				return filepath.SkipDir
-			}
-			for _, substring := range ignoreSubstrings {
-				if strings.Contains(path, substring) {
-					return filepath.SkipDir
-				}
-			}
-			log.Info("watching", "path", path)
-			err = watcher.Add(path)
+	matches := []string{}
+	if len(config.Watch) == 0 {
+		matches = append(matches, config.Root)
+	} else {
+		for _, watch := range config.Watch {
+			pattern := filepath.Join(config.Root, watch)
+			patternMatches, err := filepath.Glob(pattern)
 			if err != nil {
 				return err
 			}
+			matches = append(matches, patternMatches...)
 		}
-		return nil
-	})
-	if err != nil {
-		return err
 	}
 
-	headFile := filepath.Join(root, ".git/HEAD")
+	ignoreSubstrings := []string{"node_modules"}
+	for _, match := range matches {
+		err = filepath.Walk(match, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if strings.HasPrefix(info.Name(), ".") {
+					return filepath.SkipDir
+				}
+				for _, substring := range ignoreSubstrings {
+					if strings.Contains(path, substring) {
+						return filepath.SkipDir
+					}
+				}
+
+				log.Info("watching", "path", path)
+				err = watcher.Add(path)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	headFile := filepath.Join(config.Root, ".git/HEAD")
 	watcher.Add(headFile)
 	limiter := map[string]time.Time{}
 	for {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -35,6 +35,7 @@ type App struct {
 	Home      string                 `json:"home"`
 	Version   string                 `json:"version"`
 	Protect   bool                   `json:"protect"`
+	Watch     []string               `json:"watch"`
 	// Deprecated: Backend is now Home
 	Backend string `json:"backend"`
 	// Deprecated: RemovalPolicy is now Removal

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -270,6 +270,22 @@ export interface App {
    * `sst dev`, it'll still get removed. To avoid this, check out the `removal` prop.
    */
   protect?: boolean;
+
+  /**
+   * Configure which directories should be watched for changes when running `sst dev`.
+   * By default, all directories are watched (except node_modules and hidden directories).
+   *
+   * @example
+   * ```ts
+   * {
+   *   watch: ["packages/www", "packages/api"]
+   * }
+   * ```
+   *
+   * This will only watch the `packages/www` and `packages/api` directories.
+   * The paths are relative to the project root.
+   */
+  watch?: string[];
 }
 
 export interface AppInput {


### PR DESCRIPTION
Add `watch` property to app to allow watching specific directories for changes when running `sst dev`.

closes #5003, closes #4233