### PR TITLE
Make Rust SDK `SST_KEY` environment variables optional

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -44,6 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +206,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -136,9 +247,30 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
@@ -147,10 +279,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polyval"
@@ -183,12 +356,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -196,6 +397,27 @@ name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -230,6 +452,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "sst_sdk"
 version = "0.1.0"
 dependencies = [
@@ -237,6 +496,8 @@ dependencies = [
  "base64",
  "serde",
  "serde_json",
+ "serial_test",
+ "tempfile",
  "thiserror",
 ]
 
@@ -255,6 +516,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -310,3 +584,33 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,3 +16,8 @@ base64 = "0.21.5"
 serde = "1.0.217"
 serde_json = "1.0"
 thiserror = "1.0"
+
+[dev-dependencies]
+serde = { version = "1.0.217", features = ["derive"] }
+tempfile = "3.8"
+serial_test = "3.0"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -30,25 +30,29 @@ pub struct Resource {
 
 impl Resource {
     pub fn init() -> Result<Self, ResourceError> {
-        let key = BASE64_STANDARD.decode(env::var("SST_KEY")?)?;
-        let encrypted_data = std::fs::read(env::var("SST_KEY_FILE")?)?;
+        let mut resources: HashMap<String, Value> = HashMap::new();
 
-        let nonce = GenericArray::from_slice(&[0u8; 12]);
-        let cipher = Aes256Gcm::new(GenericArray::from_slice(&key));
+        if let (Ok(sst_key), Ok(sst_key_file)) = (env::var("SST_KEY"), env::var("SST_KEY_FILE")) {
+            let key = BASE64_STANDARD.decode(sst_key)?;
+            let encrypted_data = std::fs::read(sst_key_file)?;
 
-        let auth_tag_start = encrypted_data.len() - 16;
-        let actual_ciphertext = &encrypted_data[..auth_tag_start];
-        let auth_tag = &encrypted_data[auth_tag_start..];
+            let nonce = GenericArray::from_slice(&[0u8; 12]);
+            let cipher = Aes256Gcm::new(GenericArray::from_slice(&key));
 
-        let mut ciphertext_with_tag = Vec::with_capacity(encrypted_data.len());
-        ciphertext_with_tag.extend_from_slice(actual_ciphertext);
-        ciphertext_with_tag.extend_from_slice(auth_tag);
+            let auth_tag_start = encrypted_data.len() - 16;
+            let actual_ciphertext = &encrypted_data[..auth_tag_start];
+            let auth_tag = &encrypted_data[auth_tag_start..];
 
-        let decrypted = cipher
-            .decrypt(nonce, ciphertext_with_tag.as_ref())
-            .map_err(|e| ResourceError::DecryptionError(e.to_string()))?;
+            let mut ciphertext_with_tag = Vec::with_capacity(encrypted_data.len());
+            ciphertext_with_tag.extend_from_slice(actual_ciphertext);
+            ciphertext_with_tag.extend_from_slice(auth_tag);
 
-        let mut resources: HashMap<String, Value> = serde_json::from_slice(&decrypted)?;
+            let decrypted = cipher
+                .decrypt(nonce, ciphertext_with_tag.as_ref())
+                .map_err(|e| ResourceError::DecryptionError(e.to_string()))?;
+
+            resources = serde_json::from_slice(&decrypted)?;
+        }
 
         for (key, value) in env::vars() {
             if key.starts_with("SST_RESOURCE_") {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -74,3 +74,176 @@ impl Resource {
         self.resources
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use serial_test::serial;
+    use std::env;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // Helper to clear all SST-related environment variables
+    fn clear_env_vars() {
+        env::remove_var("SST_KEY");
+        env::remove_var("SST_KEY_FILE");
+        
+        let sst_resource_vars: Vec<String> = env::vars()
+            .filter(|(key, _)| key.starts_with("SST_RESOURCE_"))
+            .map(|(key, _)| key)
+            .collect();
+        
+        for var in sst_resource_vars {
+            env::remove_var(&var);
+        }
+    }
+
+    // Helper to create an encrypted file for testing
+    fn create_encrypted_file(data: &HashMap<String, Value>) -> (TempDir, String, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("encrypted.bin");
+
+        let key = [0u8; 32];
+        let key_base64 = BASE64_STANDARD.encode(&key);
+
+        let json_data = serde_json::to_vec(data).unwrap();
+        let nonce = GenericArray::from_slice(&[0u8; 12]);
+        let cipher = Aes256Gcm::new(GenericArray::from_slice(&key));
+
+        let ciphertext = cipher.encrypt(nonce, json_data.as_ref()).unwrap();
+
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(&ciphertext).unwrap();
+
+        (temp_dir, file_path.to_str().unwrap().to_string(), key_base64)
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_without_sst_key_vars() {
+        clear_env_vars();
+
+        let resource = Resource::init();
+        assert!(resource.is_ok());
+        let resource = resource.unwrap();
+        assert_eq!(resource.resources.len(), 0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_sst_resource_env_vars() {
+        clear_env_vars();
+
+        env::set_var("SST_RESOURCE_MyBucket", r#"{"name":"my-bucket","type":"aws.s3.Bucket"}"#);
+        env::set_var("SST_RESOURCE_MyTable", r#"{"name":"my-table","type":"aws.dynamodb.Table"}"#);
+
+        let resource = Resource::init().unwrap();
+
+        assert_eq!(resource.resources.len(), 2);
+        assert!(resource.resources.contains_key("MyBucket"));
+        assert!(resource.resources.contains_key("MyTable"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_encrypted_file() {
+        clear_env_vars();
+
+        let mut data = HashMap::new();
+        data.insert("EncryptedBucket".to_string(), json!({"name": "encrypted-bucket", "type": "aws.s3.Bucket"}));
+        data.insert("EncryptedQueue".to_string(), json!({"name": "encrypted-queue", "type": "aws.sqs.Queue"}));
+
+        let (_temp_dir, file_path, key_base64) = create_encrypted_file(&data);
+
+        env::set_var("SST_KEY", &key_base64);
+        env::set_var("SST_KEY_FILE", &file_path);
+
+        let resource = Resource::init().unwrap();
+
+        assert_eq!(resource.resources.len(), 2);
+        assert!(resource.resources.contains_key("EncryptedBucket"));
+        assert!(resource.resources.contains_key("EncryptedQueue"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_both_encrypted_and_env_vars() {
+        clear_env_vars();
+
+        let mut encrypted_data = HashMap::new();
+        encrypted_data.insert("EncryptedResource".to_string(), json!({"name": "encrypted", "type": "aws.s3.Bucket"}));
+
+        let (_temp_dir, file_path, key_base64) = create_encrypted_file(&encrypted_data);
+
+        env::set_var("SST_KEY", &key_base64);
+        env::set_var("SST_KEY_FILE", &file_path);
+        env::set_var("SST_RESOURCE_EnvResource", r#"{"name":"env-resource","type":"aws.dynamodb.Table"}"#);
+
+        let resource = Resource::init().unwrap();
+
+        assert_eq!(resource.resources.len(), 2);
+        assert!(resource.resources.contains_key("EncryptedResource"));
+        assert!(resource.resources.contains_key("EnvResource"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_existing_resource() {
+        clear_env_vars();
+
+        env::set_var("SST_RESOURCE_TestBucket", r#"{"name":"test-bucket","arn":"arn:aws:s3:::test-bucket"}"#);
+
+        let resource = Resource::init().unwrap();
+
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct BucketInfo {
+            name: String,
+            arn: String,
+        }
+
+        let bucket: BucketInfo = resource.get("TestBucket").unwrap();
+        assert_eq!(bucket.name, "test-bucket");
+        assert_eq!(bucket.arn, "arn:aws:s3:::test-bucket");
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_nonexistent_resource() {
+        clear_env_vars();
+
+        let resource = Resource::init().unwrap();
+
+        let result: Result<Value, _> = resource.get("NonExistent");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ResourceError::NotFound));
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_only_sst_key() {
+        clear_env_vars();
+
+        env::set_var("SST_KEY", "dGVzdA=="); // base64 "test"
+
+        let resource = Resource::init();
+        assert!(resource.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_into_inner() {
+        clear_env_vars();
+
+        env::set_var("SST_RESOURCE_Resource1", r#"{"value":"test1"}"#);
+        env::set_var("SST_RESOURCE_Resource2", r#"{"value":"test2"}"#);
+
+        let resource = Resource::init().unwrap();
+        let inner = resource.into_inner();
+
+        assert_eq!(inner.len(), 2);
+        assert!(inner.contains_key("Resource1"));
+        assert!(inner.contains_key("Resource2"));
+    }
+}


### PR DESCRIPTION
closes #6161

the Rust SDK behaves differently than the JS SDK because it required the `SST_KEY` and `SST_KEY_FILE` env vars to be present

this PR makes them optional

i also added some tests to prevent this issue in the future