### PR TITLE
fix: update launchdarkly link to actual provider from sst/provider

### DIFF
--- a/www/src/content/docs/docs/all-providers.mdx
+++ b/www/src/content/docs/docs/all-providers.mdx
@@ -187,7 +187,7 @@ If you want SST to support a Terraform provider or update a version, you can **s
 | [Kubernetes](https://www.pulumi.com/registry/packages/kubernetes) | `kubernetes` |
 | [Kubernetes Cert Manager](https://www.pulumi.com/registry/packages/kubernetes-cert-manager) | `kubernetes-cert-manager` |
 | [Kubernetes CoreDNS](https://www.pulumi.com/registry/packages/kubernetes-coredns) | `kubernetes-coredns` |
-| [LaunchDarkly](https://www.pulumi.com/registry/packages/launchdarkly) | `@lbrlabs/pulumi-lauchdarkly` |
+| [LaunchDarkly](https://registry.terraform.io/providers/launchdarkly/launchdarkly) | `lauchdarkly` |
 | [LBr Labs EKS](https://www.pulumi.com/registry/packages/lbrlabs-eks) | `@lbrlabs/pulumi-eks` |
 | [libvirt](https://www.pulumi.com/registry/packages/libvirt) | `libvirt` |
 | [Linode](https://www.pulumi.com/registry/packages/linode) | `linode` |


### PR DESCRIPTION
The LaunchDarkly provider in [sst/provider](https://github.com/sst/provider/blob/24e18e8a1ab99e94b6b36df387c4e7b66493bd2d/metadata/launchdarkly.toml#L2) is different than the one the docs point to.

Docs here are simply outdated, they point to an archive of an unofficial pulumi implementation.