### PR TITLE
Fix(ssr-site): Prevent static routes from shadowing SSR routes in nested paths

### DIFF
--- a/platform/src/components/aws/astro.ts
+++ b/platform/src/components/aws/astro.ts
@@ -500,6 +500,7 @@ export class Astro extends SsrSite {
             )
             ? "/404.html"
             : undefined,
+        hasStaticRoutes: true,
       };
     });
   }

--- a/platform/src/components/aws/solid-start.ts
+++ b/platform/src/components/aws/solid-start.ts
@@ -461,6 +461,7 @@ export class SolidStart extends SsrSite {
             cached: true,
           },
         ],
+        hasStaticRoutes: true,
       };
     });
   }

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -111,6 +111,7 @@ export type Plan = {
   };
   custom404?: string;
   buildId?: string;
+  hasStaticRoutes?: boolean;
 };
 
 export interface SsrSiteArgs extends BaseSsrSiteArgs {
@@ -1399,6 +1400,35 @@ async function handler(event) {
             const expandDirs = [".well-known"];
 
             plan.assets.forEach((copy) => {
+              // Helper function to recursively find HTML files in directories
+              const findHtmlFiles = (dirPath: string, basePath: string, depth = 0) => {
+
+                const results: string[] = [];
+                const files = fs.readdirSync(dirPath, { withFileTypes: true });
+                // avoid infinite loop
+                if(depth > 100) {
+                  console.warn(`findHtmlFiles: depth > 100, skipping ${dirPath}`);
+                  return results;
+                }
+
+                for (const file of files) {
+                  const fullPath = path.join(dirPath, file.name);
+                  const relativePath = path.join(basePath, file.name);
+                  
+                  if(file.isSymbolicLink() || file.name.startsWith('.')) {
+                    continue;
+                  } else if (file.isDirectory()) {
+                    // Recursively process subdirectories
+                    results.push(...findHtmlFiles(fullPath, relativePath, depth + 1));
+                  } else if (file.isFile() && file.name.endsWith('.html')) {
+                    // Found an HTML file
+                    results.push(relativePath);
+                  }
+                }
+                
+                return results;
+              };
+
               const processDir = (childPath = "", level = 0) => {
                 const currentPath = path.join(outputPath, copy.from, childPath);
                 fs.readdirSync(currentPath, { withFileTypes: true }).forEach(
@@ -1422,7 +1452,36 @@ async function handler(event) {
                     ) {
                       processDir(path.join(childPath, item.name), level + 1);
                       return;
-                    }
+                    }               
+                  // Resolves routing precedence bug in nested paths with mixed rendering modes.
+                  //   Issue: Directory-level S3 classification caused static routes to shadow SSR siblings
+                  //   (e.g., /api/users/static masks /api/users/ssr from reaching Lambda).
+                  //   Fix: Perform deep file-level scanning when prerendered routes exist, adding only
+                  //   concrete static assets to KV metadata. Handles framework-specific output patterns:
+                  //   SvelteKit (route.html) vs Astro / SolidStart (route/index.html), ensuring CloudFront router
+                  // correctly differentiates S3-served files from Lambda-routed SSR endpoints.
+                    if (plan.hasStaticRoutes) {
+
+                      // For versioned asset dir, add to routes and do not recurse
+                      if (item.name === copy.versionedSubDir) {
+                        dirs.push(toPosix(path.join("/", childPath, item.name)));
+                        return;
+                      } 
+                      
+                      const dirPath = path.join(currentPath, item.name);
+                      const dirRelativePath = path.join(childPath, item.name);
+                      
+                      // Find all HTML files in this directory and its subdirectories
+                      const htmlFiles = findHtmlFiles(dirPath, dirRelativePath);
+
+                      // Add all HTML files to S3 keys to avoid ssr overrride
+                      if (htmlFiles.length > 0) {
+                        htmlFiles.forEach(htmlFile => {
+                          kvEntries[toPosix(path.join("/", htmlFile))] = "s3";
+                        });
+                        return;
+                      }
+                    }       
                     // Directory + NOT expand: add to route
                     dirs.push(toPosix(path.join("/", childPath, item.name)));
                   },

--- a/platform/src/components/aws/svelte-kit.ts
+++ b/platform/src/components/aws/svelte-kit.ts
@@ -481,6 +481,7 @@ export class SvelteKit extends SsrSite {
             cached: false,
           },
         ],
+        hasStaticRoutes: true,
       };
     });
   }


### PR DESCRIPTION
## Problem

When using SSR frameworks (Astro, SvelteKit, SolidStart) with mixed rendering modes in nested routes, SSR endpoints were unreachable if a static route existed in the same parent directory.

**Example:**
- `/route/sub/ssr` (SSR endpoint)
- `/route/sub/static` (Static/prerendered page)

The presence of `/route/sub/static` caused the entire `/route/sub/` directory to be classified as a static S3 route, preventing `/route/sub/ssr` from reaching the Lambda function.

## Root Cause

The KV metadata generation logic performed directory-level classification rather than file-level detection. When scanning assets, entire directories were added to the S3 route table, causing static routes to shadow their SSR siblings.

## Solution

Implemented granular static route detection:

1. **Deep file scanning**: When prerendered routes are detected, recursively scan subdirectories and add only concrete static files to S3 keys
2. **Framework-specific handling**: Account for different prerendering output patterns:
   - **SvelteKit**: Outputs prerendered routes as `staticRoute.html`
   - **Astro**: Outputs prerendered routes as `staticRoute/index.html`

This allows the CloudFront router to correctly differentiate between:
- Files that exist in S3 (serve directly)
- Dynamic routes that should hit the SSR Lambda

## Changes

- Modified asset scanning logic in `createKvEntries()` to perform file-level detection instead of directory-level classification
- Added `findHtmlFiles()` helper to recursively scan for actual static files
- Updated KV metadata to only include concrete file paths, not directory patterns

## Testing

Tested with:
- ✅ Astro with mixed SSR/static routes
- ✅ SvelteKit with mixed SSR/static routes  
- ✅ SolidStart with mixed SSR/static routes

## Fixes

Resolves routing precedence issues in nested paths with mixed rendering modes across SSR frameworks.

### Bonus Fix: Framework Output Pattern Compatibility

Also resolves SvelteKit routing issues caused by different prerendering patterns:
- **SvelteKit**: `route.html` → CloudFront was incorrectly appending `/index.html` through the edge function.
- **Astro/SolidStart**: `route/index.html` → Required `/index.html` suffix

File-level detection now respects each framework's actual output structure, fixing SvelteKit static route serving.