### PR TITLE
Replace yum with dnf

### DIFF
--- a/examples/aws-python-container/custom_dockerfile/Dockerfile
+++ b/examples/aws-python-container/custom_dockerfile/Dockerfile
@@ -5,9 +5,9 @@ ARG PYTHON_VERSION=3.11
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
 # # Ensure git is installed so we can install git based dependencies (such as sst)
-RUN yum update -y && \
-    yum install -y git gcc && \
-    yum clean all
+RUN dnf update -y && \
+    dnf install -y git gcc && \
+    dnf clean all
 
 # Install UV to manage your python runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv


### PR DESCRIPTION
The Amazon Linux 2023 base image has [replaced yum with dnf](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/). 

This updated installs git and gcc with dnf instead of yum.

Fixes [@5849](https://github.com/sst/sst/issues/5849)