### PR TITLE
feat: add name property to cloudflare bucket

### DIFF
--- a/platform/src/components/cloudflare/bucket.ts
+++ b/platform/src/components/cloudflare/bucket.ts
@@ -96,7 +96,9 @@ export class Bucket extends Component implements Link.Linkable {
    */
   getSSTLink() {
     return {
-      properties: {},
+      properties: {
+        name: this.bucket.name,
+      },
       include: [
         binding({
           type: "r2BucketBindings",


### PR DESCRIPTION
This adds the bucket name to the Cloudflare bucket component to mirror the AWS bucket component. Bucket name is necessary for usage with s3 client.

AWS bucket component has a name property:
https://github.com/sst/sst/blob/abc254382ee01d87cb8b3c859e1dc90de7f8adc5/platform/src/components/aws/bucket.ts#L1647-L1651