### PR TITLE
[Issue 6103] Add tags to all AWS resources being created

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -35,6 +35,7 @@ type App struct {
 	Home      string                 `json:"home"`
 	Version   string                 `json:"version"`
 	Protect   bool                   `json:"protect"`
+	Tags      map[string]string      `json:"tags"`
 	// Deprecated: Backend is now Home
 	Backend string `json:"backend"`
 	// Deprecated: RemovalPolicy is now Removal
@@ -304,7 +305,24 @@ func (proj *Project) LoadHome() error {
 		if match == nil {
 			continue
 		}
-		err := match.Init(proj.app.Name, proj.app.Stage, args.(map[string]interface{}))
+
+		providerArgs := args.(map[string]interface{})
+		if key == "aws" && len(proj.app.Tags) > 0 {
+			defaultTags, ok := providerArgs["defaultTags"].(map[string]interface{})
+			if !ok {
+				defaultTags = map[string]interface{}{}
+				providerArgs["defaultTags"] = defaultTags
+			}
+			tags, ok := defaultTags["tags"].(map[string]interface{})
+			if !ok {
+				tags = map[string]interface{}{}
+				defaultTags["tags"] = tags
+			}
+			for tagKey, tagValue := range proj.app.Tags {
+				tags[tagKey] = tagValue
+			}
+		}
+		err := match.Init(proj.app.Name, proj.app.Stage, providerArgs)
 		if err != nil {
 			return util.NewReadableError(err, key+": "+err.Error())
 		}

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -245,6 +245,31 @@ export interface App {
   home: "aws" | "cloudflare" | "local";
 
   /**
+   * Default tags to apply to all AWS resources created by SST.
+   * 
+   * These tags will be automatically applied to every resource created in your app
+   * using default tag configuration for the AWS provider.
+   * 
+   * :::tip
+   * This is useful for applying organization-wide tags like cost center, environment, or team.
+   * :::
+   * 
+   * @example
+   * 
+   * ```ts
+   * {
+   *  tags: {
+   *    "Environment": "production",
+   *    "Team": "platform",
+   *    "CostCenter": "engineering"
+   *  }
+   * }
+   * 
+   * The tags will be merged with SST's build-in tags like `sst:app` and `sst:stage`.
+   */
+  tags?: Record<string, string>;
+
+  /**
    * If set to `true`, the `sst remove` CLI will not run and will error out.
    *
    * This is useful for preventing cases where you run `sst remove --stage <stage>` for the


### PR DESCRIPTION
## Scope

- [x] Add config for tagging to all AWS resources being created
- [x] Document this global tagging config

Issue Id: [#6103](https://github.com/sst/sst/issues/6103)