### PR TITLE
Fix wrong default value for asset purge in docs (ssr-site)

### DIFF
--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -599,7 +599,7 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
     fileOptions?: Input<Prettify<BaseSiteFileOptions>[]>;
     /**
      * Configure if files from previous deployments should be purged from the bucket.
-     * @default `true`
+     * @default `false`
      * @example
      * ```js
      * {


### PR DESCRIPTION
the actual code (line 675) is `const purge = output(args.assets).apply((assets) => assets?.purge ?? false);` which suggests to me that the actual default value is false.