### PR TITLE
Improve renaming command

### DIFF
--- a/www/src/content/docs/docs/set-up-a-monorepo.mdx
+++ b/www/src/content/docs/docs/set-up-a-monorepo.mdx
@@ -26,7 +26,7 @@ To use this template.
 4. From the project root, run the following to rename it to your app.
 
    ```bash
-   npx replace-in-file /monorepo-template/g MY_APP **/*.* --verbose
+   npx replace-in-file "monorepo-template" "MY_APP" "./**/*" --verbose
    ```
 
 5. Install the dependencies.

--- a/www/src/content/docs/docs/set-up-a-monorepo.mdx
+++ b/www/src/content/docs/docs/set-up-a-monorepo.mdx
@@ -26,7 +26,7 @@ To use this template.
 4. From the project root, run the following to rename it to your app.
 
    ```bash
-   npx replace-in-file "monorepo-template" "MY_APP" "./**/*" --verbose
+   npx replace-in-file "/monorepo-template/g" "MY_APP" "./**/*" --verbose
    ```
 
 5. Install the dependencies.


### PR DESCRIPTION
`npx replace-in-file /monorepo-template/g MY_APP **/*.* --verbose` will not work in `zsh` or `fish`, `npx replace-in-file "monorepo-template" "MY_APP" "./**/*" --verbose` will work everywhere