### PR TITLE
Fix `nodejs.install` `package.json` lookup

### DIFF
--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -246,7 +246,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 
 		if len(installPackages) > 0 {
 			log.Info("installing", "packages", installPackages)
-			src, err := fs.FindUp(filepath.Dir(target), "package.json")
+			src, err := fs.FindUp(filepath.Dir(file), "package.json")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Use the handler's directory as the starting point so we pick up the correct package.json for workspaces, monorepos or nested packages (eg. "apps/function").
Fixes #5987 