### PR TITLE
fix: correct operator precedence in health check path configuration

### DIFF
--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -1883,7 +1883,7 @@ export class Service extends Component implements Link.Linkable {
               return [
                 k,
                 {
-                  path: v.path ?? type === "application" ? "/" : undefined,
+                  path: v.path ?? (type === "application" ? "/" : undefined),
                   interval: v.interval ? toSeconds(v.interval) : 30,
                   timeout: v.timeout
                     ? toSeconds(v.timeout)


### PR DESCRIPTION
## Summary
Fixed operator precedence bug in Service component health check path configuration. The nullish coalescing operator (`??`) was being evaluated incorrectly due to operator precedence, causing custom health check paths to be overridden.

## Changes
- Added parentheses to ensure `v.path` is checked first before applying the default based on load balancer type
- Changed line 1886 in `platform/src/components/aws/service.ts` from:
  ```typescript
  path: v.path ?? type === "application" ? "/" : undefined,
  ```
  to:
  ```typescript
  path: v.path ?? (type === "application" ? "/" : undefined),
  ```

## Impact
This fix ensures that when users specify a custom health check path in their load balancer configuration, it will be respected instead of being overridden with "/".