### PR TITLE
Fix Cloudflare DNS TypeScript error

### DIFF
--- a/platform/src/components/cloudflare/dns.ts
+++ b/platform/src/components/cloudflare/dns.ts
@@ -110,7 +110,7 @@ export function dns(args: DnsArgs = {}) {
         zoneId: args.zone,
       });
       return {
-        id: zone.zoneId,
+        id: args.zone,
         name: zone.name,
       };
     }

--- a/platform/src/components/cloudflare/dns.ts
+++ b/platform/src/components/cloudflare/dns.ts
@@ -110,7 +110,7 @@ export function dns(args: DnsArgs = {}) {
         zoneId: args.zone,
       });
       return {
-        id: args.zone,
+        id: output(args.zone),
         name: zone.name,
       };
     }


### PR DESCRIPTION
my latest merged PR #6032 gave a TS error after merging

the Cloudflare Pulumi SDK seems to be typed incorrectly when compared with their docs

this time i double checked by running `tsc` locally