### PR TITLE
fix: issue 5595, double dash in replicationGroupId

### DIFF
--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -231,7 +231,7 @@ export class Component extends ComponentResource {
             "aws:elasticache/replicationGroup:ReplicationGroup": [
               "replicationGroupId",
               40,
-              { lower: true },
+              { lower: true, replace: (name) => name.replaceAll(/-+/g, "-") },
             ],
             "aws:elasticache/subnetGroup:SubnetGroup": [
               "name",


### PR DESCRIPTION
add replace for anymore than a single dash in replicationGroupId of elasticache clusters

closed #5595 closes #6124 