### PR TITLE
Docs: add note for required preset for TanStackStart

### DIFF
--- a/platform/src/components/aws/tan-stack-start.ts
+++ b/platform/src/components/aws/tan-stack-start.ts
@@ -284,6 +284,10 @@ export interface TanStackStartArgs extends SsrSiteArgs {
 /**
  * The `TanStackStart` component lets you deploy a [TanStack Start](https://tanstack.com/start/latest) app to AWS.
  *
+ * :::note
+ * You need to make sure the `server.preset` value in the `app.config.ts` is set to `aws-lambda`.
+ * :::
+ *
  * @example
  *
  * #### Minimal example


### PR DESCRIPTION
```
 |  Error       
TanStackStart's app.config.ts must be configured to use the "aws-lambda" preset. It is currently set to "node-server".
```

I added a note to the docs with a required setting for TanStackStart, otherwise the example app won't build out of the box.