### PR TITLE
unwrap Input<string[]> before spreading in server install config

### DIFF
--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -1133,10 +1133,10 @@ async function handler(event) {
                 nodejs: {
                   ...planServer.nodejs,
                   format: "esm" as const,
-                  install: [
-                    ...(args.server?.install ?? []),
-                    ...(planServer.nodejs?.install ?? [])
-                  ],
+                  install: output(args.server).apply((server) => [
+                    ...(server?.install ?? []),
+                    ...(planServer.nodejs?.install ?? []),
+                  ]),
                   loader: args.server?.loader ?? planServer.nodejs?.loader,
                 },
                 environment: output(args.environment).apply((environment) => ({


### PR DESCRIPTION
release is [broken](https://github.com/sst/sst/actions/runs/18287399258/job/52065926413)

```
Run cd platform && bun tsc --noEmit
src/components/aws/ssr-site.ts(1137,24): error TS2488: Type 'Input<string[]>' must have a '[Symbol.iterator]()' method that returns an iterator.
error: "tsc" exited with code 2
```

this pr maybe fixes that:
changed from direct spread of args.server?.install to using output(args.server).apply() to unwrap
the Input type first like its done repeatedly in that file