### PR TITLE
fix: skip send to partial channel on diff

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -505,7 +505,7 @@ loop:
 			}
 		}
 
-		if event.ResOutputsEvent != nil || event.CancelEvent != nil || event.SummaryEvent != nil {
+		if input.Command != "diff" && (event.ResOutputsEvent != nil || event.CancelEvent != nil || event.SummaryEvent != nil) {
 			partial <- 1
 		}
 


### PR DESCRIPTION
Resolves https://github.com/sst/sst/issues/5856

partial channel was filling up during `sst diff` but this channel is not consumed in this mode due to this go routine:
```
	go func() {
		if input.Command == "diff" {
			return
		}
		for {
			select {
			case <-partialContext.Done():
				partialDone <- nil
				return
			case <-partial:
				workdir.PushPartial(update.ID)
			case <-time.After(time.Second * 5):
				workdir.PushPartial(update.ID)
				continue
			}
		}
	}()
```

 so once the buffer hit 1000 it started blocking and causes the command to hang indefinitely.

