### PR TITLE
fix: fixes double dashes in names of components

### DIFF
--- a/platform/src/components/naming.ts
+++ b/platform/src/components/naming.ts
@@ -17,7 +17,7 @@ export function physicalName(max: number, name: string, suffix: string = "") {
     crypto.randomBytes(8).toString("hex"),
     8,
   );
-  return `${main}-${random}${suffix}`;
+  return `${main}-${random}${suffix}`.replace(/-+/g, "-");
 }
 
 export function prefixName(max: number, name: string) {

--- a/platform/test/components/naming2.test.ts
+++ b/platform/test/components/naming2.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { physicalName } from "../../src/components/naming.js";
+
+// @ts-ignore
+global.$app = {
+  name: "my-app",
+  stage: "test",
+};
+describe("generateName with dashed app name", function () {
+  it(() => expect(physicalName(10, "myapp")).toMatch(/^m-[a-z]{8}$/));
+  it(() => expect(physicalName(11, "myapp")).toMatch(/^my-[a-z]{8}$/));
+  it(() => expect(physicalName(12, "myapp")).toMatch(/^mya-[a-z]{8}$/));
+  it(() => expect(physicalName(13, "myapp")).toMatch(/^myap-[a-z]{8}$/));
+  it(() => expect(physicalName(14, "myapp")).toMatch(/^myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(15, "myapp")).toMatch(/^myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(16, "myapp")).toMatch(/^t-myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(17, "myapp")).toMatch(/^te-myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(18, "myapp")).toMatch(/^tes-myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(19, "myapp")).toMatch(/^test-myapp-[a-z]{8}$/));
+  it(() => expect(physicalName(20, "myapp")).toMatch(/^test-myapp-[a-z]{8}$/));
+  it(() =>
+    expect(physicalName(21, "myapp")).toMatch(/^m-test-myapp-[a-z]{8}$/),
+  );
+  it(() =>
+    expect(physicalName(22, "myapp")).toMatch(/^my-test-myapp-[a-z]{8}$/),
+  );
+  it(() =>
+    expect(physicalName(23, "myapp")).toMatch(/^my-test-myapp-[a-z]{8}$/),
+  );
+});


### PR DESCRIPTION
I added tests to confirm but did so in a new file due to the global var.

This was about #5595