### PR TITLE
docs: fix StaticSite's default value for `assets.fileOptions`

### DIFF
--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -264,7 +264,7 @@ export interface StaticSiteArgs extends BaseStaticSiteArgs {
    *     textEncoding: "utf-8",
    *     fileOptions: [
    *       {
-   *         files: ["**\/*.css", "**\/*.js"],
+   *         files: "**",
    *         cacheControl: "max-age=31536000,public,immutable"
    *       },
    *       {


### PR DESCRIPTION
The default value for `assets.fileOptions` was changed in f26a3f9. This PR reflects these changes in the docs. 