### PR TITLE
Support providing a package name that is different from the provider name

### DIFF
--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -591,7 +591,7 @@ var root = &cli.Command{
 						return err
 					}
 				}
-				entry, err := project.FindProvider(pkg, pkg, "latest")
+				entry, err := project.FindProvider(pkg, "latest", pkg)
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)
 				}

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -591,7 +591,7 @@ var root = &cli.Command{
 						return err
 					}
 				}
-				entry, err := project.FindProvider(pkg, "latest")
+				entry, err := project.FindProvider(pkg, pkg, "latest")
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)
 				}

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -595,7 +595,11 @@ var root = &cli.Command{
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)
 				}
-				err = p.Add(entry.ProviderName(), entry.Version, entry.PackageOverride())
+				pkgOverride := ""
+				if entry.Name != pkg {
+					pkgOverride = entry.Package
+				}
+				err = p.Add(entry.Name, entry.Version, pkgOverride)
 				if err != nil {
 					return util.NewReadableError(err, err.Error())
 				}

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -595,7 +595,7 @@ var root = &cli.Command{
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)
 				}
-				err = p.Add(entry.Name, entry.Version)
+				err = p.Add(entry.ProviderName(), entry.Version, entry.PackageOverride())
 				if err != nil {
 					return util.NewReadableError(err, err.Error())
 				}

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -595,11 +595,15 @@ var root = &cli.Command{
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)
 				}
+				// When the user passed a full package name (e.g. @paynearme/pulumi-jetstream),
+				// use the alias as the config key and set the package override
+				providerName := entry.Name
 				pkgOverride := ""
-				if entry.Name != pkg {
+				if entry.Name == entry.Package {
+					providerName = entry.Alias
 					pkgOverride = entry.Package
 				}
-				err = p.Add(entry.Name, entry.Version, pkgOverride)
+				err = p.Add(providerName, entry.Version, pkgOverride)
 				if err != nil {
 					return util.NewReadableError(err, err.Error())
 				}

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -186,8 +186,11 @@ type Package struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	Pulumi  *struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
+		Name             string `json:"name"`
+		Version          string `json:"version"`
+		Parameterization *struct {
+			Name string `json:"name"`
+		} `json:"parameterization"`
 	}
 }
 

--- a/pkg/project/add.go
+++ b/pkg/project/add.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 )
 
-func (p *Project) Add(pkg string, version string) error {
+func (p *Project) Add(pkg string, version string, pkgName string) error {
 	var stderr bytes.Buffer
-	cmd := process.Command("node", filepath.Join(p.PathPlatformDir(), "src/ast/add.mjs"),
+	cmd := process.Command("node",
+		filepath.Join(p.PathPlatformDir(), "src/ast/add.mjs"),
 		p.PathConfig(),
 		pkg,
 		version,
+		pkgName,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderr

--- a/pkg/project/add.go
+++ b/pkg/project/add.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 )
 
-func (p *Project) Add(pkg string, version string, pkgName string) error {
+func (p *Project) Add(provider string, version string, pkg string) error {
 	var stderr bytes.Buffer
 	cmd := process.Command("node",
 		filepath.Join(p.PathPlatformDir(), "src/ast/add.mjs"),
 		p.PathConfig(),
-		pkg,
+		provider,
 		version,
-		pkgName,
+		pkg,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderr

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -156,7 +156,7 @@ func (p *Project) writeTypes() error {
 	file.WriteString(`  interface Providers {` + "\n")
 	file.WriteString(`    providers?: {` + "\n")
 	for _, entry := range p.lock {
-		file.WriteString(`      "` + entry.Name + `"?:  (_` + entry.Alias + `.ProviderArgs & { version?: string }) | boolean | string;` + "\n")
+		file.WriteString(`      "` + entry.Name + `"?:  (_` + entry.Alias + `.ProviderArgs & { package?: string, version?: string }) | boolean | string;` + "\n")
 	}
 	file.WriteString(`    }` + "\n")
 	file.WriteString(`  }` + "\n")
@@ -218,12 +218,16 @@ func (p *Project) generateProviderLock() error {
 	}
 	for name, config := range p.app.Providers {
 		n := name
+		pkgName := config.(map[string]interface{})["package"]
+		if pkgName == nil || pkgName == "" {
+			pkgName = n
+		}
 		version := config.(map[string]interface{})["version"]
 		if version == nil || version == "" {
 			version = "latest"
 		}
 		wg.Go(func() error {
-			result, err := FindProvider(n, version.(string))
+			result, err := FindProvider(n, pkgName.(string), version.(string))
 			if err != nil {
 				return err
 			}
@@ -257,10 +261,10 @@ func (p *Project) generateProviderLock() error {
 	return nil
 }
 
-func FindProvider(name string, version string) (*ProviderLockEntry, error) {
+func FindProvider(name string, pkgName string, version string) (*ProviderLockEntry, error) {
 	registry := npm.LoadRegistry()
 	for _, prefix := range []string{"@sst-provider/", "@pulumi/", "@pulumiverse/", "pulumi-", "@", ""} {
-		pkg, err := npm.Get(registry, prefix+name, version)
+		pkg, err := npm.Get(registry, prefix+pkgName, version)
 		if err != nil {
 			continue
 		}

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -289,11 +289,6 @@ func FindProvider(provider string, version string, pkg string) (*ProviderLockEnt
 			}
 		}
 		alias = strings.ReplaceAll(alias, "-", "")
-		// When the user passed a full package name (e.g. @paynearme/pulumi-jetstream),
-		// use the alias as the config key instead
-		if provider == npmPkg.Name {
-			provider = alias
-		}
 		return &ProviderLockEntry{
 			Name:    provider,
 			Package: npmPkg.Name,

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -196,25 +196,6 @@ type ProviderLockEntry struct {
 	Alias   string `json:"alias"`
 }
 
-// ProviderName returns the config key for this provider.
-// When the user passed a full package name (e.g. @paynearme/pulumi-jetstream),
-// Name equals Package, so we use the Alias instead.
-func (e *ProviderLockEntry) ProviderName() string {
-	if e.Name == e.Package {
-		return e.Alias
-	}
-	return e.Name
-}
-
-// PackageOverride returns the NPM package name when it differs from the
-// provider name, or empty string when no override is needed.
-func (e *ProviderLockEntry) PackageOverride() string {
-	if e.Name == e.Package {
-		return e.Package
-	}
-	return ""
-}
-
 type ProviderLock = []*ProviderLockEntry
 
 func (p *Project) loadProviderLock() error {
@@ -241,6 +222,7 @@ func (p *Project) generateProviderLock() error {
 	}
 	for name, config := range p.app.Providers {
 		n := name
+		// Use the explicit package name if set, otherwise default to the provider name
 		pkgName := config.(map[string]interface{})["package"]
 		if pkgName == nil || pkgName == "" {
 			pkgName = n
@@ -284,22 +266,22 @@ func (p *Project) generateProviderLock() error {
 	return nil
 }
 
-func FindProvider(name string, pkgName string, version string) (*ProviderLockEntry, error) {
+func FindProvider(provider string, pkg string, version string) (*ProviderLockEntry, error) {
 	registry := npm.LoadRegistry()
 	for _, prefix := range []string{"@sst-provider/", "@pulumi/", "@pulumiverse/", "pulumi-", "@", ""} {
-		pkg, err := npm.Get(registry, prefix+pkgName, version)
+		npmPkg, err := npm.Get(registry, prefix+pkg, version)
 		if err != nil {
 			continue
 		}
-		if pkg.Pulumi == nil {
+		if npmPkg.Pulumi == nil {
 			continue
 		}
-		alias := pkg.Pulumi.Name
+		alias := npmPkg.Pulumi.Name
 		if alias == "" || alias == "terraform-provider" {
-			if pkg.Pulumi.Parameterization != nil && pkg.Pulumi.Parameterization.Name != "" {
-				alias = pkg.Pulumi.Parameterization.Name
+			if npmPkg.Pulumi.Parameterization != nil && npmPkg.Pulumi.Parameterization.Name != "" {
+				alias = npmPkg.Pulumi.Parameterization.Name
 			} else {
-				alias = pkg.Name
+				alias = npmPkg.Name
 				alias = strings.ReplaceAll(alias, "@sst-provider", "")
 				alias = strings.ReplaceAll(alias, "/", "")
 				alias = strings.ReplaceAll(alias, "@", "")
@@ -307,14 +289,19 @@ func FindProvider(name string, pkgName string, version string) (*ProviderLockEnt
 			}
 		}
 		alias = strings.ReplaceAll(alias, "-", "")
+		// When the user passed a full package name (e.g. @paynearme/pulumi-jetstream),
+		// use the alias as the config key instead
+		if provider == npmPkg.Name {
+			provider = alias
+		}
 		return &ProviderLockEntry{
-			Name:    name,
-			Package: pkg.Name,
-			Version: pkg.Version,
+			Name:    provider,
+			Package: npmPkg.Name,
+			Version: npmPkg.Version,
 			Alias:   alias,
 		}, nil
 	}
-	return nil, fmt.Errorf("provider %s not found", name)
+	return nil, fmt.Errorf("provider %s not found", provider)
 }
 
 func (p *Project) writeProviderLock() error {

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -232,7 +232,7 @@ func (p *Project) generateProviderLock() error {
 			version = "latest"
 		}
 		wg.Go(func() error {
-			result, err := FindProvider(n, pkgName.(string), version.(string))
+			result, err := FindProvider(n, version.(string), pkgName.(string))
 			if err != nil {
 				return err
 			}
@@ -266,7 +266,7 @@ func (p *Project) generateProviderLock() error {
 	return nil
 }
 
-func FindProvider(provider string, pkg string, version string) (*ProviderLockEntry, error) {
+func FindProvider(provider string, version string, pkg string) (*ProviderLockEntry, error) {
 	registry := npm.LoadRegistry()
 	for _, prefix := range []string{"@sst-provider/", "@pulumi/", "@pulumiverse/", "pulumi-", "@", ""} {
 		npmPkg, err := npm.Get(registry, prefix+pkg, version)

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -40,6 +40,10 @@ func (p *Project) NeedsInstall() bool {
 			return false
 		}
 		config := match.(map[string]interface{})
+		pkg := config["package"]
+		if pkg != nil && pkg != "" && pkg != entry.Package {
+			return true
+		}
 		version := config["version"]
 		if version == nil || version == "" {
 			continue
@@ -192,6 +196,25 @@ type ProviderLockEntry struct {
 	Alias   string `json:"alias"`
 }
 
+// ProviderName returns the config key for this provider.
+// When the user passed a full package name (e.g. @paynearme/pulumi-jetstream),
+// Name equals Package, so we use the Alias instead.
+func (e *ProviderLockEntry) ProviderName() string {
+	if e.Name == e.Package {
+		return e.Alias
+	}
+	return e.Name
+}
+
+// PackageOverride returns the NPM package name when it differs from the
+// provider name, or empty string when no override is needed.
+func (e *ProviderLockEntry) PackageOverride() string {
+	if e.Name == e.Package {
+		return e.Package
+	}
+	return ""
+}
+
 type ProviderLock = []*ProviderLockEntry
 
 func (p *Project) loadProviderLock() error {
@@ -273,11 +296,15 @@ func FindProvider(name string, pkgName string, version string) (*ProviderLockEnt
 		}
 		alias := pkg.Pulumi.Name
 		if alias == "" || alias == "terraform-provider" {
-			alias = pkg.Name
-			alias = strings.ReplaceAll(alias, "@sst-provider", "")
-			alias = strings.ReplaceAll(alias, "/", "")
-			alias = strings.ReplaceAll(alias, "@", "")
-			alias = strings.ReplaceAll(alias, "pulumi", "")
+			if pkg.Pulumi.Parameterization != nil && pkg.Pulumi.Parameterization.Name != "" {
+				alias = pkg.Pulumi.Parameterization.Name
+			} else {
+				alias = pkg.Name
+				alias = strings.ReplaceAll(alias, "@sst-provider", "")
+				alias = strings.ReplaceAll(alias, "/", "")
+				alias = strings.ReplaceAll(alias, "@", "")
+				alias = strings.ReplaceAll(alias, "pulumi", "")
+			}
 		}
 		alias = strings.ReplaceAll(alias, "-", "")
 		return &ProviderLockEntry{

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -306,7 +306,7 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 		for provider, opts := range p.app.Providers {
 			for key, value := range opts.(map[string]interface{}) {
 				// Skip SST-only fields that Pulumi doesn't understand
-			if key == "package" || key == "version" {
+				if key == "package" {
 					continue
 				}
 				switch v := value.(type) {

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -305,7 +305,8 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 	if input.Command == "deploy" || input.Command == "diff" || input.Command == "refresh" {
 		for provider, opts := range p.app.Providers {
 			for key, value := range opts.(map[string]interface{}) {
-				if key == "package" || key == "version" {
+				// Skip SST-only fields that Pulumi doesn't understand
+			if key == "package" || key == "version" {
 					continue
 				}
 				switch v := value.(type) {

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -305,6 +305,9 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 	if input.Command == "deploy" || input.Command == "diff" || input.Command == "refresh" {
 		for provider, opts := range p.app.Providers {
 			for key, value := range opts.(map[string]interface{}) {
+				if key == "package" || key == "version" {
+					continue
+				}
 				switch v := value.(type) {
 				case map[string]interface{}:
 					bytes, err := json.Marshal(v)

--- a/platform/src/ast/add.mjs
+++ b/platform/src/ast/add.mjs
@@ -7,6 +7,7 @@ import prettier from "prettier";
 const config = process.argv[2];
 const pkg = process.argv[3];
 const version = process.argv[4];
+const pkgName = process.argv[5] || "";
 
 const code = fs.readFileSync(config);
 
@@ -83,10 +84,25 @@ if (
 ) {
   process.exit(0);
 }
-// Create a new property node for "foo: {}"
+// Create a new property node
+let newValue;
+if (pkgName) {
+  newValue = ts.factory.createObjectLiteralExpression([
+    ts.factory.createPropertyAssignment(
+      "package",
+      ts.factory.createStringLiteral(pkgName),
+    ),
+    ts.factory.createPropertyAssignment(
+      "version",
+      ts.factory.createStringLiteral(version),
+    ),
+  ], false);
+} else {
+  newValue = ts.factory.createStringLiteral(version);
+}
 const newProperty = ts.factory.createPropertyAssignment(
   ts.factory.createStringLiteral(pkg),
-  ts.factory.createStringLiteral(version),
+  newValue,
 );
 
 providersProperty.initializer.properties.push(newProperty);


### PR DESCRIPTION
Fixes https://github.com/sst/sst/issues/6203 by adding a `package` configuration option for `providers` that allows specifying the NPM package name for the provider.