### PR TITLE
docs: update prisma docs with missing datasource

### DIFF
--- a/www/src/content/docs/docs/start/aws/prisma.mdx
+++ b/www/src/content/docs/docs/start/aws/prisma.mdx
@@ -182,6 +182,11 @@ We are setting Prisma Studio to not auto-start since it pops up a browser window
 Let's create a simple schema. Add this to your `schema.prisma`.
 
 ```prisma title="schema.prisma"
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
 model User {
   id    Int     @id @default(autoincrement())
   name  String?


### PR DESCRIPTION
Currently with the prisma documentation [here](https://sst.dev/docs/start/aws/prisma/) on the [Generate a migration](https://sst.dev/docs/start/aws/prisma/#generate-a-migration) step, it will fail with the following error:

```
aws-prisma npx sst shell --target Prisma -- npx prisma migrate dev --name init
Environment variables loaded from .env
Prisma schema loaded from schema.prisma

Error: A datasource block is missing in the Prisma schema file.
```

This is because as the error says:

> A datasource block is missing in the Prisma schema file


So this PR is to add the datasource in the [4. Create a schema](https://sst.dev/docs/start/aws/prisma/#4-create-a-schema) step