### PR TITLE
fix: Ensure DevCommands respect `autostart`

### DIFF
--- a/cmd/sst/mosaic/multiplexer/multiplexer.go
+++ b/cmd/sst/mosaic/multiplexer/multiplexer.go
@@ -105,7 +105,7 @@ func (s *Multiplexer) Start() {
 			case *EventProcess:
 				for _, p := range s.processes {
 					if p.key == evt.Key {
-						if p.dead {
+						if p.dead && evt.Autostart {
 							p.start()
 							s.sort()
 							s.draw()


### PR DESCRIPTION
Addresses #5635  - checks if a dead process has autostart enabled in multiplexer `start()`

Can stop and start all processes as expected - not exactly sure whether this is the place to check for autostart - call me out if not!