### PR TITLE
Bump OpenNext to v3.6.4

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -11,7 +11,7 @@ import { isALteB } from "../../util/compare-semver.js";
 import { Plan, SsrSite, SsrSiteArgs } from "./ssr-site.js";
 import { Bucket } from "./bucket.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.6.2";
+const DEFAULT_OPEN_NEXT_VERSION = "3.6.4";
 
 type BaseFunction = {
   handler: string;


### PR DESCRIPTION
[opennextjs/opennextjs-aws/releases](https://github.com/opennextjs/opennextjs-aws/releases)