### PR TITLE
feat(bucket): add lifecycle config to built-in bucket component

### DIFF
--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -165,6 +165,7 @@ export class Component extends ComponentResource {
               "aws:s3/bucketPolicy:BucketPolicy",
               "aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock",
               "aws:s3/bucketVersioningV2:BucketVersioningV2",
+              "aws:s3/bucketLifecycleConfigurationV2:BucketLifecycleConfigurationV2",
               "aws:s3/bucketWebsiteConfigurationV2:BucketWebsiteConfigurationV2",
               "aws:secretsmanager/secretVersion:SecretVersion",
               "aws:ses/domainIdentityVerification:DomainIdentityVerification",

--- a/platform/src/components/duration.ts
+++ b/platform/src/components/duration.ts
@@ -24,8 +24,10 @@ export type DurationHours = `${number} ${
   | "hour"
   | "hours"}`;
 
+export type DurationDays = `${number} ${"day" | "days"}`;
+
 export function toSeconds(
-  duration: Duration | DurationMinutes | DurationSeconds,
+  duration: Duration | DurationMinutes | DurationSeconds | DurationDays,
 ) {
   const [count, unit] = duration.split(" ");
   const countNum = parseInt(count);


### PR DESCRIPTION
Hi guys,

initially i just thought about adding docs with an example (https://github.com/sst/sst/pull/6206) but after thinking some more I feel like this is such a common use case that it warrants first party support.

This PR adds just that.

In this basic version I expose expiration and filters, not the full blown [pulumi lifecycle rules](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketlifecycleconfigurationv2/#bucketlifecycleconfigurationv2rule) for simplicity and ease of configuration. 

Happy to expand / iterate on everything if you think its required.

Cheers ✌️ 