### PR TITLE
fix: support S3 to SQS notifications with KMS-encrypted queues by updating queue policy

### DIFF
--- a/platform/src/components/aws/bucket-notification.ts
+++ b/platform/src/components/aws/bucket-notification.ts
@@ -159,7 +159,7 @@ export class BucketNotification extends Component {
             const policy = Queue.createPolicy(
               `${name}Notification${n.name}Policy`,
               arn,
-              { parent: self },
+              { parent: self, sourceArns: [bucket.arn] },
             );
             return { args: n, queueArn: arn, dependsOn: policy };
           }

--- a/platform/src/components/aws/queue.ts
+++ b/platform/src/components/aws/queue.ts
@@ -13,7 +13,7 @@ import { VisibleError } from "../error";
 import { hashStringToPrettyString, logicalName } from "../naming";
 import { parseQueueArn } from "./helpers/arn";
 import { QueueLambdaSubscriber } from "./queue-lambda-subscriber";
-import { iam, lambda, sqs } from "@pulumi/aws";
+import { iam, lambda, sqs, getCallerIdentity } from "@pulumi/aws";
 import { DurationHours, DurationMinutes, toSeconds } from "../duration";
 import { permission } from "./permission.js";
 
@@ -670,8 +670,10 @@ export class Queue extends Component implements Link.Linkable {
   static createPolicy(
     name: string,
     arn: Output<string>,
-    opts?: ComponentResourceOptions,
+    opts?: ComponentResourceOptions & { sourceArns?: Output<string>[]},
   ) {
+    const accountId = getCallerIdentity().then(identity => identity.accountId);
+
     return new sqs.QueuePolicy(
       name,
       {
@@ -691,6 +693,18 @@ export class Queue extends Component implements Link.Linkable {
                   ],
                 },
               ],
+              conditions:  opts?.sourceArns && [
+                {
+                  test: "StringEquals",
+                  variable: "aws:SourceAccount",
+                  values: [accountId],
+                },
+                {
+                  test: "ArnEquals",
+                  variable: "aws:SourceArn",
+                  values: opts!.sourceArns,
+                },
+              ]                
             },
           ],
         }).json,


### PR DESCRIPTION
## Problem

When using `bucket.notify(...)` to create an S3 → SQS notification, SST automatically sets a queue policy allowing s3.amazonaws.com to send messages. However, this deployment silently fails if the SQS queue is encrypted with an AWS-managed KMS key (e.g., `alias/aws/sqs`).

S3 requires the SQS queue policy to include specific conditions to validate the destination when encryption is enabled. Without these conditions, the `PutBucketNotificationConfiguration` API returns:

```sh
InvalidArgument: Unable to validate the following destination configurations
```

## Why this happens only with KMS?

When a queue uses an AWS-managed key, S3 must call `kms:GenerateDataKey` on the queue’s KMS key. AWS only allows this if the queue policy includes:

```json
"Condition": {
  "ArnEquals": {
    "aws:SourceArn": "<bucket-arn>"
  }
}
```

Notice that in the approach I'm also restricting to the current aws account. This is a good security measure considering that the bucket arns are global

## The Fix

This PR updates bucket.notify(...) to automatically add the required `aws:SourceArn` condition to the SQS queue policy.

Adding these conditions unconditionally is safe because:
	•	They only restrict permissions for `s3.amazonaws.com`, which is a best practice for security.
	•	They do not interfere with other services like SNS or EventBridge.
	•	S3 requires these conditions for validating notifications but does not fail if they are present when not strictly needed.