### PR TITLE
Docs: Improvements to SQS examples

### DIFF
--- a/examples/aws-bucket-queue-subscriber/package.json
+++ b/examples/aws-bucket-queue-subscriber/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-dead-letter-queue",
+  "name": "aws-bucket-queue-subscriber",
   "version": "1.0.0",
   "description": "",
   "type": "module",
@@ -15,8 +15,5 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.149",
     "sst": "3.0.37"
-  },
-  "dependencies": {
-    "@aws-sdk/client-sqs": "^3.515.0"
   }
 }

--- a/examples/aws-bucket-queue-subscriber/subscriber.ts
+++ b/examples/aws-bucket-queue-subscriber/subscriber.ts
@@ -1,4 +1,6 @@
-export const handler = async (event) => {
+import type { SQSEvent } from "aws-lambda";
+
+export const handler = async (event: SQSEvent) => {
   console.log(event);
   return "ok";
 };

--- a/examples/aws-dead-letter-queue/sst.config.ts
+++ b/examples/aws-dead-letter-queue/sst.config.ts
@@ -1,9 +1,9 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
 /**
- * ## Subscribe to queues
+ * ## Subscribe to queues with dead-letter queue
  *
- * Create an SQS queue, subscribe to it, and publish to it from a function.
+ * Messages not processed successfully by the primary subscriber function will be sent to the dead-letter queue after the retry limit is reached.
  */
 export default $config({
   app(input) {

--- a/examples/aws-dead-letter-queue/subscriber.ts
+++ b/examples/aws-dead-letter-queue/subscriber.ts
@@ -1,9 +1,11 @@
+import type { SQSEvent, SQSHandler } from "aws-lambda";
+
 export const main = async (event) => {
   console.log(event);
   throw new Error("Manual error");
 };
 
-export const dlq = async (event) => {
+export const dlq: SQSHandler = async (event: SQSEvent) => {
   console.log(event);
-  return "ok";
+  return;
 };

--- a/examples/aws-queue/package.json
+++ b/examples/aws-queue/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.149",
     "sst": "3.0.37"
   },
   "dependencies": {

--- a/examples/aws-queue/sst.config.ts
+++ b/examples/aws-queue/sst.config.ts
@@ -4,6 +4,73 @@
  * ## Subscribe to queues
  *
  * Create an SQS queue, subscribe to it, and publish to it from a function.
+ * 
+ * ```ts title="sst.config.ts"
+ * const queue = new sst.aws.Queue("MyQueue");
+ * queue.subscribe("subscriber.handler");
+ * 
+ * const app = new sst.aws.Function("MyApp", {
+ *   handler: "publisher.handler",
+ *   link: [queue],
+ *   url: true,
+ * });
+ * 
+ * return {
+ *   app: app.url,
+ *   queue: queue.url,
+ * };
+ * ```
+ *
+ * The subscriber will read messages from the queue in batches. This array of messages exists on the `Records` property of the `SQSEvent`.
+ *
+ * ```ts title="subscriber.ts"
+ * import type { SQSEvent, SQSHandler } from "aws-lambda";
+ * 
+ * export const handler: SQSHandler = async (event: SQSEvent) => {
+ *   for (const record of event.Records){
+ *     // Message bodies are always strings
+ *     console.log(record.body) 
+ *   }
+ *   return;
+ * };
+ * ```
+ *
+ * By default, all messages in the batch become visible in the queue again if an error occurs. This can lead to unnecessary extra processing and messages being processed more than once. The solution is to enable [partial batch responsese](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting) and return which specific messages within the batch should be made visible again in the queue.
+ *
+ * Update the queue subscriber.
+ *
+ * ```ts title="sst.config.ts"
+ * queue.subscribe("subscriber.handler", {
+ *   batch: {
+ *     partialResponses: true,
+ *   }
+ * });
+ * ```
+ *
+ * Then update the handler to return the failed items.
+ *
+ * ```ts title="subscriber.ts"
+ * import type { SQSEvent, SQSHandler } from "aws-lambda";
+ * 
+ * export const handler: SQSHandler = async (event: SQSEvent) => {
+ *   const batchItemFailures = []
+ *   for (const record of event.Records){
+ *     try {
+ *       console.log(record.body)
+ *       if (Math.random() < 0.1){
+ *         throw new Error("An error occurred")
+ *       }
+ *     }
+ *     catch (e) {
+ *       batchItemFailures.push({ itemIdentifier: record.messageId });
+ *     }
+ *   }
+ * 
+ *   // Failed items will be made visible in the queue again
+ *   return { batchItemFailures };
+ * };
+ * ```
+ *
  */
 export default $config({
   app(input) {

--- a/examples/aws-queue/sst.config.ts
+++ b/examples/aws-queue/sst.config.ts
@@ -15,7 +15,11 @@ export default $config({
   },
   async run() {
     const queue = new sst.aws.Queue("MyQueue");
-    queue.subscribe("subscriber.handler");
+    queue.subscribe("subscriber.handler", {
+      batch: {
+        partialResponses: true,
+      }
+    });
 
     const app = new sst.aws.Function("MyApp", {
       handler: "publisher.handler",

--- a/examples/aws-queue/subscriber.ts
+++ b/examples/aws-queue/subscriber.ts
@@ -1,4 +1,19 @@
-export const handler = async (event) => {
-  console.log(event);
-  return "ok";
+import type { SQSEvent, SQSHandler } from "aws-lambda";
+
+export const handler: SQSHandler = async (event: SQSEvent) => {
+  const batchItemFailures = []
+  for (const record of event.Records){
+    try {
+      console.log(record.body)
+      if (Math.random() < 0.1){
+        throw new Error("An error occurred")
+      }
+    }
+    catch (e) {
+      batchItemFailures.push({ itemIdentifier: record.messageId });
+    }
+  }
+
+  // Failed items will be made visible in the queue again
+  return { batchItemFailures };
 };

--- a/examples/aws-topic/package.json
+++ b/examples/aws-topic/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.149",
     "sst": "latest"
   },
   "dependencies": {

--- a/examples/aws-topic/subscriber.ts
+++ b/examples/aws-topic/subscriber.ts
@@ -1,4 +1,6 @@
-export const handler = async (event) => {
+import type { SQSEvent } from "aws-lambda";
+
+export const handler = async (event: SQSEvent) => {
   console.log(event);
   return "ok";
 };

--- a/www/src/content/docs/docs/examples.mdx
+++ b/www/src/content/docs/docs/examples.mdx
@@ -868,9 +868,9 @@ View the [full example](https://github.com/sst/sst/tree/dev/examples/aws-cluster
 
 
 ---
-## Subscribe to queues
+## Subscribe to queues with dead-letter queue
 
-Create an SQS queue, subscribe to it, and publish to it from a function.
+Messages not processed successfully by the primary subscriber function will be sent to the dead-letter queue after the retry limit is reached.
 ```ts title="sst.config.ts"
 // create dead letter queue
 const dlq = new sst.aws.Queue("DeadLetterQueue");
@@ -3512,6 +3512,56 @@ const app = new sst.aws.Function("MyApp", {
 return {
   app: app.url,
   queue: queue.url,
+};
+```
+
+The subscriber will read messages from the queue in batches. This array of messages exists on the `Records` property of the `SQSEvent`.
+
+```ts title="subscriber.ts"
+import type { SQSEvent, SQSHandler } from "aws-lambda";
+
+export const handler: SQSHandler = async (event: SQSEvent) => {
+  for (const record of event.Records){
+    // Message bodies are always strings
+    console.log(record.body) 
+  }
+  return;
+};
+```
+
+By default, all messages in the batch become visible in the queue again if an error occurs. This can lead to unnecessary extra processing and messages being processed more than once. The solution is to enable [partial batch responsese](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting) and return which specific messages within the batch should be made visible again in the queue.
+
+Update the queue subscriber.
+
+```ts title="sst.config.ts"
+queue.subscribe("subscriber.handler", {
+  batch: {
+    partialResponses: true,
+  }
+});
+```
+
+Then update the handler to return the failed items.
+
+```ts title="subscriber.ts"
+import type { SQSEvent, SQSHandler } from "aws-lambda";
+
+export const handler: SQSHandler = async (event: SQSEvent) => {
+  const batchItemFailures = []
+  for (const record of event.Records){
+    try {
+      console.log(record.body)
+      if (Math.random() < 0.1){
+        throw new Error("An error occurred")
+      }
+    }
+    catch (e) {
+      batchItemFailures.push({ itemIdentifier: record.messageId });
+    }
+  }
+
+  // Failed items will be made visible in the queue again
+  return { batchItemFailures };
 };
 ```
 


### PR DESCRIPTION
This PR cleans up a few components of the docs and enhances the basic SQS example to also showcase how to handle partial batch responses.

1. In `examples.mdx` both the main queue example and the dead-letter queue example were called "Subscribe to queues". This differentiates the naming to make it clear that it is in fact two different examples
2. SQS event handler type definitions existed for some of the examples but not all. This PR adds them in the places where they were missing
3. The main "Subscribe to queue" example was not particularly useful for demonstrating how to actually process the messages once they are in the read by the lambda handler. This pr adds basic scaffolding of looping through each record on the SQS event and demonstrates how to use partial batch responses.
4. `aws-bucket-queue-subscriber` did not have a package.json