### PR TITLE
Add example of how to enable an API key on a route

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -1163,7 +1163,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
    * @param name The name of the usage plan.
    * @param args Configure the usage plan.
    * @example
-   * Add a usage plan with throttle and quota.
+   * Add a usage plan with throttle and quota. This can only be done after the routes are created and deployed.
    *
    * ```js title="sst.config.ts"
    * const plan = api.addUsagePlan("MyPlan", {
@@ -1183,6 +1183,12 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
    *
    * ```js title="sst.config.ts"
    * const key = plan.addApiKey("MyKey");
+   * ```
+   *
+   * The API key needs to be enabled on each route, as by default it is disabled.
+   *
+   * ```js title="sst.config.ts"
+   * api.route("GET /", "src/get.handler", { transform: { method: { apiKeyRequired: true } } });
    * ```
    *
    * You can link the API key to other resources, like a function. Once linked,


### PR DESCRIPTION
The docs have an example of how to create an API key, but the API key only takes effect when it is explicitly enabled on the API routes. This proposal adds a description of this behaviour and an example.