### PR TITLE
Replace EventBus with Bus

### DIFF
--- a/www/src/content/docs/docs/migrate-from-v2.mdx
+++ b/www/src/content/docs/docs/migrate-from-v2.mdx
@@ -1137,7 +1137,7 @@ In your function you'd access this using.
 <Tabs>
   <TabItem label="v3">
   ```ts title="sst.config.ts"
-  const bus = new sst.aws.EventBus("Bus");
+  const bus = new sst.aws.Bus("Bus");
 
   bus.subscribe("MySubscriber1", "src/function1.handler", {
     pattern: {


### PR DESCRIPTION
In the migrate from v2 guide it specifies to use the EventBus construct but it actually should be Bus instead