### PR TITLE
fix(service): correct operator precedence in health check path normalization

### DIFF
--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -1883,7 +1883,7 @@ export class Service extends Component implements Link.Linkable {
               return [
                 k,
                 {
-                  path: v.path ?? type === "application" ? "/" : undefined,
+                  path: v.path ?? (type === "application" ? "/" : undefined),
                   interval: v.interval ? toSeconds(v.interval) : 30,
                   timeout: v.timeout
                     ? toSeconds(v.timeout)


### PR DESCRIPTION
## Description

Fixes #6184

This PR fixes an operator precedence bug in the health check path normalization logic that caused custom health check paths (like `/healthz` or `/ok`) to be ignored.

## Problem

The health check path normalization code had a subtle operator precedence issue introduced in commit [9b54838](https://github.com/sst/sst/commit/9b5483892606601d07b329ee1935dc2514e1a7de) (v3.19.17):

```typescript
path: v.path ?? type === "application" ? "/" : undefined,
```

Due to JavaScript’s operator precedence rules (`===` has higher precedence than `??`), this expression was actually parsed as:

```typescript
path: (v.path ?? (type === "application")) ? "/" : undefined
```

This means the entire expression before the `?` was treated as the conditional part of the ternary operator, not the value assignment.

As a result:
- When `v.path` was defined (e.g. `"/healthz"`), it evaluated as truthy
- The ternary then resolved to `"/"`, ignoring the custom path

Example evaluation for ALB:
1. `type === "application"` → `true`
2. `v.path ?? true` → `"/healthz"` (since `v.path` is not nullish)
3. `"/healthz" ? "/" : undefined` → `"/"`

So regardless of the configured custom path, the normalized path always defaulted to `/`.

## Solution

Add explicit parentheses to enforce the intended grouping:

```typescript
path: v.path ?? (type === "application" ? "/" : undefined),
```

Now it correctly:
1. Uses `v.path` if defined
2. Falls back to `"/"` for application load balancers when `v.path` is `null/undefined`
3. Falls back to undefined for network load balancers when `v.path` is `null`/`undefined`

## Impact

Since v3.19.17, any user-defined `loadBalancer.health["<listener>"].path` was effectively ignored.

This fix ensures that custom paths are respected again in generated target group health checks.

## Testing

Verified the operator precedence behavior with:

```typescript
const type = "application";
const v = { path: "/healthz" };

const path = v.path ?? type === "application" ? "/" : undefined;

console.log(path); // "/"
```

And:

```typescript
const type = "application";
const v = { path: "/healthz" };

const path = v.path ?? (type === "application" ? "/" : undefined);


console.log(path); // "/healthz"
```

Tested with the following configuration:

```typescript
new sst.aws.Service("MyService", {
  cluster,
  loadBalancer: {
    rules: [
      { listen: "80/http", redirect: "443/https" },
      { listen: "443/https", forward: "80/http" },
    ],
    health: {
      "80/http": {
        path: "/healthz",
        successCodes: "200",
        interval: "30 seconds",
        timeout: "5 seconds",
        healthyThreshold: 3,
        unhealthyThreshold: 3,
      },
    },
  },
});
```
Before the fix: Health check path defaulted to `/` (custom path ignored)

After the fix: Health check path correctly resolves to `/healthz`

## Checklist

- [x] Tested locally
- [x] No breaking changes