### PR TITLE
Fix `nodejs.splitting` enabled breaking the lambda handler

### DIFF
--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -159,6 +159,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 			".js": ".mjs",
 		}
 		options.Outfile = ""
+		options.EntryNames = "bundle"
 	}
 
 	if !input.Dev {


### PR DESCRIPTION
I hit this exact issue: https://github.com/sst/sst/issues/5346

After bundling with `splitting: true` the output folder no longer contains a `bundle.mjs`. Instead it contains `basename(functionOptions.handler).mjs`

The lambda build output after enabling `splitting: true`

```
$ ls ./.sst/artifacts/MyFunctionFn-src/ | grep my-function.mjs
my-function.mjs
my-function.mjs.map
```

I can check that the lambda is configured to load `bundle` by creating a 'bootstrap.mjs' file and adding it to my lambda bundle.
I can run the bootstrap by setting `NODE_OPTIONS=--import=./bootstrap.mjs`
```ts
console.log('DEBUG: handler', {
  // https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
  // _HANDLER – The handler location configured on the function.
  _HANDLER: process.env._HANDLER,
});
```

The output:
```
DEBUG: handler {
_HANDLER: 'bundle.handler',
}
```
This means the lambda is configured by sst to load `bundle.handler` regardless if splitting is enabled or not


After my bootstrap finishes, it tries to load the non-existent `bundle.mjs` file and errors out with
```
undefined	ERROR	Uncaught Exception 	
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module 'bundle'\nRequire stack:\n- /var/runtime/index.mjs",
    "stack": [
        "Runtime.ImportModuleError: Error: Cannot find module 'bundle'",
        "Require stack:",
        "- /var/runtime/index.mjs",
        "    at _loadUserApp (file:///var/runtime/index.mjs:1109:17)",
        "    at async UserFunction.js.module.exports.load (file:///var/runtime/index.mjs:1148:21)",
        "    at async start (file:///var/runtime/index.mjs:1335:23)",
        "    at async file:///var/runtime/index.mjs:1342:1"
    ]
}
```

Adding the one line in this PR fixes the issue because there is now a bundle.mjs file in the output folder.

When using the patched sst cli
```
$ ls .sst/artifacts/MyFunctionFn-src/ | grep bundle.mjs
bundle.mjs
bundle.mjs.map
```
When using sst v3.17.12
```
$ ls ./.sst/artifacts/MyFunctionFn-src/ | grep my-function.mjs
my-function.mjs
my-function.mjs.map
$ ls ./.sst/artifacts/MyFunctionFn-src/ | grep bundle.mjs
$ pnpm exec sst version
sst 3.17.12
```

