### PR TITLE
fix: ensure StaticSite uploads html after other assets

### DIFF
--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -942,13 +942,29 @@ export class StaticSite extends Component implements Link.Linkable {
           const nonHtmlFileOptions: typeof reversedFileOptions = [];
 
           /**
-           * StaticSite historically replays `fileOptions` in reverse so the
-           * last config wins. That works fine for cache headers, but it means
-           * HTML often syncs *before* hashed JS/CSS when users leave the
-           * defaults in place. We bucket options by whether they target HTML
-           * and run those after everything else, preserving the "last wins"
-           * semantics while ensuring every referenced asset is in S3 before a
-           * new `index.html` ships.
+           * StaticSite historically replays `fileOptions` in reverse order, so
+           * the *last* entry in config becomes the *first* upload pass. With
+           * the default options that put HTML last, the runtime actually pushes
+           * `index.html` to S3 *before* its hashed JS/CSS siblings:
+           *
+           * ```text
+           * deploy start
+           *   ├─▶ (reverse) upload index.html
+           *   │       └─▶ CloudFront serves fresh HTML referencing app.[hash].js
+           *   └───── lag ──▶ upload app.[hash].js (still missing in S3)
+           *                               ↓
+           *                           viewer request → S3 403 → white screen
+           * ```
+           *
+           * To close that race we bucket options by whether they touch HTML,
+           * process non-HTML first, then HTML. Behavioural invariants remain:
+           *
+           * ```text
+           * configure: [ ...non-html..., ...html... ]
+           * reverse ▶  [ html-group, non-html-group ]
+           * reorder ▶  [ non-html-group, html-group ]
+           * result  ▶  assets uploaded → index.html uploaded → no 403 gap
+           * ```
            */
           for (const option of reversedFileOptions) {
             const patterns = Array.isArray(option.files)

--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -937,7 +937,28 @@ export class StaticSite extends Component implements Link.Linkable {
 
           // Upload files based on fileOptions
           const filesProcessed: string[] = [];
-          for (const fileOption of fileOptions.reverse()) {
+          const reversedFileOptions = [...fileOptions].reverse();
+          const htmlFileOptions: typeof reversedFileOptions = [];
+          const nonHtmlFileOptions: typeof reversedFileOptions = [];
+
+          for (const option of reversedFileOptions) {
+            const patterns = Array.isArray(option.files)
+              ? option.files
+              : [option.files];
+            const targetsHtml = patterns.some((pattern) =>
+              pattern.includes(".html"),
+            );
+
+            if (targetsHtml) {
+              htmlFileOptions.push(option);
+            } else {
+              nonHtmlFileOptions.push(option);
+            }
+          }
+
+          const uploadOrder = [...nonHtmlFileOptions, ...htmlFileOptions];
+
+          for (const fileOption of uploadOrder) {
             const files = globSync(fileOption.files, {
               cwd: path.resolve(outputPath),
               nodir: true,

--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -941,6 +941,15 @@ export class StaticSite extends Component implements Link.Linkable {
           const htmlFileOptions: typeof reversedFileOptions = [];
           const nonHtmlFileOptions: typeof reversedFileOptions = [];
 
+          /**
+           * StaticSite historically replays `fileOptions` in reverse so the
+           * last config wins. That works fine for cache headers, but it means
+           * HTML often syncs *before* hashed JS/CSS when users leave the
+           * defaults in place. We bucket options by whether they target HTML
+           * and run those after everything else, preserving the "last wins"
+           * semantics while ensuring every referenced asset is in S3 before a
+           * new `index.html` ships.
+           */
           for (const option of reversedFileOptions) {
             const patterns = Array.isArray(option.files)
               ? option.files


### PR DESCRIPTION
**Why it matters:** CloudFront served a brand-new `index.html` while the referenced `app.[hash].js` files were still on their way to S3, so early visitors hit 403s and saw a white screen.

```
 deploy start
   ├─▶ (reverse iteration) upload index.html
   │       └─▶ HTML points at app.[hash].js (missing)
   └───── lag ──▶ upload app.[hash].js
                           ↓
                       viewer → S3 403 → sad user
```

**What changed:** we keep user-defined cache semantics, but split `fileOptions` into HTML vs. non-HTML buckets so SST always ships hashed assets before HTML.

```
 configure: [ ...non-html..., ...html... ]
 reverse ▶  [ html-group, non-html-group ]
 reorder ▶  [ non-html-group, html-group ]
 serve   ▶  assets uploaded → index.html uploaded → no 403 gap
```

**Testing:** not run (library change).