### PR TITLE
feat: Add configurable ignore patterns for file watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ Learn more about some of the key concepts:
 - [Console](https://sst.dev/docs/console)
 - [Components](https://sst.dev/docs/components)
 
+## Configuration
+
+Your SST app is configured through the `sst.config.ts` file. You can specify app settings like ignore patterns for the file watcher:
+
+```typescript
+export default $config({
+  app(input) {
+    return {
+      name: "my-app",
+      home: "aws",
+      ignore: [".egg-info", "functions-"] // Ignore Python build artifacts
+    };
+  }
+});
+```
+
+See the [configuration reference](https://sst.dev/docs/reference/config) for all available options.
+
 ## Contributing
 
 Here's how you can contribute:

--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -158,7 +158,7 @@ func CmdMosaic(c *cli.Cli) error {
 
 	wg.Go(func() error {
 		defer c.Cancel()
-		return watcher.Start(c.Context, p.PathRoot())
+		return watcher.Start(c.Context, p.PathRoot(), p.App().Ignore)
 	})
 
 	server, err := server.New()

--- a/cmd/sst/mosaic/aws/function.go
+++ b/cmd/sst/mosaic/aws/function.go
@@ -258,6 +258,7 @@ func function(ctx context.Context, input input) {
 		return true
 	}
 
+skipIgnoredFiles:
 	for {
 		select {
 		case <-ctx.Done():
@@ -368,6 +369,18 @@ func function(ctx context.Context, input input) {
 			case *runtime.BuildInput:
 				targets[evt.FunctionID] = evt
 			case *watcher.FileChangedEvent:
+				// Check if file should be ignored based on ignore patterns
+				shouldIgnore := false
+				for _, pattern := range input.project.App().Ignore {
+					if strings.Contains(evt.Path, pattern) {
+						shouldIgnore = true
+						break
+					}
+				}
+				if shouldIgnore {
+					continue skipIgnoredFiles
+				}
+				
 				log.Info("checking if code needs to be rebuilt", "file", evt.Path)
 				toBuild := map[string]bool{}
 

--- a/cmd/sst/mosaic/watcher/watcher.go
+++ b/cmd/sst/mosaic/watcher/watcher.go
@@ -16,7 +16,7 @@ type FileChangedEvent struct {
 	Path string
 }
 
-func Start(ctx context.Context, root string) error {
+func Start(ctx context.Context, root string, ignorePatterns []string) error {
 	log := slog.Default().With("service", "watcher")
 	defer log.Info("done")
 	log.Info("starting watcher", "root", root)
@@ -28,7 +28,7 @@ func Start(ctx context.Context, root string) error {
 	if err != nil {
 		return err
 	}
-	ignoreSubstrings := []string{"node_modules"}
+	ignoreSubstrings := append([]string{"node_modules"}, ignorePatterns...)
 
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -35,6 +35,7 @@ type App struct {
 	Home      string                 `json:"home"`
 	Version   string                 `json:"version"`
 	Protect   bool                   `json:"protect"`
+	Ignore    []string               `json:"ignore"`
 	// Deprecated: Backend is now Home
 	Backend string `json:"backend"`
 	// Deprecated: RemovalPolicy is now Removal
@@ -202,6 +203,10 @@ console.log("~j" + JSON.stringify(await mod.app({
 
 			if proj.app.Providers == nil {
 				proj.app.Providers = map[string]interface{}{}
+			}
+
+			if proj.app.Ignore == nil {
+				proj.app.Ignore = []string{}
 			}
 
 			for name, args := range proj.app.Providers {

--- a/www/src/content/docs/docs/workflow.mdx
+++ b/www/src/content/docs/docs/workflow.mdx
@@ -276,6 +276,33 @@ Similar to the app and stage, if you want to switch regions; you'll need to remo
 
 ---
 
+### Ignore patterns
+
+By default, SST's file watcher ignores `node_modules` directories to prevent unnecessary rebuilds. However, when working with Python, Go, or other build systems, additional build artifacts can trigger infinite rebuild loops during `sst dev`.
+
+You can configure additional ignore patterns in your app configuration:
+
+```ts title="sst.config.ts" {6}
+export default $config({
+  app(input) {
+    return {
+      name: "my-sst-app",
+      home: "aws",
+      ignore: [".egg-info", "functions-"]
+    };
+  }
+});
+```
+
+**Common ignore patterns:**
+
+- **Python**: `[".egg-info", "functions-"]`
+- **Build artifacts**: `["dist/", "build/", ".tmp/"]`
+
+Pattern matching uses substring matching, so `".egg-info"` will ignore any path containing `.egg-info`, and `"functions-"` will ignore build artifacts like `functions-0.1.0.tar.gz`.
+
+---
+
 ## Commands
 
 Now with the above background let's look at the workflow of building an SST app.


### PR DESCRIPTION
This PR adds support for configurable ignore patterns in the SST file watcher to prevent infinite rebuild loops caused by build artifacts.

When using SST with Python projects (or other build systems), package builds create artifacts like `.egg-info` directories and `functions-*.tar.gz` files that trigger SST's file watcher, causing infinite rebuild loops during `sst dev`. Makes local dev not work.

So, this:
  - Added `ignore` field to the App struct in `pkg/project/project.go`
  - Modified file watcher in `cmd/sst/mosaic/watcher/watcher.go` to accept custom ignore patterns
  - Updated `cmd/sst/mosaic.go` to pass ignore patterns from project config
  - Added ignore filtering in AWS function service to prevent rebuilds on ignored files
  - Uses substring matching for pattern detection (e.g., `".egg-info"` matches any path containing `.egg-info`)

  Configure ignore patterns in your `sst.config.ts`:

  ```typescript
  export default $config({
    app(input) {
      return {
        name: "my-app",
        home: "aws",
        ignore: [".egg-info", "functions-"] // Ignore Python build artifacts
      };
    }
  });

I tested:

  - Verified no crash loops with Python build artifacts
  - Confirmed successful deployment and working Lambda endpoints
  - Tested that ignored files don't trigger rebuilds during sst dev