### PR TITLE
fix: kill entire process groups to prevent dev server zombie processes on timeout

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -90,7 +90,7 @@ func CmdMosaic(c *cli.Cli) error {
 				go func() {
 					evts <- true
 				}()
-				fmt.Println(ui.TEXT_DIM.Render("[timeout]"))
+				fmt.Println("\n"+ui.TEXT_DIM.Render("[timeout]"))
 				timer.Reset(timeout)
 				continue
 			case _, ok := <-evts:

--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/kballard/go-shellquote"
@@ -126,6 +127,11 @@ func CmdMosaic(c *cli.Cli) error {
 					cmd.Env = append(cmd.Env, "FORCE_COLOR=1")
 					for k, v := range nextEnv.Env {
 						cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+					}
+					if goruntime.GOOS != "windows" {
+						cmd.SysProcAttr = &syscall.SysProcAttr{
+							Setpgid: true,
+						}
 					}
 					cmd.Stdin = os.Stdin
 					cmd.Stdout = os.Stdout

--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/kballard/go-shellquote"
@@ -128,11 +127,7 @@ func CmdMosaic(c *cli.Cli) error {
 					for k, v := range nextEnv.Env {
 						cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 					}
-					if goruntime.GOOS != "windows" {
-						cmd.SysProcAttr = &syscall.SysProcAttr{
-							Setpgid: true,
-						}
-					}
+					process.Detach(cmd)
 					cmd.Stdin = os.Stdin
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr

--- a/cmd/sst/mosaic/multiplexer/tcell-term/vt_unix.go
+++ b/cmd/sst/mosaic/multiplexer/tcell-term/vt_unix.go
@@ -8,7 +8,6 @@ import "syscall"
 func getPtyAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Setsid:  true,
-		Setpgid: true,
 		Setctty: true,
 		Ctty:    1,
 	}

--- a/cmd/sst/mosaic/multiplexer/tcell-term/vt_unix.go
+++ b/cmd/sst/mosaic/multiplexer/tcell-term/vt_unix.go
@@ -7,8 +7,9 @@ import "syscall"
 
 func getPtyAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		Setsid: true,
+		Setsid:  true,
+		Setpgid: true,
 		Setctty: true,
-		Ctty: 1,
+		Ctty:    1,
 	}
 }

--- a/pkg/process/detach_unix.go
+++ b/pkg/process/detach_unix.go
@@ -9,8 +9,10 @@ import (
 )
 
 func Detach(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-		Pgid:    0,
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+	// Ensure the child is the leader of its own process group without
+	// clobbering any other existing SysProcAttr fields set by the caller.
+	cmd.SysProcAttr.Setpgid = true
 }

--- a/pkg/process/kill_unix.go
+++ b/pkg/process/kill_unix.go
@@ -15,14 +15,19 @@ func sendSignal(process *os.Process, sig syscall.Signal) error {
 		return errors.New("invalid process")
 	}
 	if err := syscall.Kill(-process.Pid, sig); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			slog.Info("process already exited, skipping signal", "pid", process.Pid, "signal", sig)
-			return nil
+		if !errors.Is(err, syscall.ESRCH) {
+			slog.Warn("failed to kill process group", "pid", process.Pid, "signal", sig, "err", err)
 		}
-		slog.Warn("failed to kill process group, trying individual process", "pid", process.Pid, "signal", sig, "err", err)
+		// Group kill failed — either no such group (ESRCH) or other error.
+		// Fall back to signaling the individual process.
 		if err := process.Signal(sig); err != nil {
+			if errors.Is(err, os.ErrProcessDone) {
+				slog.Info("process already exited", "pid", process.Pid, "signal", sig)
+				return nil
+			}
 			return err
 		}
+		slog.Info("sent signal to individual process", "pid", process.Pid, "signal", sig)
 	} else {
 		slog.Info("sent signal to process group", "pid", process.Pid, "signal", sig)
 	}

--- a/pkg/process/kill_unix.go
+++ b/pkg/process/kill_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+// +build !windows
+
+package process
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"syscall"
+)
+
+func sendSignal(process *os.Process, sig syscall.Signal) error {
+	if process == nil || process.Pid <= 0 {
+		return errors.New("invalid process")
+	}
+	if err := syscall.Kill(-process.Pid, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			slog.Info("process already exited, skipping signal", "pid", process.Pid, "signal", sig)
+			return nil
+		}
+		slog.Warn("failed to kill process group, trying individual process", "pid", process.Pid, "signal", sig, "err", err)
+		if err := process.Signal(sig); err != nil {
+			return err
+		}
+	} else {
+		slog.Info("sent signal to process group", "pid", process.Pid, "signal", sig)
+	}
+
+	return nil
+}
+
+func sendTermSignal(process *os.Process) error {
+	return sendSignal(process, syscall.SIGTERM)
+}
+
+func sendKillSignal(process *os.Process) error {
+	return sendSignal(process, syscall.SIGKILL)
+}

--- a/pkg/process/kill_unix.go
+++ b/pkg/process/kill_unix.go
@@ -11,7 +11,7 @@ import (
 )
 
 func sendSignal(process *os.Process, sig syscall.Signal) error {
-	if process == nil || process.Pid <= 0 {
+	if process.Pid <= 0 {
 		return errors.New("invalid process")
 	}
 	if err := syscall.Kill(-process.Pid, sig); err != nil {

--- a/pkg/process/kill_unix_test.go
+++ b/pkg/process/kill_unix_test.go
@@ -4,7 +4,6 @@
 package process
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"testing"
@@ -68,31 +67,17 @@ func TestSendSignalAlreadyExited(t *testing.T) {
 // findChildInGroup looks for a process whose pgid matches the parent pid.
 func findChildInGroup(t *testing.T, parentPid int) int {
 	t.Helper()
-	// read /proc or use ps to find children
-	// fallback: just check the group is killable
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		// not on linux (e.g. macOS), skip child check
-		return 0
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		var pid int
-		if _, err := fmt.Sscanf(e.Name(), "%d", &pid); err != nil {
-			continue
-		}
-		if pid == parentPid {
-			continue
-		}
+	// use syscall.Getpgid to scan for children in the same group
+	// check pids near the parent (children are typically allocated sequentially)
+	for pid := parentPid + 1; pid < parentPid+50; pid++ {
 		pgid, err := syscall.Getpgid(pid)
 		if err != nil {
 			continue
 		}
-		if pgid == parentPid {
+		if pgid == parentPid && pid != parentPid {
 			return pid
 		}
 	}
+	t.Fatal("could not find child process in group")
 	return 0
 }

--- a/pkg/process/kill_unix_test.go
+++ b/pkg/process/kill_unix_test.go
@@ -1,0 +1,98 @@
+//go:build !windows
+// +build !windows
+
+package process
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestKillTerminatesProcessGroup(t *testing.T) {
+	reset()
+	// spawn a shell that starts a child; both share the process group
+	cmd := Command("sh", "-c", "sleep 60 & wait")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	parentPid := cmd.Process.Pid
+
+	// give child time to spawn
+	time.Sleep(100 * time.Millisecond)
+
+	// find a child in the same process group
+	childPid := findChildInGroup(t, parentPid)
+
+	if err := Kill(cmd.Process); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+
+	// both parent and child should be dead
+	time.Sleep(100 * time.Millisecond)
+	if err := syscall.Kill(parentPid, 0); err == nil {
+		t.Error("parent still alive after Kill")
+	}
+	if childPid != 0 {
+		if err := syscall.Kill(childPid, 0); err == nil {
+			t.Error("child still alive after group Kill")
+		}
+	}
+}
+
+func TestSendSignalInvalidPid(t *testing.T) {
+	p := &os.Process{}
+	// Pid 0 should be rejected
+	if err := sendSignal(p, syscall.SIGTERM); err == nil {
+		t.Error("expected error for pid 0")
+	}
+}
+
+func TestSendSignalAlreadyExited(t *testing.T) {
+	cmd := Command("true")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	cmd.Wait()
+
+	// should return nil (ESRCH is swallowed)
+	if err := sendSignal(cmd.Process, syscall.SIGTERM); err != nil {
+		t.Fatalf("expected nil for exited process, got: %v", err)
+	}
+}
+
+// findChildInGroup looks for a process whose pgid matches the parent pid.
+func findChildInGroup(t *testing.T, parentPid int) int {
+	t.Helper()
+	// read /proc or use ps to find children
+	// fallback: just check the group is killable
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		// not on linux (e.g. macOS), skip child check
+		return 0
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		var pid int
+		if _, err := fmt.Sscanf(e.Name(), "%d", &pid); err != nil {
+			continue
+		}
+		if pid == parentPid {
+			continue
+		}
+		pgid, err := syscall.Getpgid(pid)
+		if err != nil {
+			continue
+		}
+		if pgid == parentPid {
+			return pid
+		}
+	}
+	return 0
+}

--- a/pkg/process/kill_windows.go
+++ b/pkg/process/kill_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package process
+
+import "os"
+
+func sendTermSignal(process *os.Process) error {
+	return process.Kill()
+}
+
+func sendKillSignal(process *os.Process) error {
+	return process.Kill()
+}

--- a/pkg/process/kill_windows.go
+++ b/pkg/process/kill_windows.go
@@ -5,6 +5,9 @@ package process
 
 import "os"
 
+// Windows doesn't support process groups like Unix. These functions only
+// terminate the target process; child processes may continue running.
+
 func sendTermSignal(process *os.Process) error {
 	return process.Kill()
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -148,5 +148,5 @@ func untrack(pid int) {
 			return
 		}
 	}
-	slog.Info("untracked process", "pid", pid)
+	slog.Info("process not found in tracked list", "pid", pid)
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -108,9 +108,14 @@ func Kill(process *os.Process) error {
 		break
 
 	default:
-		if err := process.Signal(syscall.SIGTERM); err != nil {
-			slog.Error("failed to send sigterm", "pid", process.Pid)
-			return err
+		if err := syscall.Kill(-process.Pid, syscall.SIGTERM); err != nil {
+			slog.Info("failed to kill process group, trying individual process", "pid", process.Pid, "err", err)
+			if err := process.Signal(syscall.SIGTERM); err != nil {
+				slog.Error("failed to send sigterm", "pid", process.Pid)
+				return err
+			}
+		} else {
+			slog.Info("sent sigterm to process group", "pid", process.Pid)
 		}
 	}
 
@@ -126,9 +131,14 @@ func Kill(process *os.Process) error {
 		break
 	case <-time.After(killWait):
 		slog.Info("process not responding, sending sigkill", "pid", process.Pid)
-		if err := process.Signal(syscall.SIGKILL); err != nil {
-			slog.Error("failed to send sigkill", "pid", process.Pid)
-			return err
+		if err := syscall.Kill(-process.Pid, syscall.SIGKILL); err != nil {
+			slog.Info("failed to kill process group with SIGKILL, trying individual process", "pid", process.Pid, "err", err)
+			if err := process.Signal(syscall.SIGKILL); err != nil {
+				slog.Error("failed to send sigkill", "pid", process.Pid)
+				return err
+			}
+		} else {
+			slog.Info("sent sigkill to process group", "pid", process.Pid)
 		}
 
 		// Wait for SIGKILL to complete

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -143,7 +143,8 @@ cleanup:
 		if cmds[i].Process != nil && cmds[i].Process.Pid == process.Pid {
 			cmds[i] = cmds[len(cmds)-1]
 			cmds = cmds[:len(cmds)-1]
-			break
+
+			return nil
 		}
 	}
 	slog.Info("untracked process", "pid", process.Pid)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -103,6 +103,8 @@ func Kill(process *os.Process) error {
 		close(done)
 	}()
 
+	var killErr error
+
 	if err := sendTermSignal(process); err != nil {
 		slog.Error("failed to send term signal, escalating", "pid", process.Pid, "err", err)
 	} else {
@@ -122,8 +124,8 @@ func Kill(process *os.Process) error {
 		slog.Info("process not responding, sending kill signal", "pid", process.Pid)
 		if err := sendKillSignal(process); err != nil {
 			slog.Error("failed to send kill signal", "pid", process.Pid, "err", err)
-
-			return err
+			killErr = err
+			goto cleanup
 		}
 
 		select {
@@ -131,8 +133,7 @@ func Kill(process *os.Process) error {
 			slog.Info("process killed with kill", "pid", process.Pid)
 		case <-time.After(killWait):
 			slog.Info("timed out waiting for kill signal", "pid", process.Pid)
-
-			return syscall.ETIMEDOUT
+			killErr = syscall.ETIMEDOUT
 		}
 	}
 
@@ -144,10 +145,10 @@ cleanup:
 			cmds[i] = cmds[len(cmds)-1]
 			cmds = cmds[:len(cmds)-1]
 
-			return nil
+			return killErr
 		}
 	}
 	slog.Info("untracked process", "pid", process.Pid)
 
-	return nil
+	return killErr
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -98,59 +97,46 @@ func Kill(process *os.Process) error {
 	}
 	slog.Info("killing process", "pid", process.Pid)
 
-	switch runtime.GOOS {
-
-	case "windows":
-		if err := process.Kill(); err != nil {
-			slog.Error("failed to kill", "pid", process.Pid)
-			return err
-		}
-		break
-
-	default:
-		if err := syscall.Kill(-process.Pid, syscall.SIGTERM); err != nil {
-			slog.Info("failed to kill process group, trying individual process", "pid", process.Pid, "err", err)
-			if err := process.Signal(syscall.SIGTERM); err != nil {
-				slog.Error("failed to send sigterm", "pid", process.Pid)
-				return err
-			}
-		} else {
-			slog.Info("sent sigterm to process group", "pid", process.Pid)
-		}
-	}
-
 	done := make(chan struct{})
 	go func() {
-		process.Wait()
+		_, _ = process.Wait()
 		close(done)
 	}()
 
+	if err := sendTermSignal(process); err != nil {
+		slog.Error("failed to send term signal, escalating", "pid", process.Pid, "err", err)
+	} else {
+		select {
+		case <-done:
+			slog.Info("process killed with term", "pid", process.Pid)
+			goto cleanup
+		case <-time.After(killWait):
+			slog.Info("process not responding to term, sending kill", "pid", process.Pid)
+		}
+	}
+
 	select {
 	case <-done:
-		slog.Info("process killed with term", "pid", process.Pid)
-		break
+		slog.Info("process killed before kill escalation", "pid", process.Pid)
 	case <-time.After(killWait):
-		slog.Info("process not responding, sending sigkill", "pid", process.Pid)
-		if err := syscall.Kill(-process.Pid, syscall.SIGKILL); err != nil {
-			slog.Info("failed to kill process group with SIGKILL, trying individual process", "pid", process.Pid, "err", err)
-			if err := process.Signal(syscall.SIGKILL); err != nil {
-				slog.Error("failed to send sigkill", "pid", process.Pid)
-				return err
-			}
-		} else {
-			slog.Info("sent sigkill to process group", "pid", process.Pid)
+		slog.Info("process not responding, sending kill signal", "pid", process.Pid)
+		if err := sendKillSignal(process); err != nil {
+			slog.Error("failed to send kill signal", "pid", process.Pid, "err", err)
+
+			return err
 		}
 
-		// Wait for SIGKILL to complete
 		select {
 		case <-done:
 			slog.Info("process killed with kill", "pid", process.Pid)
-			break
 		case <-time.After(killWait):
-			slog.Info("timed out waiting for sigkill", "pid", process.Pid)
+			slog.Info("timed out waiting for kill signal", "pid", process.Pid)
+
 			return syscall.ETIMEDOUT
 		}
 	}
+
+cleanup:
 	lock.Lock()
 	defer lock.Unlock()
 	for i := len(cmds) - 1; i >= 0; i-- {
@@ -161,5 +147,6 @@ func Kill(process *os.Process) error {
 		}
 	}
 	slog.Info("untracked process", "pid", process.Pid)
+
 	return nil
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -103,52 +103,50 @@ func Kill(process *os.Process) error {
 		close(done)
 	}()
 
-	var killErr error
+	killErr := escalatingKill(process, done)
+	untrack(process.Pid)
+	return killErr
+}
 
+func escalatingKill(process *os.Process, done <-chan struct{}) error {
 	if err := sendTermSignal(process); err != nil {
-		slog.Error("failed to send term signal, escalating", "pid", process.Pid, "err", err)
-	} else {
-		select {
-		case <-done:
-			slog.Info("process killed with term", "pid", process.Pid)
-			goto cleanup
-		case <-time.After(killWait):
-			slog.Info("process not responding to term, sending kill", "pid", process.Pid)
-		}
+		slog.Error("term signal failed, escalating", "pid", process.Pid, "err", err)
+		return forceKill(process, done)
 	}
-
 	select {
 	case <-done:
-		slog.Info("process killed before kill escalation", "pid", process.Pid)
+		slog.Info("process killed with term", "pid", process.Pid)
+		return nil
 	case <-time.After(killWait):
-		slog.Info("process not responding, sending kill signal", "pid", process.Pid)
-		if err := sendKillSignal(process); err != nil {
-			slog.Error("failed to send kill signal", "pid", process.Pid, "err", err)
-			killErr = err
-			goto cleanup
-		}
-
-		select {
-		case <-done:
-			slog.Info("process killed with kill", "pid", process.Pid)
-		case <-time.After(killWait):
-			slog.Info("timed out waiting for kill signal", "pid", process.Pid)
-			killErr = syscall.ETIMEDOUT
-		}
+		slog.Info("term timeout, escalating", "pid", process.Pid)
+		return forceKill(process, done)
 	}
+}
 
-cleanup:
+func forceKill(process *os.Process, done <-chan struct{}) error {
+	if err := sendKillSignal(process); err != nil {
+		slog.Error("kill signal failed", "pid", process.Pid, "err", err)
+		return err
+	}
+	select {
+	case <-done:
+		slog.Info("process killed with kill", "pid", process.Pid)
+		return nil
+	case <-time.After(killWait):
+		slog.Info("timed out waiting for kill", "pid", process.Pid)
+		return syscall.ETIMEDOUT
+	}
+}
+
+func untrack(pid int) {
 	lock.Lock()
 	defer lock.Unlock()
 	for i := len(cmds) - 1; i >= 0; i-- {
-		if cmds[i].Process != nil && cmds[i].Process.Pid == process.Pid {
+		if cmds[i].Process != nil && cmds[i].Process.Pid == pid {
 			cmds[i] = cmds[len(cmds)-1]
 			cmds = cmds[:len(cmds)-1]
-
-			return killErr
+			return
 		}
 	}
-	slog.Info("untracked process", "pid", process.Pid)
-
-	return killErr
+	slog.Info("untracked process", "pid", pid)
 }

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,113 @@
+package process
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestKillNil(t *testing.T) {
+	if err := Kill(nil); err != nil {
+		t.Fatalf("Kill(nil) returned error: %v", err)
+	}
+}
+
+func TestKillTerminatesProcess(t *testing.T) {
+	reset()
+	cmd := Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	if err := Kill(cmd.Process); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+
+	// process should no longer exist
+	if err := signalProcess(pid); err == nil {
+		t.Fatal("process still alive after Kill")
+	}
+}
+
+func TestCleanupKillsAllTracked(t *testing.T) {
+	reset()
+	var pids []int
+	for i := 0; i < 3; i++ {
+		cmd := Command("sleep", "60")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start process %d: %v", i, err)
+		}
+		pids = append(pids, cmd.Process.Pid)
+	}
+
+	if err := Cleanup(); err != nil {
+		t.Fatalf("Cleanup returned error: %v", err)
+	}
+
+	for _, pid := range pids {
+		if err := signalProcess(pid); err == nil {
+			t.Errorf("process %d still alive after Cleanup", pid)
+		}
+	}
+}
+
+func TestKillAlreadyExited(t *testing.T) {
+	reset()
+	cmd := Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	cmd.Wait()
+	// should not error on already-exited process
+	if err := Kill(cmd.Process); err != nil {
+		t.Fatalf("Kill on exited process returned error: %v", err)
+	}
+}
+
+func TestCommandTracksProcess(t *testing.T) {
+	reset()
+	cmd := Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer Kill(cmd.Process)
+
+	lock.Lock()
+	count := len(cmds)
+	lock.Unlock()
+
+	if count != 1 {
+		t.Fatalf("expected 1 tracked command, got %d", count)
+	}
+}
+
+func TestKillUntracksProcess(t *testing.T) {
+	reset()
+	cmd := Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	Kill(cmd.Process)
+
+	lock.Lock()
+	count := len(cmds)
+	lock.Unlock()
+
+	if count != 0 {
+		t.Fatalf("expected 0 tracked commands after Kill, got %d", count)
+	}
+}
+
+func signalProcess(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Signal(os.Interrupt)
+}
+
+func init() {
+	killWait = 1 * time.Second
+}


### PR DESCRIPTION
### Summary

SST dev command was leaking child processes when timing out. Each timeout left an entire process tree running, eventually exhausting system resources. This fix ensures all spawned processes die with their parents.

#### Background
 
Our team continuously experiences memory exhaustion and database connection leaks from sst dev, even when idling. During normal development work (hot reloads, rebuilds), it spawns new processes without cleaning up old ones, accumulating 200+ processes consuming over 100% system memory in a single dev session.

#### The Bug

When `sst dev` times out (default 50 mins), it prints `[timeout]` but never kills the running process. The timeout handler in [mosaic.go:85-91](https://github.com/sst/sst/blob/9ced491d45eb971842c67e2b87ba43df817bc241/cmd/sst/mosaic.go#L85-L90) just continues the loop without calling `process.Kill()`. When the loop eventually restarts, only the parent dies - children survive as zombies. 🧟 

**Reproduction:**
```bash
#!/bin/bash
node -e "setInterval(() => console.log('child alive'), 2000)" &
wait
```

1. Lower the timeout in `mosaic.go` for debugging.
1. Run above script with `sst dev`
1. Wait for the timeout
1. Check `ps aux | grep node` for accumulating orphaned processes (parent PID is 1)

#### The Fix

1. **Create process groups:** Set `Setpgid: true` for spawned processes on Unix ([mosaic.go:126-130](https://github.com/sst/sst/pull/6133/files#diff-d596e671dba70e5c2adde994d2c251da1f11e48cc3b2179f0a97c1c00e6f4049R126-R130))
1. **Kill entire groups:** Use `syscall.Kill(-pid, signal)` to terminate all processes in group ([process.go:111](https://github.com/sst/sst/pull/6133/files#diff-d821ab8e2837e9704c2828e47ea4558eea087c46e1870d71f51842b5764b633cR111))
1. **Graceful fallback:** If group kill fails, fall back to individual process termination

#### Test Plan

- [x] Run `sst dev` with a script that spawns children, verify all processes die on timeout
- [x] Test Ctrl+C kills entire process tree
- [x] Verify `ps aux` shows no orphaned processes after SST exits
- [ ] Confirm Windows builds work (excluded from Unix-specific changes)
- [x] Check runtime processes (Python/Go/Node/Rust) still terminate correctly
