### PR TITLE
Support shared Router in Auth and OpenControl components

### DIFF
--- a/platform/src/components/aws/auth.ts
+++ b/platform/src/components/aws/auth.ts
@@ -293,6 +293,7 @@ export class Auth extends Component implements Link.Linkable {
         },
         (args) => {
           args.url = {
+            ...(typeof args.url === "object" ? args.url : {}),
             cors: false,
           };
         },

--- a/platform/src/components/aws/auth.ts
+++ b/platform/src/components/aws/auth.ts
@@ -321,11 +321,15 @@ export class Auth extends Component implements Link.Linkable {
   /**
    * The URL of the Auth component.
    *
-   * If the `domain` is set, this is the URL with the custom domain.
+   * If the `domain` is set, this is the URL of the Router created for the custom domain.
+   * If the `issuer` function is linked to a custom domain, this is the URL of the issuer.
    * Otherwise, it's the auto-generated function URL for the issuer.
    */
   public get url() {
-    return this._router?.url ?? this._issuer.url.apply((v) => v.slice(0, -1));
+    return (
+      this._router?.url ??
+      this._issuer.url.apply((v) => (v.endsWith("/") ? v.slice(0, -1) : v))
+    );
   }
 
   /**

--- a/platform/src/components/aws/opencontrol.ts
+++ b/platform/src/components/aws/opencontrol.ts
@@ -65,7 +65,7 @@ export interface OpenControlArgs {
  * });
  * ```
  *
- * #### Link your AI API keys 
+ * #### Link your AI API keys
  *
  * ```ts title="sst.config.ts" {6}
  * const anthropicKey = new sst.Secret("AnthropicKey");
@@ -189,14 +189,12 @@ export class OpenControl extends Component {
           environment: {
             OPENCONTROL_KEY: key,
           },
-          url: true,
+          url: {
+            cors: false,
+          },
           _skipHint: true,
         },
-        (args) => {
-          args.url = {
-            cors: false,
-          };
-        },
+        undefined,
         { parent: self },
       ).apply((v) => v.getFunction());
     }


### PR DESCRIPTION
This PR modifies the `Auth` and `OpenControl` components to allow reusing an existing `Router`. 

Currently, both of these component apply the following transformation function to the function arguments:
```
        (args) => {
          args.url = {
            cors: false,
          };
        },
```

This will overwrite any `url` options passed in by the caller, for example: 
```
const router = new sst.aws.Router("Router", {
  domain: {
    name: "example.com",
    aliases: [`*.example.com`],
    dns: sst.cloudflare.dns(),
  },
})

// works as expected
export const ApiFunction = new sst.aws.Function("Api", {
  handler: "./packages/functions/src/api/function.handler",
  url: {
    router: {
      instance: router,
      domain: "auth.example.com",
    },
  },
});

// router options are ignored
export const AuthFunction = new sst.aws.Auth("Auth", {
  issuer: {
    handler: "./packages/functions/src/authorizer.handler",
    url: {
      router: {
        instance: router,
        domain: "auth.example.com",
      },
    },
  },
});
```

For the `Auth` component, I kept the transformation function but modified it so that other fields of `args.url` are combined with `cors: false`. For `OpenControl`, I moved the `cors: false` to functionBuilder's defaultArgs field, which feels more appropriate unless cors must always be false for `OpenControl`. In addition, I modified the behavior of Auth's url getter so that it only removes the last character of `this._issuer.url` if a trailing slash is present. 

I have tested this out in my own application by copying these files into my `.sst` directory. 

