### PR TITLE
docs: update aws/permission.ts jsdocs

### DIFF
--- a/platform/src/components/aws/permission.ts
+++ b/platform/src/components/aws/permission.ts
@@ -1,3 +1,8 @@
+import { Prettify } from "../component.js";
+import { FunctionPermissionArgs } from "./function.js";
+
+export interface InputArgs extends Prettify<FunctionPermissionArgs> {}
+
 /**
  * The AWS Permission Linkable helper is used to define the AWS permissions included with the
  * [`sst.Linkable`](/docs/component/linkable/) component.
@@ -10,15 +15,7 @@
  *   resources: ["*"]
  * })
  * ```
- *
- * @packageDocumentation
  */
-
-import { Prettify } from "../component.js";
-import { FunctionPermissionArgs } from "./function.js";
-
-export interface InputArgs extends Prettify<FunctionPermissionArgs> {}
-
 export function permission(input: InputArgs) {
   return {
     type: "aws.permission" as const,


### PR DESCRIPTION
Update jsdocs for aws/permisson.ts helper, jsdocs wasn't being shown although defined.