### PR TITLE
Fix secret set command for files

### DIFF
--- a/cmd/sst/secret.go
+++ b/cmd/sst/secret.go
@@ -346,6 +346,9 @@ var CmdSecretSet = &cli.Command{
 				input, err := reader.ReadString('\n')
 				if err != nil {
 					if err == io.EOF {
+						if input != "" {
+						    value += input
+						}
 						break
 					}
 					return err


### PR DESCRIPTION
The sst secret set command has a bug when reading multiline secrets from stdin (e.g., sst secret set MySecret < file.txt). The issue occurs in the stdin reading loop where reader.ReadString('\n') can return both partial content and an io.EOF error when it reaches the end of input without finding a newline character. The current code immediately breaks on io.EOF without adding the partial content to the accumulated value, causing the last line of any file without a trailing newline to be completely dropped. This affects single-line files (which get set to empty strings) and multiline files like RSA/EC private keys where the final -----END ... KEY----- line is lost, resulting in malformed secrets that cause cryptographic operations to fail with "asymmetric key" errors.