### PR TITLE
Disable `autoMinorVersionUpgrade` for AWS databases

### DIFF
--- a/platform/src/components/aws/aurora.ts
+++ b/platform/src/components/aws/aurora.ts
@@ -1002,6 +1002,7 @@ Listening on "${dev.host}:${dev.port}"...`,
         engineVersion: cluster.engineVersion,
         dbSubnetGroupName: cluster.dbSubnetGroupName,
         dbParameterGroupName: instanceParameterGroup.name,
+        autoMinorVersionUpgrade: false,
       };
 
       // Create primary instance

--- a/platform/src/components/aws/mysql.ts
+++ b/platform/src/components/aws/mysql.ts
@@ -699,6 +699,7 @@ Listening on "${dev.host}:${dev.port}"...`,
             maxAllocatedStorage: storage,
             multiAz,
             backupRetentionPeriod: 7,
+            autoMinorVersionUpgrade: false,
             // performance insights is only supported on .micro and .small MySQL instances
             // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
             performanceInsightsEnabled: instanceType.apply(

--- a/platform/src/components/aws/postgres-v1.ts
+++ b/platform/src/components/aws/postgres-v1.ts
@@ -344,6 +344,7 @@ export class Postgres extends Component implements Link.Linkable {
             engine: rds.EngineType.AuroraPostgresql,
             engineVersion: cluster.engineVersion,
             dbSubnetGroupName: subnetGroup?.name,
+            autoMinorVersionUpgrade: false,
           },
           { parent },
         ),

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -731,6 +731,7 @@ Listening on "${dev.host}:${dev.port}"...`,
             multiAz,
             backupRetentionPeriod: 7,
             performanceInsightsEnabled: true,
+            autoMinorVersionUpgrade: false,
             tags: {
               "sst:component-version": _version.toString(),
               "sst:lookup:password": secret.id,

--- a/platform/src/components/aws/redis-v1.ts
+++ b/platform/src/components/aws/redis-v1.ts
@@ -434,6 +434,7 @@ Listening on "${dev.host}:${dev.port}"...`,
             authToken,
             subnetGroupName: subnetGroup.name,
             securityGroupIds: vpc.securityGroups,
+            autoMinorVersionUpgrade: false,
             tags: {
               "sst:auth-token-ref": secret.id,
             },

--- a/platform/src/components/aws/redis.ts
+++ b/platform/src/components/aws/redis.ts
@@ -575,6 +575,7 @@ Listening on "${dev.host}:${dev.port}"...`,
                 subnetGroupName: subnetGroup.name,
                 parameterGroupName: parameterGroup.name,
                 securityGroupIds: vpc.securityGroups,
+                autoMinorVersionUpgrade: false,
                 tags: {
                   "sst:component-version": _version.toString(),
                   "sst:ref:secret": secret.id,


### PR DESCRIPTION
AWS databases by default auto upgrade minor versions

this ends up causing a mismatch with the Pulumi specified version

leading to confusion like in #6156