### PR TITLE
Service LoadBalancer Healthcheck Path

### DIFF
--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -1883,7 +1883,7 @@ export class Service extends Component implements Link.Linkable {
               return [
                 k,
                 {
-                  path: v.path ?? "/",
+                  path: v.path ?? type === "application" ? "/" : undefined,
                   interval: v.interval ? toSeconds(v.interval) : 30,
                   timeout: v.timeout
                     ? toSeconds(v.timeout)


### PR DESCRIPTION
When the `loadBalancer` for a `Service` exposes tcp ports instead of http ports then the healthcheck path *must* be undefined for aws to register this as a tcp healthcheck. 

In it's current form if you create a `Service` with the following definition:
```typescript
new sst.aws.Service('bastion', {
  cluster,
  loadBalancer: {
    domain: {
      name: bastionDomain,
      dns: sst.cloudflare.dns(),
    },
    health: {
      '2222/tcp': {
        interval: '30 seconds',
        timeout: '10 seconds',
        healthyThreshold: 2,
        unhealthyThreshold: 2,
      },
    },
    rules: [{ listen: '22/tcp', forward: '2222/tcp' }],
  },
...
}
```
the load balancer's healthcheck ends up using http instead of tcp due to the path fallback.

This PR fixes that by checking the type to see if it's a `network` or `application` loadbalancer before falling back