### PR TITLE
force warmer to use x86 architecture

### DIFF
--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -1182,6 +1182,7 @@ async function handler(event) {
                   runtime: "nodejs20.x",
                   handler: "index.handler",
                   timeout: "900 seconds",
+                  architecture: "x86_64",
                   memory: "128 MB",
                   dev: false,
                   environment: {


### PR DESCRIPTION
I tried migrating to arm64 and kept getting this error:
```
{"errorType":"Extension.Crash","errorMessage":"RequestId: 6cb5331a-0fc1-4db8-9b44-ea081be458ea Error: exit status 126"}: provider=aws@6.66.2
```

Once I forced the ssr-site warmer to `x86_64`, everything worked