### PR TITLE
fix: normalize path separators in TypeScript reference generation

### DIFF
--- a/pkg/types/typescript/typescript.go
+++ b/pkg/types/typescript/typescript.go
@@ -104,7 +104,7 @@ func Generate(root string, links common.Links) error {
 		}
 
 		rel, err := filepath.Rel(filepath.Dir(envPath), rootEnv)
-		envFile.WriteString("/// <reference path=\"" + rel + "\" />\n")
+		envFile.WriteString("/// <reference path=\"" + filepath.ToSlash(rel) + "\" />\n")
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #5833 