### PR TITLE
fix .env.stage should override values in .env

### DIFF
--- a/cmd/sst/cli/cli.go
+++ b/cmd/sst/cli/cli.go
@@ -335,7 +335,7 @@ func (c *Cli) Stage(cfgPath string) (string, error) {
 			}
 		}
 	}
-	godotenv.Load(filepath.Join(filepath.Dir(cfgPath), ".env."+stage))
+	godotenv.Overload(filepath.Join(filepath.Dir(cfgPath), ".env."+stage))
 	return stage, nil
 }
 


### PR DESCRIPTION
Hi

when using .env files if you have a .env.stage file, its values should override the ones set in .env, since this is what you are used to from npm dotenv package defaults.

According to the godotenv docs we need to use .Overload instead of .Load because it will not overwrite existing values

https://github.com/lpernett/godotenv/blob/main/godotenv.go#L65

** NOTE **
I have not been able to test this, so please do before merging.