### PR TITLE
docs: fix typo

### DIFF
--- a/www/src/content/docs/blog/frontends-are-hard.mdx
+++ b/www/src/content/docs/blog/frontends-are-hard.mdx
@@ -142,7 +142,7 @@ We had been looking for ways to improve our setup. And now we can, [thanks to th
 
 A seemingly trivial _pre:Invent_ announcement made CloudFront a lot more _programmable_. This paved the way for us to support setups that are far **more flexible than Netlify or Vercel**.
 
-The key change here is that you can now use CloudFront Functions in tandem with a CloudFront KeyVaueStore to modify the origin of requests. This lets you create custom policies for how traffic is routed from the CDN to your application.
+The key change here is that you can now use CloudFront Functions in tandem with a CloudFront KeyValueStore to modify the origin of requests. This lets you create custom policies for how traffic is routed from the CDN to your application.
 
 In the past, you'd have to use a Lambda@Edge function and a DynamoDB table which is both a lot more expensive and a lot slower.
 


### PR DESCRIPTION
Fix typo in `frontends-are-hard.mdx`

```
CloudFront KeyVaueStore → CloudFront KeyValueStore
              ^^^^                      ^^^^^
```