### PR TITLE
run uv sync in workspace directory not root directory

### DIFF
--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -204,8 +204,13 @@ func (r *PythonRuntime) CreateBuildAsset(ctx context.Context, input *runtime.Bui
 	if arch != "x86_64" && arch != "arm64" {
 		return nil, fmt.Errorf("invalid architecture %q - must be x86_64 or arm64 - %v", arch, string(input.Properties))
 	}
-	workingDir := path.ResolveRootDir(input.CfgPath)
 
+
+	// Get the workspace directory (where pyproject.toml is located)
+	workingDir, err := r.getWorkspaceDirectory(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workspace directory: %v", err)
+	}
 	// 1. Generate non-local package index
 	syncCmd := process.CommandContext(ctx, "uv", "sync", "--all-packages")
 	syncCmd.Dir = workingDir


### PR DESCRIPTION
When working with Python containers in AWS Lambda functions, the current implementation runs the `uv sync`  command (and apparently also `uv export` and `uv build`) in the project root.

However, this assumption doesn’t always hold — especially in monorepo setups where the Python service is located in a subdirectory.

Example:

The following project structure does not work, since pyproject.toml is not at the root:

```
.
├── README.md
├── package.json
├── sst.config.ts
├── node-functions
│   └── hello-world
│       ├── index.ts
└── python-services
    └── service-A
        ├── Dockerfile
        ├── main.py
        ├── uv.lock
        ├── sst.pyi
        └── pyproject.toml
 ```
 
In this case, uv sync fails because it’s run from the wrong directory.
This change updates the logic to run `uv sync` from the workspace root instead (i.e. where the closest `pyproject.toml`) file is