### PR TITLE
Fix Remix unused '@ts-expect-error' directive

### DIFF
--- a/platform/src/components/aws/remix.ts
+++ b/platform/src/components/aws/remix.ts
@@ -478,7 +478,7 @@ export class Remix extends SsrSite {
           if (!file) return;
 
           try {
-            // @ts-expect-error
+            // @ts-ignore
             const vite = await import("vite");
             const config = await vite.loadConfigFromFile(
               { command: "build", mode: "production" },


### PR DESCRIPTION
closes #6168 #6182

this error happens because `vite` gets installed when using Remix

making it available and triggering the `@ts-expect-error` unused warning