### PR TITLE
fix: ensure personal stage .env file overwrites any environment varibles set

### DIFF
--- a/cmd/sst/cli/cli.go
+++ b/cmd/sst/cli/cli.go
@@ -335,7 +335,7 @@ func (c *Cli) Stage(cfgPath string) (string, error) {
 			}
 		}
 	}
-	godotenv.Load(filepath.Join(filepath.Dir(cfgPath), ".env."+stage))
+	godotenv.Overload(filepath.Join(filepath.Dir(cfgPath), ".env."+stage))
 	return stage, nil
 }
 


### PR DESCRIPTION
📝 Summary  
This PR makes sure that variables in `.env.<stage>` take precedence over those in `.env`. Stage-specific settings will properly override base values as intended.

---

🔍 Changes Made

🧪 Current Behavior  
- Both `.env` and `.env.<stage>` files were loaded using `godotenv.Load`.  
- Because `godotenv.Load` does not overwrite already-set environment variables, values from `.env.<stage>` could not override those set by `.env`.
- Example:  
  - `.env` contains `FOO=bar`  
  - `.env.local` contains `FOO=hello`  
  - Running with `--stage local` still resulted in `FOO=bar` instead of `FOO=hello`.

✅ New Behavior  
- The code now uses `godotenv.Overload` to load the stage-specific `.env.<stage>` file.
- This ensures that any variables in `.env.<stage>` always overwrite those from `.env`.
- Example:  
  - `.env` contains `FOO=bar`  
  - `.env.local` contains `FOO=hello`  
  - Running with `--stage local` now correctly results in `FOO=hello`.

---

## 📎 Additional Notes

How to test:

1. Add `FOO=bar` to your `.env` file.
2. Add `FOO=hello` to your `.env.local` file.
3. Run the app with `./sst dev --stage local`.
4. In your app, check the value of `FOO` (e.g., log it or print it).
5. You should see `FOO=hello`. If so, the fix is working.

