### PR TITLE
fix: incorrect VPC usage examples

### DIFF
--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -235,9 +235,7 @@ export interface ApiGatewayV2Args {
    * Or reference an existing VPC.
    *
    * ```js title="sst.config.ts"
-   * const myVpc = sst.aws.Vpc.get("MyVpc", {
-   *   id: "vpc-12345678901234567"
-   * });
+   * const myVpc = sst.aws.Vpc.get("MyVpc", "vpc-12345678901234567");
    * ```
    *
    * And pass it in. The VPC link will be placed in the public subnets.

--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -63,9 +63,7 @@ export interface ClusterArgs {
    * Or reference an existing VPC.
    *
    * ```js title="sst.config.ts"
-   * const myVpc = sst.aws.Vpc.get("MyVpc", {
-   *   id: "vpc-12345678901234567"
-   * });
+   * const myVpc = sst.aws.Vpc.get("MyVpc", "vpc-12345678901234567");
    * ```
    *
    * And pass it in.

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1353,9 +1353,7 @@ export interface FunctionArgs {
    * Or reference an existing VPC.
    *
    * ```js title="sst.config.ts"
-   * const myVpc = sst.aws.Vpc.get("MyVpc", {
-   *   id: "vpc-12345678901234567"
-   * });
+   * const myVpc = sst.aws.Vpc.get("MyVpc", "vpc-12345678901234567");
    * ```
    *
    * And pass it in.

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -497,9 +497,7 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
    * Or reference an existing VPC.
    *
    * ```js title="sst.config.ts"
-   * const myVpc = sst.aws.Vpc.get("MyVpc", {
-   *   id: "vpc-12345678901234567"
-   * });
+   * const myVpc = sst.aws.Vpc.get("MyVpc", "vpc-12345678901234567");
    * ```
    *
    * And pass it in.


### PR DESCRIPTION
This PR updates the VPC example usage in the documentation to reflect the correct and supported usage of `sst.aws.Vpc.get()`.