### PR TITLE
Replace latest tag with component name in python docker Image

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2183,7 +2183,7 @@ export class Function extends Component implements Link.Linkable {
           return new Image(
             `${name}Image`,
             {
-              tags: [$interpolate`${bootstrapData.assetEcrUrl}:latest`],
+              tags: [$interpolate`${bootstrapData.assetEcrUrl}:${name}`],
               context: {
                 location: path.join(
                   $cli.paths.work,
@@ -2443,7 +2443,7 @@ export class Function extends Component implements Link.Linkable {
                 ? {
                   packageType: "Image",
                   imageUri: imageAsset!.ref.apply(
-                    (ref) => ref?.replace(":latest", ""),
+                    (ref) => ref?.replace(`:${args.name}`, ""),
                   ),
                   imageConfig: {
                     commands: [


### PR DESCRIPTION
All newly pushed Python Docker images to ECR currently use the `latest` tag. This causes issues because it makes it harder to identify images in ECR and to implement simple lifecycle policies, such as keeping only the most recent image for each type. As a result, images accumulate over time, leading to non-negligible storage costs.

For the Service and Task components, the default tag is the component name and can be customized. Ideally, we should handle Python Docker images similarly. But as a quick fix, I propose changing the tag of newly pushed Python Docker images to use the component name instead of `latest`.