### PR TITLE
feat: per-process log files under .sst/log

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
+	"regexp"
 	"strings"
 	"time"
 
@@ -271,13 +272,19 @@ func CmdMosaic(c *cli.Cli) error {
 							}
 							multi.AddProcess(
 								d.Name,
-								append([]string{currentExecutable, "dev"}),
+								[]string{currentExecutable, "dev"},
 								"→",
 								title,
 								dir,
 								true,
 								d.Autostart,
-								append([]string{"SST_CHILD=" + d.Name}, multiEnv...)...,
+								append(
+									[]string{
+										"SST_CHILD=" + d.Name,
+										"SST_LOG=" + p.PathLog(logFileName(d.Name, d.Command)),
+									},
+									multiEnv...,
+								)...,
 							)
 						}
 						for name := range evt.Tunnels {
@@ -368,4 +375,35 @@ func diff(a map[string]string, b map[string]string) bool {
 		}
 	}
 	return false
+}
+
+// logFileName returns a filesystem-friendly log filename (without extension)
+// derived from the dev entry name and the command being executed.
+func logFileName(name, cmd string) string {
+	tokens := []string{}
+	for _, part := range strings.Fields(cmd) {
+		if strings.HasPrefix(part, "-") {
+			break // stop at first flag
+		}
+		// ignore empty
+		if part == "" {
+			continue
+		}
+		tokens = append(tokens, part)
+		if len(tokens) == 3 {
+			break
+		}
+	}
+	if len(tokens) == 0 {
+		tokens = []string{name}
+	}
+	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	for i, t := range tokens {
+		tokens[i] = strings.Trim(re.ReplaceAllString(t, "-"), "-")
+	}
+	slug := strings.ToLower(strings.Join(tokens, "-"))
+	if slug == "" {
+		slug = strings.ToLower(name)
+	}
+	return slug
 }

--- a/cmd/sst/mosaic/monoplexer/monoplexer.go
+++ b/cmd/sst/mosaic/monoplexer/monoplexer.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"os/exec"
 
 	"github.com/sst/sst/v3/pkg/process"
@@ -66,11 +68,22 @@ func (m *Monoplexer) AddProcess(name string, command []string, directory string,
 		delete(m.processes, name)
 	}
 
-	r, w := io.Pipe()
+	r, pipeWriter := io.Pipe()
+
+	var logWriter io.Writer = pipeWriter
+	if directory != "" {
+		logDir := filepath.Join(directory, ".sst", "log")
+		os.MkdirAll(logDir, 0o755)
+		file, err := os.Create(filepath.Join(logDir, name+".log"))
+		if err == nil {
+			logWriter = io.MultiWriter(pipeWriter, file)
+		}
+	}
+
 	cmd := process.Command(command[0], command[1:]...)
 	cmd.SysProcAttr = getProcAttr()
-	cmd.Stdout = w
-	cmd.Stderr = w
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
 	if directory != "" {
 		cmd.Dir = directory
 	}

--- a/cmd/sst/mosaic/multiplexer/process.go
+++ b/cmd/sst/mosaic/multiplexer/process.go
@@ -2,6 +2,9 @@ package multiplexer
 
 import (
 	"os/exec"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	tcellterm "github.com/sst/sst/v3/cmd/sst/mosaic/multiplexer/tcell-term"
@@ -56,6 +59,24 @@ func (p *pane) start() error {
 	p.cmd.Env = p.env
 	if p.dir != "" {
 		p.cmd.Dir = p.dir
+	}
+
+	// If SST_LOG is provided in the environment variables, use it to create a
+	// log file and attach it to the VT so that all output is persisted.
+	var logPath string
+	for _, e := range p.env {
+		if strings.HasPrefix(e, "SST_LOG=") {
+			logPath = strings.TrimPrefix(e, "SST_LOG=")
+			break
+		}
+	}
+	if logPath != "" {
+		// Ensure directory exists
+		os.MkdirAll(filepath.Dir(logPath), 0o755)
+		file, err := os.Create(logPath)
+		if err == nil {
+			p.vt.SetLog(file)
+		}
 	}
 	p.vt.Clear()
 	err := p.vt.Start(p.cmd)

--- a/cmd/sst/mosaic/multiplexer/tcell-term/vt.go
+++ b/cmd/sst/mosaic/multiplexer/tcell-term/vt.go
@@ -64,6 +64,12 @@ type VT struct {
 	mouseBtn tcell.ButtonMask
 
 	selection *selection
+
+	// logWriter, if set, will receive a copy of all raw bytes read from the
+	// underlying PTY. This allows callers (ie. the SST multiplexer) to persist
+	// the exact output of the process to a log file under .sst/logs while still
+	// rendering it interactively in the TUI.
+	logWriter io.Writer
 }
 
 type selection struct {
@@ -170,8 +176,16 @@ func (vt *VT) Start(cmd *exec.Cmd) error {
 		return err
 	}
 
+	// If a log writer has been configured, tee the PTY output so that the raw
+	// stream is written both to the parser (for on-screen rendering) and to the
+	// log file.
+	var reader io.Reader = vt.pty
+	if vt.logWriter != nil {
+		reader = io.TeeReader(vt.pty, vt.logWriter)
+	}
+
 	vt.Resize(w, h)
-	vt.parser = NewParser(vt.pty)
+	vt.parser = NewParser(reader)
 	go func() {
 		defer vt.recover()
 		for {
@@ -456,6 +470,9 @@ func (vt *VT) Close() {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 	vt.pty.Close()
+	if closer, ok := vt.logWriter.(io.Closer); ok {
+		closer.Close()
+	}
 }
 
 func (vt *VT) Attach(fn func(ev tcell.Event)) {
@@ -666,4 +683,11 @@ func isCellSelected(x, y, startX, startY, endX, endY int) bool {
 		return x <= maxX // Last line of multi-line selection
 	}
 	return false
+}
+
+// SetLog assigns an io.Writer that will receive a copy of everything written
+// to the terminal. Callers should close the writer themselves if they need to
+// flush or release resources.
+func (vt *VT) SetLog(w io.Writer) {
+	vt.logWriter = w
 }


### PR DESCRIPTION
Add per-process log files to sst dev
====================================

Summary
-------

This PR adds per-process log files to `sst dev`, letting tooling inspect exactly what appears in each Mosaic/Monoplexer pane. 

It addresses the request in issue #5885 – "How to get sst dev logs, including all processes?"

Disclosure - all code changes and text in this PR (apart from this paragraph) were made by an AI assistant. I'm not familiar with Go, so although the code changes look reasonable to me I'd appreciate an expert opinion. I ran the unit tests locally, and tested the patched `sst dev` against a React Router app.

Background
----------

While the interactive terminal UI shows every process's output live, that stream was not persisted to disk.  
For automation (MCP servers, CI helpers, agent debugging sessions, etc.) users need to redirect output manually or run `sst dev --mode=mono` in a wrapper script. Persisting the raw PTY stream removes that friction and gives parity with the UI.

Implementation details
----------------------

1. Virtual terminal (`cmd/sst/mosaic/multiplexer/tcell-term/vt.go`)
   • Added `logWriter io.Writer` and `SetLog(io.Writer)`.  
   • When present, the PTY's stream is copied via `io.TeeReader`, so logging has zero impact on the parser/renderer.

2. Pane bootstrap (`cmd/sst/mosaic/multiplexer/process.go`)
   • Reads `SST_LOG=<path>` from the environment, creates the file, and attaches it with `vt.SetLog`.

3. Mosaic launcher (`cmd/sst/mosaic.go`)
   • Generates a deterministic log-file name from the dev command (e.g. `npm run dev` → `npm-run-dev.log`) via `PathLog`.  
   • Exports `SST_LOG` and `SST_CHILD` per process.

4. Monoplexer / single-pane mode
   • Mirrors the behaviour so mono users get the same files.

Result
------

Example layout:

```
my-app/.sst/log/
  sst-deploy.log
  vite-dev.log
  npm-run-dev.log
  lambda-functions.log
```

Each file contains the full colourised output exactly as seen in its pane; consumers can tail, parse, or ship these logs anywhere.

Compatibility
-------------

* No breaking changes – if a tool ignores `.sst/log/*` nothing changes.
* The `logWriter` is nil by default; memory footprint is unchanged when persistence is not enabled.
* Tested on macOS with existing unit-test suite (`go test ./...`) and running the patched `sst dev` against a React Router app to confirm that `npm-run-dev.log` is created.

Fixes #5885 