### PR TITLE
Allow Lambda Function URL on a Router to restrict down to Cloudfront

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2527,6 +2527,7 @@ export class Function extends Component implements Link.Linkable {
             entries: fnUrl.functionUrl.apply((fnUrl) => ({
               metadata: JSON.stringify({
                 host: new URL(fnUrl).host,
+                oac: "lambda",
               }),
             })),
             purge: false,

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -878,16 +878,8 @@ export interface FunctionArgs {
        *   }
        * }
        * ```
-       * Only allow CloudFront to access the function URL.
-       * ```js
-       * {
-       *   url: {
-       *     authorization: "cloudfront"
-       *   }
-       * }
-       * ```
        */
-      authorization?: Input<"none" | "iam" | "cloudfront">;
+      authorization?: Input<"none" | "iam">;
       /**
        * Customize the CORS (Cross-origin resource sharing) settings for the function URL.
        * @default `true`
@@ -2511,7 +2503,7 @@ export class Function extends Component implements Link.Linkable {
           `${name}Url`,
           {
             functionName: fn.name,
-            authorizationType: url.authorization === "iam" || url.authorization === "cloudfront" ? "AWS_IAM" : "NONE",
+            authorizationType: url.authorization === "iam" ? "AWS_IAM" : "NONE",
             invokeMode: streaming.apply((streaming) =>
               streaming ? "RESPONSE_STREAM" : "BUFFERED",
             ),
@@ -2535,7 +2527,7 @@ export class Function extends Component implements Link.Linkable {
             entries: fnUrl.functionUrl.apply((fnUrl) => ({
               metadata: JSON.stringify({
                 host: new URL(fnUrl).host,
-                oac: url.authorization === "cloudfront" ? "lambda" : undefined,
+                type: "lambda",
               }),
             })),
             purge: false,

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -878,8 +878,16 @@ export interface FunctionArgs {
        *   }
        * }
        * ```
+       * Only allow CloudFront to access the function URL.
+       * ```js
+       * {
+       *   url: {
+       *     authorization: "cloudfront"
+       *   }
+       * }
+       * ```
        */
-      authorization?: Input<"none" | "iam">;
+      authorization?: Input<"none" | "iam" | "cloudfront">;
       /**
        * Customize the CORS (Cross-origin resource sharing) settings for the function URL.
        * @default `true`
@@ -2503,7 +2511,7 @@ export class Function extends Component implements Link.Linkable {
           `${name}Url`,
           {
             functionName: fn.name,
-            authorizationType: url.authorization === "iam" ? "AWS_IAM" : "NONE",
+            authorizationType: url.authorization === "iam" || url.authorization === "cloudfront" ? "AWS_IAM" : "NONE",
             invokeMode: streaming.apply((streaming) =>
               streaming ? "RESPONSE_STREAM" : "BUFFERED",
             ),
@@ -2527,7 +2535,7 @@ export class Function extends Component implements Link.Linkable {
             entries: fnUrl.functionUrl.apply((fnUrl) => ({
               metadata: JSON.stringify({
                 host: new URL(fnUrl).host,
-                oac: "lambda",
+                oac: url.authorization === "cloudfront" ? "lambda" : undefined,
               }),
             })),
             purge: false,

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2149,6 +2149,14 @@ function setUrlOrigin(urlHost, override) {
   if (override.timeouts) {
     origin.timeouts = override.timeouts;
   }
+  if (override.oac) {
+    origin.originAccessControlConfig = {
+      enabled: true,
+      signingBehavior: "always",
+      signingProtocol: "sigv4",
+      originType: override.oac,
+    }
+  }
   cf.updateRequestOrigin(origin);
 }
 

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2135,7 +2135,12 @@ function setUrlOrigin(urlHost, override) {
       protocol: "https",
       sslProtocols: ["TLSv1.2"],
     },
-    originAccessControlConfig: {
+    originAccessControlConfig: override.type === "lambda" ? {
+      enabled: true,
+      signingBehavior: "no-override",
+      signingProtocol: "sigv4",
+      originType: "lambda",
+    } : {
       enabled: false,
     }
   };
@@ -2148,14 +2153,6 @@ function setUrlOrigin(urlHost, override) {
   }
   if (override.timeouts) {
     origin.timeouts = override.timeouts;
-  }
-  if (override.oac) {
-    origin.originAccessControlConfig = {
-      enabled: true,
-      signingBehavior: "always",
-      signingProtocol: "sigv4",
-      originType: override.oac,
-    }
   }
   cf.updateRequestOrigin(origin);
 }


### PR DESCRIPTION
### Problem

At the moment we have two choices:

1. A public function url
2. A private function url but requiring real AWS credentials

We can't restrict down to Cloudfront which means I can't have a URL behind a WAF.

### Solution

Add metadata on the router that exposes the type of URL for the Cloudfront function. We can then enable the no override option on the origin access control configuration.

1. If type is AWS_IAM, we restrict down to Cloudfront
2. If type is AWS_IAM and a permission is set by a user, nothing changes?
3. If type is NONE, OAC still triggers but it's not relevant :)

