### PR TITLE
Fix tasks not receiving host OS env vars on `sst dev`

### DIFF
--- a/cmd/sst/mosaic/aws/task.go
+++ b/cmd/sst/mosaic/aws/task.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -135,7 +134,7 @@ func task(ctx context.Context, input input) {
 				}
 				cmd := process.Command(fields[0], fields[1:]...)
 				cmd.Dir = task.Directory
-				cmd.Env = mergeEnvironment(body.Environment)
+				cmd.Env = append(os.Environ(), body.Environment...)
 				stdout, _ := cmd.StdoutPipe()
 				stderr, _ := cmd.StderrPipe()
 				go func() {
@@ -204,45 +203,4 @@ func task(ctx context.Context, input input) {
 			break
 		}
 	}
-}
-
-// mergeEnvironment merges task-specific environment variables with the current system environment.
-// System variables like PATH, HOME, and USER are preserved and not overridden by task variables.
-func mergeEnvironment(taskEnv []string) []string {
-	// Critical system variables that should not be overridden
-	protectedVars := map[string]bool{
-		"PATH": true,
-		"HOME": true,
-		"USER": true,
-	}
-
-	// Start with the current system environment
-	systemEnv := os.Environ()
-
-	// Build a map of existing environment variables
-	envMap := make(map[string]string)
-	for _, e := range systemEnv {
-		if idx := strings.Index(e, "="); idx > 0 {
-			key := e[:idx]
-			envMap[key] = e
-		}
-	}
-
-	// Add task-specific environment variables
-	for _, e := range taskEnv {
-		if idx := strings.Index(e, "="); idx > 0 {
-			key := e[:idx]
-			// Only add if it's not a protected variable or doesn't exist yet
-			if !protectedVars[key] && envMap[key] == "" {
-				envMap[key] = e
-			}
-		}
-	}
-
-	// Convert map back to slice
-	result := make([]string, 0, len(envMap))
-	for _, v := range envMap {
-		result = append(result, v)
-	}
-	return result
 }

--- a/cmd/sst/mosaic/aws/task.go
+++ b/cmd/sst/mosaic/aws/task.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -133,7 +135,7 @@ func task(ctx context.Context, input input) {
 				}
 				cmd := process.Command(fields[0], fields[1:]...)
 				cmd.Dir = task.Directory
-				cmd.Env = body.Environment
+				cmd.Env = mergeEnvironment(body.Environment)
 				stdout, _ := cmd.StdoutPipe()
 				stderr, _ := cmd.StderrPipe()
 				go func() {
@@ -202,4 +204,45 @@ func task(ctx context.Context, input input) {
 			break
 		}
 	}
+}
+
+// mergeEnvironment merges task-specific environment variables with the current system environment.
+// System variables like PATH, HOME, and USER are preserved and not overridden by task variables.
+func mergeEnvironment(taskEnv []string) []string {
+	// Critical system variables that should not be overridden
+	protectedVars := map[string]bool{
+		"PATH": true,
+		"HOME": true,
+		"USER": true,
+	}
+
+	// Start with the current system environment
+	systemEnv := os.Environ()
+
+	// Build a map of existing environment variables
+	envMap := make(map[string]string)
+	for _, e := range systemEnv {
+		if idx := strings.Index(e, "="); idx > 0 {
+			key := e[:idx]
+			envMap[key] = e
+		}
+	}
+
+	// Add task-specific environment variables
+	for _, e := range taskEnv {
+		if idx := strings.Index(e, "="); idx > 0 {
+			key := e[:idx]
+			// Only add if it's not a protected variable or doesn't exist yet
+			if !protectedVars[key] && envMap[key] == "" {
+				envMap[key] = e
+			}
+		}
+	}
+
+	// Convert map back to slice
+	result := make([]string, 0, len(envMap))
+	for _, v := range envMap {
+		result = append(result, v)
+	}
+	return result
 }

--- a/platform/src/components/aws/task.ts
+++ b/platform/src/components/aws/task.ts
@@ -326,9 +326,7 @@ export class Task extends Component implements Link.Linkable {
             return [
               {
                 ...v[0],
-                image: output(
-                  "ghcr.io/anomalyco/sst/bridge-task:20241224005724",
-                ),
+                image: output("ghcr.io/anomalyco/sst/bridge-task:latest"),
                 environment: {
                   ...v[0].environment,
                   SST_TASK_ID: name,


### PR DESCRIPTION
## Problem

Task dev mode fails with errors like `node: not found` because the system PATH is not available to the spawned process.

## Fix

- Simplify environment merging in task.go to follow the standard codebase pattern
- Use `latest` bridge-task image which blacklists PATH from being forwarded from the ECS container

🤖 Collaboration with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>