### PR TITLE
Fix #6011: Inconsistent behavior of dev processes in `sst dev`

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -247,12 +247,44 @@ func CmdMosaic(c *cli.Cli) error {
 		defer func() {
 			multi.Exit()
 		}()
+
+		processCompleteEventForMultiplexer := func(evt *project.CompleteEvent, addProcess func(key string, args []string, icon string, title string, cwd string, killable bool, autostart bool, env ...string)) {
+			for _, d := range evt.Devs {
+				if d.Command == "" {
+					continue
+				}
+				dir := filepath.Join(cwd, d.Directory)
+				title := d.Title
+				if title == "" {
+					title = d.Name
+				}
+				addProcess(d.Name, append([]string{currentExecutable, "dev"}), "→", title, dir, true, d.Autostart, append([]string{"SST_CHILD=" + d.Name}, multiEnv...)...)
+			}
+
+			for name := range evt.Tunnels {
+				addProcess("tunnel", []string{currentExecutable, "tunnel", "--stage", p.App().Stage}, "⇌", "Tunnel", "", true, true, append(
+					multiEnv,
+					"SST_LOG="+p.PathLog("tunnel_"+name),
+				)...)
+			}
+
+			if len(evt.Tasks) > 0 {
+				addProcess("task", []string{currentExecutable, "ui", "--filter=task"}, "⧉", "Tasks", "", false, true, append(multiEnv, "SST_LOG="+p.PathLog("ui-task"))...)
+			}
+		}
+
 		go func() {
 			multi.Start()
 		}()
 		wg.Go(func() error {
-			evts := bus.Subscribe(&project.CompleteEvent{})
 			defer c.Cancel()
+
+			completed, err := p.GetCompleted(c.Context)
+			if err == nil && completed != nil && len(completed.Devs) > 0 {
+				processCompleteEventForMultiplexer(completed, multi.InitProcess)
+			}
+
+			evts := bus.Subscribe(&project.CompleteEvent{})
 			for {
 				select {
 				case <-c.Context.Done():
@@ -260,36 +292,7 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
-						for _, d := range evt.Devs {
-							if d.Command == "" {
-								continue
-							}
-							dir := filepath.Join(cwd, d.Directory)
-							title := d.Title
-							if title == "" {
-								title = d.Name
-							}
-							multi.AddProcess(
-								d.Name,
-								append([]string{currentExecutable, "dev"}),
-								"→",
-								title,
-								dir,
-								true,
-								d.Autostart,
-								append([]string{"SST_CHILD=" + d.Name}, multiEnv...)...,
-							)
-						}
-						for name := range evt.Tunnels {
-							multi.AddProcess("tunnel", []string{currentExecutable, "tunnel", "--stage", p.App().Stage}, "⇌", "Tunnel", "", true, true, append(
-								multiEnv,
-								"SST_LOG="+p.PathLog("tunnel_"+name),
-							)...)
-						}
-						if len(evt.Tasks) > 0 {
-							multi.AddProcess("task", []string{currentExecutable, "ui", "--filter=task"}, "⧉", "Tasks", "", false, true, append(multiEnv, "SST_LOG="+p.PathLog("ui-task"))...)
-						}
-						break
+						processCompleteEventForMultiplexer(evt, multi.AddProcess)
 					}
 				}
 			}
@@ -312,9 +315,39 @@ func CmdMosaic(c *cli.Cli) error {
 			return mono.Start(c.Context)
 		})
 
+		// Common function to process dev commands for monoplexer (simpler, no autostart/icons)
+		processCompleteEventForMonoplexer := func(evt *project.CompleteEvent) {
+			for _, d := range evt.Devs {
+				if d.Command == "" {
+					continue
+				}
+				dir := filepath.Join(cwd, d.Directory)
+				words, _ := shellquote.Split(d.Command)
+				title := d.Title
+				if title == "" {
+					title = d.Name
+				}
+				mono.AddProcess(
+					d.Name,
+					append([]string{currentExecutable, "dev", "--"}, words...),
+					dir,
+					title,
+				)
+			}
+			for range evt.Tunnels {
+				mono.AddProcess("tunnel", []string{currentExecutable, "tunnel", "--stage", p.App().Stage}, "", "Tunnel")
+			}
+		}
+
 		wg.Go(func() error {
-			evts := bus.Subscribe(&project.CompleteEvent{})
 			defer c.Cancel()
+
+			completed, err := p.GetCompleted(c.Context)
+			if err == nil && completed != nil && len(completed.Devs) > 0 {
+				processCompleteEventForMonoplexer(completed)
+			}
+
+			evts := bus.Subscribe(&project.CompleteEvent{})
 			for {
 				select {
 				case <-c.Context.Done():
@@ -322,26 +355,7 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
-						for _, d := range evt.Devs {
-							if d.Command == "" {
-								continue
-							}
-							dir := filepath.Join(cwd, d.Directory)
-							words, _ := shellquote.Split(d.Command)
-							title := d.Title
-							if title == "" {
-								title = d.Name
-							}
-							mono.AddProcess(
-								d.Name,
-								append([]string{currentExecutable, "dev", "--"}, words...),
-								dir,
-								title,
-							)
-						}
-						for range evt.Tunnels {
-							mono.AddProcess("tunnel", []string{currentExecutable, "tunnel", "--stage", p.App().Stage}, "", "Tunnel")
-						}
+						processCompleteEventForMonoplexer(evt)
 						break
 					}
 				}

--- a/cmd/sst/mosaic/multiplexer/multiplexer.go
+++ b/cmd/sst/mosaic/multiplexer/multiplexer.go
@@ -103,41 +103,7 @@ func (s *Multiplexer) Start() {
 				return
 
 			case *EventProcess:
-				for _, p := range s.processes {
-					if p.key == evt.Key {
-						if p.dead && evt.Autostart {
-							p.start()
-							s.sort()
-							s.draw()
-						}
-						return
-					}
-				}
-				proc := &pane{
-					icon:     evt.Icon,
-					key:      evt.Key,
-					dir:      evt.Cwd,
-					title:    evt.Title,
-					args:     evt.Args,
-					killable: evt.Killable,
-					env:      evt.Env,
-				}
-				term := tcellterm.New()
-				term.SetSurface(s.main)
-				term.Attach(func(ev tcell.Event) {
-					s.screen.PostEvent(ev)
-				})
-				proc.vt = term
-				if evt.Autostart {
-					proc.start()
-				}
-				if !evt.Autostart {
-					proc.vt.Start(process.Command("echo", evt.Key+" has auto-start disabled, press enter to start."))
-					proc.dead = true
-				}
-				s.processes = append(s.processes, proc)
-				s.sort()
-				s.draw()
+				s.InitProcess(evt.Key, evt.Args, evt.Icon, evt.Title, evt.Cwd, evt.Killable, evt.Autostart, evt.Env...)
 				break
 
 			case *tcell.EventMouse:
@@ -380,4 +346,44 @@ func (s *Multiplexer) copy() {
 	}
 	encoded := base64.StdEncoding.EncodeToString([]byte(data))
 	fmt.Fprintf(os.Stdout, "\x1b]52;c;%s\x07", encoded)
+}
+
+func (s *Multiplexer) InitProcess(key string, args []string, icon string, title string, cwd string, killable bool, autostart bool, env ...string) {
+	for _, p := range s.processes {
+		if p.key == key {
+			if p.dead && autostart {
+				p.start()
+				s.sort()
+				s.draw()
+			}
+			return
+		}
+	}
+
+	proc := &pane{
+		icon:     icon,
+		key:      key,
+		dir:      cwd,
+		title:    title,
+		args:     args,
+		killable: killable,
+		env:      env,
+	}
+	term := tcellterm.New()
+	term.SetSurface(s.main)
+	term.Attach(func(ev tcell.Event) {
+		s.screen.PostEvent(ev)
+	})
+	proc.vt = term
+
+	if autostart {
+		proc.start()
+	} else {
+		proc.vt.Start(process.Command("echo", key+" has auto-start disabled, press enter to start."))
+		proc.dead = true
+	}
+
+	s.processes = append(s.processes, proc)
+	s.sort()
+	s.draw()
 }


### PR DESCRIPTION
A possible fix for the behavior laid out in #6011 

## Description  
Fixes startup inconsistency in the dev command by ensuring that already completed events are processed immediately when starting sst, rather than waiting for new events to arrive.

## Changes:  
- **Refactored event processing logic**: Extracted common event processing functions (`processCompleteEventForMultiplexer` and `processCompleteEventForMonoplexer`) to eliminate code duplication between events processed before server start and after
- **Added immediate startup processing**: Both multiplexer and monoplexer now check for and process any already completed events (`p.GetCompleted()`) before subscribing to new events
- **Added InitProcess**: Moved process initialization logic from the event handler into a dedicated `InitProcess` method for better separation of concerns

## Considerations:  
- I'll attach some additional videos to this when I get a chance to compare current behavior and behavior with these fixes. As mentioned in the issue - not 100% certain this is THE fix - but it certainly solves most of what we're seeing today. I am not convinced this provides the correct experience on the first `sst dev` run for a stage. 