### PR TITLE
Fix .html files cache headers

### DIFF
--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -886,12 +886,12 @@ export class StaticSite extends Component implements Link.Linkable {
           // Build fileOptions
           const fileOptions = assets?.fileOptions ?? [
             {
-              files: "**/*.html",
-              cacheControl: "max-age=0,no-cache,no-store,must-revalidate",
-            },
-            {
               files: "**",
               cacheControl: "max-age=31536000,public,immutable",
+            },
+            {
+              files: "**/*.html",
+              cacheControl: "max-age=0,no-cache,no-store,must-revalidate",
             },
           ];
 


### PR DESCRIPTION
Fixes:
https://github.com/sst/sst/issues/5673

The issue:
`.html` files have public caching headers set with 1 year lifetime. The commit here put the `fileOptions` in the wrong order:
https://github.com/sst/sst/commit/f26a3f99fe4cb5184ec743ddef2fc97f316bb6fb

This is severe. I expect more and more people having broken apps in production as they upgrade. This needs to be merged in asap @fwang 