### PR TITLE
Set Node.js 22 as default runtime for JS Lambda functions

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1628,17 +1628,17 @@ export class Function extends Component implements Link.Linkable {
     () =>
       new RandomBytes("LambdaEncryptionKey", {
         length: 32,
-      })
+      }),
   );
 
   public static readonly appsync = lazy(() =>
-    rpc.call("Provider.Aws.Appsync", {})
+    rpc.call("Provider.Aws.Appsync", {}),
   );
 
   constructor(
     name: string,
     args: FunctionArgs,
-    opts?: ComponentResourceOptions
+    opts?: ComponentResourceOptions,
   ) {
     super(__pulumiType, name, args, opts);
     this.constructorName = name;
@@ -1646,7 +1646,7 @@ export class Function extends Component implements Link.Linkable {
     const parent = this;
     const dev = normalizeDev();
     const isContainer = all([args.python, dev]).apply(
-      ([python, dev]) => !dev && (python?.container ?? false)
+      ([python, dev]) => !dev && (python?.container ?? false),
     );
     const partition = getPartitionOutput({}, opts).partition;
     const region = getRegionOutput({}, opts).name;
@@ -1695,14 +1695,14 @@ export class Function extends Component implements Link.Linkable {
       encryptionKey: Function.encryptionKey().base64,
       runtime,
       links: output(linkData).apply((input) =>
-        Object.fromEntries(input.map((item) => [item.name, item.properties]))
+        Object.fromEntries(input.map((item) => [item.name, item.properties])),
       ),
       copyFiles,
       properties: output({ nodejs: args.nodejs, python: args.python }).apply(
         (val) => ({
           ...(val.nodejs || val.python),
           architecture,
-        })
+        }),
       ),
       dev,
     });
@@ -1735,9 +1735,9 @@ export class Function extends Component implements Link.Linkable {
                 copyFiles,
                 properties: nodejs,
               };
-            }
+            },
           );
-        })
+        }),
       ),
       _metadata: {
         handler: args.handler,
@@ -1749,7 +1749,7 @@ export class Function extends Component implements Link.Linkable {
 
     function normalizeDev() {
       return all([args.dev, args.live]).apply(
-        ([d, l]) => $dev && d !== false && l !== false
+        ([d, l]) => $dev && d !== false && l !== false,
       );
     }
 
@@ -1814,7 +1814,7 @@ export class Function extends Component implements Link.Linkable {
 
         if (logging?.retention && logging?.logGroup) {
           throw new VisibleError(
-            `Cannot set both "logging.retention" and "logging.logGroup"`
+            `Cannot set both "logging.retention" and "logging.logGroup"`,
           );
         }
 
@@ -1859,12 +1859,12 @@ export class Function extends Component implements Link.Linkable {
           url.cors === false
             ? undefined
             : url.cors === true || url.cors === undefined
-            ? defaultCors
-            : {
-                ...defaultCors,
-                ...url.cors,
-                maxAge: url.cors.maxAge && toSeconds(url.cors.maxAge),
-              };
+              ? defaultCors
+              : {
+                  ...defaultCors,
+                  ...url.cors,
+                  maxAge: url.cors.maxAge && toSeconds(url.cors.maxAge),
+                };
 
         return {
           authorization,
@@ -1882,7 +1882,7 @@ export class Function extends Component implements Link.Linkable {
             const to = entry.to || entry.from;
             if (path.isAbsolute(to)) {
               throw new VisibleError(
-                `Copy destination path "${to}" must be relative`
+                `Copy destination path "${to}" must be relative`,
               );
             }
 
@@ -1890,8 +1890,8 @@ export class Function extends Component implements Link.Linkable {
             const isDir = stats.isDirectory();
 
             return { from, to, isDir };
-          })
-        )
+          }),
+        ),
       );
     }
 
@@ -1912,7 +1912,7 @@ export class Function extends Component implements Link.Linkable {
         ]).apply(([id, natGateways, natInstances]) => {
           if (natGateways.length === 0 && natInstances.length === 0) {
             warnOnce(
-              `\nWarning: One or more functions are deployed in the "${id}" VPC, which does not have a NAT gateway. As a result, these functions cannot access the internet. If your functions need internet access, enable it by setting the "nat" prop on the "Vpc" component.\n`
+              `\nWarning: One or more functions are deployed in the "${id}" VPC, which does not have a NAT gateway. As a result, these functions cannot access the internet. If your functions need internet access, enable it by setting the "nat" prop on the "Vpc" component.\n`,
             );
           }
           return result;
@@ -1923,7 +1923,7 @@ export class Function extends Component implements Link.Linkable {
         // "vpc" is object
         if (vpc.subnets) {
           throw new VisibleError(
-            `The "vpc.subnets" property has been renamed to "vpc.privateSubnets". Update your code to use "vpc.privateSubnets" instead.`
+            `The "vpc.subnets" property has been renamed to "vpc.privateSubnets". Update your code to use "vpc.privateSubnets" instead.`,
           );
         }
 
@@ -1968,7 +1968,7 @@ export class Function extends Component implements Link.Linkable {
             bundle: buildResult.out,
             sourcemaps: buildResult.sourcemaps,
           };
-        }
+        },
       );
     }
 
@@ -2010,12 +2010,12 @@ export class Function extends Component implements Link.Linkable {
           // Validate handler file exists
           const newHandlerFileExt = [".js", ".mjs", ".cjs"].find((ext) =>
             fs.existsSync(
-              path.join(bundle!, handlerDir, oldHandlerFileName + ext)
-            )
+              path.join(bundle!, handlerDir, oldHandlerFileName + ext),
+            ),
           );
           if (!newHandlerFileExt) {
             throw new VisibleError(
-              `Could not find handler file "${handler}" for function "${name}"`
+              `Could not find handler file "${handler}" for function "${name}"`,
             );
           }
 
@@ -2028,13 +2028,13 @@ export class Function extends Component implements Link.Linkable {
               acc.inner.push(item);
               return acc;
             },
-            { outer: [] as string[], inner: [] as string[] }
+            { outer: [] as string[], inner: [] as string[] },
           );
 
           return {
             handler: path.posix.join(
               handlerDir,
-              `${newHandlerFileName}.${newHandlerFunction}`
+              `${newHandlerFileName}.${newHandlerFunction}`,
             ),
             wrapper: {
               name: path.posix.join(handlerDir, `${newHandlerFileName}.mjs`),
@@ -2057,7 +2057,7 @@ export class Function extends Component implements Link.Linkable {
                   ].join("\n"),
             },
           };
-        }
+        },
       );
       return {
         handler: ret.handler,
@@ -2071,7 +2071,7 @@ export class Function extends Component implements Link.Linkable {
           `${name}Role`,
           output(args.role).apply(parseRoleArn).roleName,
           {},
-          { parent }
+          { parent },
         );
       }
 
@@ -2106,7 +2106,7 @@ export class Function extends Component implements Link.Linkable {
               actions: item.actions,
               resources: item.resources,
             })),
-          })
+          }),
       );
 
       return new iam.Role(
@@ -2142,7 +2142,7 @@ export class Function extends Component implements Link.Linkable {
             // if there are no statements, do not add an inline policy.
             // adding an inline policy with no statements will cause an error.
             inlinePolicies: policy.apply(({ statements }) =>
-              statements ? [{ name: "inline", policy: policy.json }] : []
+              statements ? [{ name: "inline", policy: policy.json }] : [],
             ),
             managedPolicyArns: all([logging, policies]).apply(
               ([logging, policies]) => [
@@ -2157,11 +2157,11 @@ export class Function extends Component implements Link.Linkable {
                       interpolate`arn:${partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole`,
                     ]
                   : []),
-              ]
+              ],
             ),
           },
-          { parent }
-        )
+          { parent },
+        ),
       );
     }
 
@@ -2189,7 +2189,7 @@ export class Function extends Component implements Link.Linkable {
                 location: path.join(
                   $cli.paths.work,
                   "artifacts",
-                  `${name}-src`
+                  `${name}-src`,
                 ),
               },
               cacheFrom: [
@@ -2211,7 +2211,7 @@ export class Function extends Component implements Link.Linkable {
               ],
               platforms: [
                 architecture.apply((v) =>
-                  v === "arm64" ? "linux/arm64" : "linux/amd64"
+                  v === "arm64" ? "linux/arm64" : "linux/amd64",
                 ),
               ],
               push: true,
@@ -2223,9 +2223,9 @@ export class Function extends Component implements Link.Linkable {
                 })),
               ],
             },
-            { parent }
+            { parent },
           );
-        }
+        },
       );
     }
 
@@ -2258,7 +2258,7 @@ export class Function extends Component implements Link.Linkable {
             $cli.paths.work,
             "artifacts",
             name,
-            "code.zip"
+            "code.zip",
           );
           await fs.promises.mkdir(path.dirname(zipPath), {
             recursive: true,
@@ -2307,7 +2307,7 @@ export class Function extends Component implements Link.Linkable {
                 ...found.map((file) => ({
                   from: path.join(item.from, file),
                   to: path.join(item.to, file),
-                }))
+                })),
               );
             }
             files.sort((a, b) => a.to.localeCompare(b.to));
@@ -2334,7 +2334,7 @@ export class Function extends Component implements Link.Linkable {
           hash.update(await fs.promises.readFile(zipPath, "utf-8"));
           const hashValue = hash.digest("hex");
           const assetBucket = region.apply((region) =>
-            bootstrap.forRegion(region).then((d) => d.asset)
+            bootstrap.forRegion(region).then((d) => d.asset),
           );
           if (logGroupArn && sourcemaps) {
             let index = 0;
@@ -2343,12 +2343,12 @@ export class Function extends Component implements Link.Linkable {
                 `${name}Sourcemap${index}`,
                 {
                   key: interpolate`sourcemap/${logGroupArn}/${hashValue}.${path.basename(
-                    file
+                    file,
                   )}`,
                   bucket: assetBucket,
                   source: new asset.FileAsset(file),
                 },
-                { parent, retainOnDelete: true }
+                { parent, retainOnDelete: true },
               );
               index++;
             }
@@ -2361,9 +2361,9 @@ export class Function extends Component implements Link.Linkable {
               bucket: assetBucket,
               source: new asset.FileArchive(zipPath),
             },
-            { parent }
+            { parent },
           );
-        }
+        },
       );
     }
 
@@ -2382,8 +2382,8 @@ export class Function extends Component implements Link.Linkable {
               }`,
               retentionInDays: RETENTION[logging.retention],
             },
-            { parent, ignoreChanges: ["name"] }
-          )
+            { parent, ignoreChanges: ["name"] },
+          ),
         );
       });
     }
@@ -2444,8 +2444,8 @@ export class Function extends Component implements Link.Linkable {
               ...(isContainer
                 ? {
                     packageType: "Image",
-                    imageUri: imageAsset!.ref.apply((ref) =>
-                      ref?.replace(":latest", "")
+                    imageUri: imageAsset!.ref.apply(
+                      (ref) => ref?.replace(":latest", ""),
                     ),
                     imageConfig: {
                       commands: [
@@ -2468,11 +2468,11 @@ export class Function extends Component implements Link.Linkable {
                     s3Key: zipAsset!.key,
                     handler: unsecret(handler),
                     runtime: runtime.apply((v) =>
-                      v === "go" || v === "rust" ? "provided.al2023" : v
+                      v === "go" || v === "rust" ? "provided.al2023" : v,
                     ),
                   }),
             },
-            { parent }
+            { parent },
           );
           return new lambda.Function(
             transformed[0],
@@ -2482,7 +2482,7 @@ export class Function extends Component implements Link.Linkable {
                 ? {
                     description: transformed[1].description
                       ? output(transformed[1].description).apply(
-                          (v) => `${v.substring(0, 240)} (live)`
+                          (v) => `${v.substring(0, 240)} (live)`,
                         )
                       : "live",
                     runtime: "provided.al2023",
@@ -2490,9 +2490,9 @@ export class Function extends Component implements Link.Linkable {
                   }
                 : {}),
             },
-            transformed[2]
+            transformed[2],
           );
-        }
+        },
       );
     }
 
@@ -2507,11 +2507,11 @@ export class Function extends Component implements Link.Linkable {
             functionName: fn.name,
             authorizationType: url.authorization === "iam" ? "AWS_IAM" : "NONE",
             invokeMode: streaming.apply((streaming) =>
-              streaming ? "RESPONSE_STREAM" : "BUFFERED"
+              streaming ? "RESPONSE_STREAM" : "BUFFERED",
             ),
             cors: url.cors,
           },
-          { parent }
+          { parent },
         );
         if (!url.route) return fnUrl.functionUrl;
 
@@ -2533,7 +2533,7 @@ export class Function extends Component implements Link.Linkable {
             })),
             purge: false,
           },
-          { parent }
+          { parent },
         );
         new KvRoutesUpdate(
           `${name}RoutesUpdate`,
@@ -2543,11 +2543,11 @@ export class Function extends Component implements Link.Linkable {
             key: "routes",
             entry: url.route.apply((route) =>
               ["url", routeNamespace, route.hostPattern, route.pathPrefix].join(
-                ","
-              )
+                ",",
+              ),
             ),
           },
-          { parent }
+          { parent },
         );
         return url.route.routerUrl;
       });
@@ -2562,7 +2562,7 @@ export class Function extends Component implements Link.Linkable {
 
           if (publish !== true) {
             throw new VisibleError(
-              `Provisioned concurrency requires function versioning. Set "versioning: true" to enable function versioning.`
+              `Provisioned concurrency requires function versioning. Set "versioning: true" to enable function versioning.`,
             );
           }
 
@@ -2573,9 +2573,9 @@ export class Function extends Component implements Link.Linkable {
               qualifier: fn.version,
               provisionedConcurrentExecutions: concurrency.provisioned,
             },
-            { parent }
+            { parent },
           );
-        }
+        },
       );
     }
 
@@ -2592,8 +2592,8 @@ export class Function extends Component implements Link.Linkable {
             functionName: fn.name,
             maximumRetryAttempts: args.retries,
           },
-          { parent }
-        )
+          { parent },
+        ),
       );
     }
   }
@@ -2629,7 +2629,7 @@ export class Function extends Component implements Link.Linkable {
     return this.urlEndpoint.apply((url) => {
       if (!url) {
         throw new VisibleError(
-          `Function URL is not enabled. Enable it with "url: true".`
+          `Function URL is not enabled. Enable it with "url: true".`,
         );
       }
       return url;
@@ -2680,7 +2680,7 @@ export class Function extends Component implements Link.Linkable {
         environment,
         region: getRegionOutput(undefined, { parent: this }).name,
       },
-      { parent: this }
+      { parent: this },
     );
   }
 
@@ -2690,7 +2690,7 @@ export class Function extends Component implements Link.Linkable {
     definition: Input<string | FunctionArgs>,
     override: Pick<FunctionArgs, "description" | "permissions">,
     argsTransform?: Transform<FunctionArgs>,
-    opts?: ComponentResourceOptions
+    opts?: ComponentResourceOptions,
   ) {
     return output(definition).apply((definition) => {
       if (typeof definition === "string") {
@@ -2699,8 +2699,8 @@ export class Function extends Component implements Link.Linkable {
             argsTransform,
             name,
             { handler: definition, ...override },
-            opts || {}
-          )
+            opts || {},
+          ),
         );
       } else if (definition.handler) {
         return new Function(
@@ -2718,8 +2718,8 @@ export class Function extends Component implements Link.Linkable {
                 ...(overridePermissions ?? []),
               ]),
             },
-            opts || {}
-          )
+            opts || {},
+          ),
         );
       }
       throw new Error(`Invalid function definition for the "${name}" Function`);

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -306,7 +306,7 @@ export interface FunctionArgs {
    * Node.js and Golang are officially supported. While, Python and Rust are
    * community supported. Support for other runtimes are on the roadmap.
    *
-   * @default `"nodejs20.x"`
+   * @default `"nodejs22.x"`
    *
    * @example
    * ```js
@@ -667,53 +667,53 @@ export interface FunctionArgs {
   logging?: Input<
     | false
     | {
-      /**
-       * The duration the function logs are kept in CloudWatch.
-       *
-       * Not application when an existing log group is provided.
-       *
-       * @default `1 month`
-       * @example
-       * ```js
-       * {
-       *   logging: {
-       *     retention: "forever"
-       *   }
-       * }
-       * ```
-       */
-      retention?: Input<keyof typeof RETENTION>;
-      /**
-       * Assigns the given CloudWatch log group name to the function. This allows you to pass in a previously created log group.
-       *
-       * By default, the function creates a new log group when it's created.
-       *
-       * @default Creates a log group
-       * @example
-       * ```js
-       * {
-       *   logging: {
-       *     logGroup: "/existing/log-group"
-       *   }
-       * }
-       * ```
-       */
-      logGroup?: Input<string>;
-      /**
-       * The [log format](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-advanced.html)
-       * of the Lambda function.
-       * @default `"text"`
-       * @example
-       * ```js
-       * {
-       *   logging: {
-       *     format: "json"
-       *   }
-       * }
-       * ```
-       */
-      format?: Input<"text" | "json">;
-    }
+        /**
+         * The duration the function logs are kept in CloudWatch.
+         *
+         * Not application when an existing log group is provided.
+         *
+         * @default `1 month`
+         * @example
+         * ```js
+         * {
+         *   logging: {
+         *     retention: "forever"
+         *   }
+         * }
+         * ```
+         */
+        retention?: Input<keyof typeof RETENTION>;
+        /**
+         * Assigns the given CloudWatch log group name to the function. This allows you to pass in a previously created log group.
+         *
+         * By default, the function creates a new log group when it's created.
+         *
+         * @default Creates a log group
+         * @example
+         * ```js
+         * {
+         *   logging: {
+         *     logGroup: "/existing/log-group"
+         *   }
+         * }
+         * ```
+         */
+        logGroup?: Input<string>;
+        /**
+         * The [log format](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-advanced.html)
+         * of the Lambda function.
+         * @default `"text"`
+         * @example
+         * ```js
+         * {
+         *   logging: {
+         *     format: "json"
+         *   }
+         * }
+         * ```
+         */
+        format?: Input<"text" | "json">;
+      }
   >;
   /**
    * The [architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html)
@@ -775,137 +775,137 @@ export interface FunctionArgs {
   url?: Input<
     | boolean
     | {
-      /**
-       * @deprecated The `url.router` prop is now the recommended way to serve your
-       * function URL through a `Router` component.
-       */
-      route?: Prettify<RouterRouteArgsDeprecated>;
-      /**
-       * Serve your function URL through a `Router` instead of a standalone Function URL.
-       *
-       * By default, this component creates a direct function URL endpoint. But you might
-       * want to serve it through the distribution of your `Router` as a:
-       *
-       * - A path like `/api/users`
-       * - A subdomain like `api.example.com`
-       * - Or a combined pattern like `dev.example.com/api`
-       *
-       * @example
-       *
-       * To serve your function **from a path**, you'll need to configure the root domain
-       * in your `Router` component.
-       *
-       * ```ts title="sst.config.ts" {2}
-       * const router = new sst.aws.Router("Router", {
-       *   domain: "example.com"
-       * });
-       * ```
-       *
-       * Now set the `router` and the `path` in the `url` prop.
-       *
-       * ```ts {4,5}
-       * {
-       *   url: {
-       *     router: {
-       *       instance: router,
-       *       path: "/api/users"
-       *     }
-       *   }
-       * }
-       * ```
-       *
-       * To serve your function **from a subdomain**, you'll need to configure the
-       * domain in your `Router` component to match both the root and the subdomain.
-       *
-       * ```ts title="sst.config.ts" {3,4}
-       * const router = new sst.aws.Router("Router", {
-       *   domain: {
-       *     name: "example.com",
-       *     aliases: ["*.example.com"]
-       *   }
-       * });
-       * ```
-       *
-       * Now set the `domain` in the `router` prop.
-       *
-       * ```ts {5}
-       * {
-       *   url: {
-       *     router: {
-       *       instance: router,
-       *       domain: "api.example.com"
-       *     }
-       *   }
-       * }
-       * ```
-       *
-       * Finally, to serve your function **from a combined pattern** like
-       * `dev.example.com/api`, you'll need to configure the domain in your `Router` to
-       * match the subdomain.
-       *
-       * ```ts title="sst.config.ts" {3,4}
-       * const router = new sst.aws.Router("Router", {
-       *   domain: {
-       *     name: "example.com",
-       *     aliases: ["*.example.com"]
-       *   }
-       * });
-       * ```
-       *
-       * And set the `domain` and the `path`.
-       *
-       * ```ts {5,6}
-       * {
-       *   url: {
-       *     router: {
-       *       instance: router,
-       *       domain: "dev.example.com",
-       *       path: "/api/users"
-       *     }
-       *   }
-       * }
-       * ```
-       */
-      router?: Prettify<RouterRouteArgs>;
-      /**
-       * The authorization used for the function URL. Supports [IAM authorization](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
-       * @default `"none"`
-       * @example
-       * ```js
-       * {
-       *   url: {
-       *     authorization: "iam"
-       *   }
-       * }
-       * ```
-       */
-      authorization?: Input<"none" | "iam">;
-      /**
-       * Customize the CORS (Cross-origin resource sharing) settings for the function URL.
-       * @default `true`
-       * @example
-       * Disable CORS.
-       * ```js
-       * {
-       *   url: {
-       *     cors: false
-       *   }
-       * }
-       * ```
-       * Only enable the `GET` and `POST` methods for `https://example.com`.
-       * ```js
-       * {
-       *   url: {
-       *     cors: {
-       *       allowMethods: ["GET", "POST"],
-       *       allowOrigins: ["https://example.com"]
-       *     }
-       *   }
-       * }
-       * ```
-       */
-      cors?: Input<boolean | Prettify<FunctionUrlCorsArgs>>;
-    }
+        /**
+         * @deprecated The `url.router` prop is now the recommended way to serve your
+         * function URL through a `Router` component.
+         */
+        route?: Prettify<RouterRouteArgsDeprecated>;
+        /**
+         * Serve your function URL through a `Router` instead of a standalone Function URL.
+         *
+         * By default, this component creates a direct function URL endpoint. But you might
+         * want to serve it through the distribution of your `Router` as a:
+         *
+         * - A path like `/api/users`
+         * - A subdomain like `api.example.com`
+         * - Or a combined pattern like `dev.example.com/api`
+         *
+         * @example
+         *
+         * To serve your function **from a path**, you'll need to configure the root domain
+         * in your `Router` component.
+         *
+         * ```ts title="sst.config.ts" {2}
+         * const router = new sst.aws.Router("Router", {
+         *   domain: "example.com"
+         * });
+         * ```
+         *
+         * Now set the `router` and the `path` in the `url` prop.
+         *
+         * ```ts {4,5}
+         * {
+         *   url: {
+         *     router: {
+         *       instance: router,
+         *       path: "/api/users"
+         *     }
+         *   }
+         * }
+         * ```
+         *
+         * To serve your function **from a subdomain**, you'll need to configure the
+         * domain in your `Router` component to match both the root and the subdomain.
+         *
+         * ```ts title="sst.config.ts" {3,4}
+         * const router = new sst.aws.Router("Router", {
+         *   domain: {
+         *     name: "example.com",
+         *     aliases: ["*.example.com"]
+         *   }
+         * });
+         * ```
+         *
+         * Now set the `domain` in the `router` prop.
+         *
+         * ```ts {5}
+         * {
+         *   url: {
+         *     router: {
+         *       instance: router,
+         *       domain: "api.example.com"
+         *     }
+         *   }
+         * }
+         * ```
+         *
+         * Finally, to serve your function **from a combined pattern** like
+         * `dev.example.com/api`, you'll need to configure the domain in your `Router` to
+         * match the subdomain.
+         *
+         * ```ts title="sst.config.ts" {3,4}
+         * const router = new sst.aws.Router("Router", {
+         *   domain: {
+         *     name: "example.com",
+         *     aliases: ["*.example.com"]
+         *   }
+         * });
+         * ```
+         *
+         * And set the `domain` and the `path`.
+         *
+         * ```ts {5,6}
+         * {
+         *   url: {
+         *     router: {
+         *       instance: router,
+         *       domain: "dev.example.com",
+         *       path: "/api/users"
+         *     }
+         *   }
+         * }
+         * ```
+         */
+        router?: Prettify<RouterRouteArgs>;
+        /**
+         * The authorization used for the function URL. Supports [IAM authorization](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
+         * @default `"none"`
+         * @example
+         * ```js
+         * {
+         *   url: {
+         *     authorization: "iam"
+         *   }
+         * }
+         * ```
+         */
+        authorization?: Input<"none" | "iam">;
+        /**
+         * Customize the CORS (Cross-origin resource sharing) settings for the function URL.
+         * @default `true`
+         * @example
+         * Disable CORS.
+         * ```js
+         * {
+         *   url: {
+         *     cors: false
+         *   }
+         * }
+         * ```
+         * Only enable the `GET` and `POST` methods for `https://example.com`.
+         * ```js
+         * {
+         *   url: {
+         *     cors: {
+         *       allowMethods: ["GET", "POST"],
+         *       allowOrigins: ["https://example.com"]
+         *     }
+         *   }
+         * }
+         * ```
+         */
+        cors?: Input<boolean | Prettify<FunctionUrlCorsArgs>>;
+      }
   >;
   /**
    * Configure how your function is bundled.
@@ -1367,22 +1367,22 @@ export interface FunctionArgs {
    * ```
    */
   vpc?:
-  | Vpc
-  | Input<{
-    /**
-     * A list of VPC security group IDs.
-     */
-    securityGroups: Input<Input<string>[]>;
-    /**
-     * A list of VPC subnet IDs.
-     */
-    privateSubnets: Input<Input<string>[]>;
-    /**
-     * A list of VPC subnet IDs.
-     * @deprecated Use `privateSubnets` instead.
-     */
-    subnets?: Input<Input<string>[]>;
-  }>;
+    | Vpc
+    | Input<{
+        /**
+         * A list of VPC security group IDs.
+         */
+        securityGroups: Input<Input<string>[]>;
+        /**
+         * A list of VPC subnet IDs.
+         */
+        privateSubnets: Input<Input<string>[]>;
+        /**
+         * A list of VPC subnet IDs.
+         * @deprecated Use `privateSubnets` instead.
+         */
+        subnets?: Input<Input<string>[]>;
+      }>;
 
   /**
    * Hook into the Lambda function build process.
@@ -1628,17 +1628,17 @@ export class Function extends Component implements Link.Linkable {
     () =>
       new RandomBytes("LambdaEncryptionKey", {
         length: 32,
-      }),
+      })
   );
 
   public static readonly appsync = lazy(() =>
-    rpc.call("Provider.Aws.Appsync", {}),
+    rpc.call("Provider.Aws.Appsync", {})
   );
 
   constructor(
     name: string,
     args: FunctionArgs,
-    opts?: ComponentResourceOptions,
+    opts?: ComponentResourceOptions
   ) {
     super(__pulumiType, name, args, opts);
     this.constructorName = name;
@@ -1646,13 +1646,13 @@ export class Function extends Component implements Link.Linkable {
     const parent = this;
     const dev = normalizeDev();
     const isContainer = all([args.python, dev]).apply(
-      ([python, dev]) => !dev && (python?.container ?? false),
+      ([python, dev]) => !dev && (python?.container ?? false)
     );
     const partition = getPartitionOutput({}, opts).partition;
     const region = getRegionOutput({}, opts).name;
     const bootstrapData = region.apply((region) => bootstrap.forRegion(region));
     const injections = normalizeInjections();
-    const runtime = output(args.runtime ?? "nodejs20.x");
+    const runtime = output(args.runtime ?? "nodejs22.x");
     const timeout = normalizeTimeout();
     const memory = normalizeMemory();
     const storage = output(args.storage).apply((v) => v ?? "512 MB");
@@ -1695,14 +1695,14 @@ export class Function extends Component implements Link.Linkable {
       encryptionKey: Function.encryptionKey().base64,
       runtime,
       links: output(linkData).apply((input) =>
-        Object.fromEntries(input.map((item) => [item.name, item.properties])),
+        Object.fromEntries(input.map((item) => [item.name, item.properties]))
       ),
       copyFiles,
       properties: output({ nodejs: args.nodejs, python: args.python }).apply(
         (val) => ({
           ...(val.nodejs || val.python),
           architecture,
-        }),
+        })
       ),
       dev,
     });
@@ -1731,13 +1731,13 @@ export class Function extends Component implements Link.Linkable {
                 links,
                 handler: handler,
                 bundle: bundle,
-                runtime: runtime || "nodejs20.x",
+                runtime: runtime || "nodejs22.x",
                 copyFiles,
                 properties: nodejs,
               };
-            },
+            }
           );
-        }),
+        })
       ),
       _metadata: {
         handler: args.handler,
@@ -1749,7 +1749,7 @@ export class Function extends Component implements Link.Linkable {
 
     function normalizeDev() {
       return all([args.dev, args.live]).apply(
-        ([d, l]) => $dev && d !== false && l !== false,
+        ([d, l]) => $dev && d !== false && l !== false
       );
     }
 
@@ -1814,7 +1814,7 @@ export class Function extends Component implements Link.Linkable {
 
         if (logging?.retention && logging?.logGroup) {
           throw new VisibleError(
-            `Cannot set both "logging.retention" and "logging.logGroup"`,
+            `Cannot set both "logging.retention" and "logging.logGroup"`
           );
         }
 
@@ -1859,8 +1859,8 @@ export class Function extends Component implements Link.Linkable {
           url.cors === false
             ? undefined
             : url.cors === true || url.cors === undefined
-              ? defaultCors
-              : {
+            ? defaultCors
+            : {
                 ...defaultCors,
                 ...url.cors,
                 maxAge: url.cors.maxAge && toSeconds(url.cors.maxAge),
@@ -1882,7 +1882,7 @@ export class Function extends Component implements Link.Linkable {
             const to = entry.to || entry.from;
             if (path.isAbsolute(to)) {
               throw new VisibleError(
-                `Copy destination path "${to}" must be relative`,
+                `Copy destination path "${to}" must be relative`
               );
             }
 
@@ -1890,8 +1890,8 @@ export class Function extends Component implements Link.Linkable {
             const isDir = stats.isDirectory();
 
             return { from, to, isDir };
-          }),
-        ),
+          })
+        )
       );
     }
 
@@ -1912,7 +1912,7 @@ export class Function extends Component implements Link.Linkable {
         ]).apply(([id, natGateways, natInstances]) => {
           if (natGateways.length === 0 && natInstances.length === 0) {
             warnOnce(
-              `\nWarning: One or more functions are deployed in the "${id}" VPC, which does not have a NAT gateway. As a result, these functions cannot access the internet. If your functions need internet access, enable it by setting the "nat" prop on the "Vpc" component.\n`,
+              `\nWarning: One or more functions are deployed in the "${id}" VPC, which does not have a NAT gateway. As a result, these functions cannot access the internet. If your functions need internet access, enable it by setting the "nat" prop on the "Vpc" component.\n`
             );
           }
           return result;
@@ -1923,7 +1923,7 @@ export class Function extends Component implements Link.Linkable {
         // "vpc" is object
         if (vpc.subnets) {
           throw new VisibleError(
-            `The "vpc.subnets" property has been renamed to "vpc.privateSubnets". Update your code to use "vpc.privateSubnets" instead.`,
+            `The "vpc.subnets" property has been renamed to "vpc.privateSubnets". Update your code to use "vpc.privateSubnets" instead.`
           );
         }
 
@@ -1968,7 +1968,7 @@ export class Function extends Component implements Link.Linkable {
             bundle: buildResult.out,
             sourcemaps: buildResult.sourcemaps,
           };
-        },
+        }
       );
     }
 
@@ -2010,12 +2010,12 @@ export class Function extends Component implements Link.Linkable {
           // Validate handler file exists
           const newHandlerFileExt = [".js", ".mjs", ".cjs"].find((ext) =>
             fs.existsSync(
-              path.join(bundle!, handlerDir, oldHandlerFileName + ext),
-            ),
+              path.join(bundle!, handlerDir, oldHandlerFileName + ext)
+            )
           );
           if (!newHandlerFileExt) {
             throw new VisibleError(
-              `Could not find handler file "${handler}" for function "${name}"`,
+              `Could not find handler file "${handler}" for function "${name}"`
             );
           }
 
@@ -2028,36 +2028,36 @@ export class Function extends Component implements Link.Linkable {
               acc.inner.push(item);
               return acc;
             },
-            { outer: [] as string[], inner: [] as string[] },
+            { outer: [] as string[], inner: [] as string[] }
           );
 
           return {
             handler: path.posix.join(
               handlerDir,
-              `${newHandlerFileName}.${newHandlerFunction}`,
+              `${newHandlerFileName}.${newHandlerFunction}`
             ),
             wrapper: {
               name: path.posix.join(handlerDir, `${newHandlerFileName}.mjs`),
               content: streaming
                 ? [
-                  ...split.outer,
-                  `export const ${newHandlerFunction} = awslambda.streamifyResponse(async (event, responseStream, context) => {`,
-                  ...split.inner,
-                  `  const { ${oldHandlerFunction}: rawHandler} = await import("./${oldHandlerFileName}${newHandlerFileExt}");`,
-                  `  return rawHandler(event, responseStream, context);`,
-                  `});`,
-                ].join("\n")
+                    ...split.outer,
+                    `export const ${newHandlerFunction} = awslambda.streamifyResponse(async (event, responseStream, context) => {`,
+                    ...split.inner,
+                    `  const { ${oldHandlerFunction}: rawHandler} = await import("./${oldHandlerFileName}${newHandlerFileExt}");`,
+                    `  return rawHandler(event, responseStream, context);`,
+                    `});`,
+                  ].join("\n")
                 : [
-                  ...split.outer,
-                  `export const ${newHandlerFunction} = async (event, context) => {`,
-                  ...split.inner,
-                  `  const { ${oldHandlerFunction}: rawHandler} = await import("./${oldHandlerFileName}${newHandlerFileExt}");`,
-                  `  return rawHandler(event, context);`,
-                  `};`,
-                ].join("\n"),
+                    ...split.outer,
+                    `export const ${newHandlerFunction} = async (event, context) => {`,
+                    ...split.inner,
+                    `  const { ${oldHandlerFunction}: rawHandler} = await import("./${oldHandlerFileName}${newHandlerFileExt}");`,
+                    `  return rawHandler(event, context);`,
+                    `};`,
+                  ].join("\n"),
             },
           };
-        },
+        }
       );
       return {
         handler: ret.handler,
@@ -2071,7 +2071,7 @@ export class Function extends Component implements Link.Linkable {
           `${name}Role`,
           output(args.role).apply(parseRoleArn).roleName,
           {},
-          { parent },
+          { parent }
         );
       }
 
@@ -2083,20 +2083,20 @@ export class Function extends Component implements Link.Linkable {
               ...linkPermissions,
               ...(dev
                 ? [
-                  {
-                    effect: "allow",
-                    actions: ["appsync:*"],
-                    resources: ["*"],
-                  },
-                  {
-                    effect: "allow",
-                    actions: ["s3:*"],
-                    resources: [
-                      interpolate`arn:${partition}:s3:::${bootstrapData.asset}`,
-                      interpolate`arn:${partition}:s3:::${bootstrapData.asset}/*`,
-                    ],
-                  },
-                ]
+                    {
+                      effect: "allow",
+                      actions: ["appsync:*"],
+                      resources: ["*"],
+                    },
+                    {
+                      effect: "allow",
+                      actions: ["s3:*"],
+                      resources: [
+                        interpolate`arn:${partition}:s3:::${bootstrapData.asset}`,
+                        interpolate`arn:${partition}:s3:::${bootstrapData.asset}/*`,
+                      ],
+                    },
+                  ]
                 : []),
             ].map((item) => ({
               effect: (() => {
@@ -2106,7 +2106,7 @@ export class Function extends Component implements Link.Linkable {
               actions: item.actions,
               resources: item.resources,
             })),
-          }),
+          })
       );
 
       return new iam.Role(
@@ -2116,51 +2116,52 @@ export class Function extends Component implements Link.Linkable {
           {
             assumeRolePolicy: !dev
               ? iam.assumeRolePolicyForPrincipal({
-                Service: "lambda.amazonaws.com",
-              })
+                  Service: "lambda.amazonaws.com",
+                })
               : iam.getPolicyDocumentOutput({
-                statements: [
-                  {
-                    actions: ["sts:AssumeRole"],
-                    principals: [
-                      {
-                        type: "Service",
-                        identifiers: ["lambda.amazonaws.com"],
-                      },
-                      {
-                        type: "AWS",
-                        identifiers: [
-                          interpolate`arn:${partition}:iam::${getCallerIdentityOutput({}, opts).accountId
+                  statements: [
+                    {
+                      actions: ["sts:AssumeRole"],
+                      principals: [
+                        {
+                          type: "Service",
+                          identifiers: ["lambda.amazonaws.com"],
+                        },
+                        {
+                          type: "AWS",
+                          identifiers: [
+                            interpolate`arn:${partition}:iam::${
+                              getCallerIdentityOutput({}, opts).accountId
                             }:root`,
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              }).json,
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                }).json,
             // if there are no statements, do not add an inline policy.
             // adding an inline policy with no statements will cause an error.
             inlinePolicies: policy.apply(({ statements }) =>
-              statements ? [{ name: "inline", policy: policy.json }] : [],
+              statements ? [{ name: "inline", policy: policy.json }] : []
             ),
             managedPolicyArns: all([logging, policies]).apply(
               ([logging, policies]) => [
                 ...policies,
                 ...(logging
                   ? [
-                    interpolate`arn:${partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole`,
-                  ]
+                      interpolate`arn:${partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole`,
+                    ]
                   : []),
                 ...(vpc
                   ? [
-                    interpolate`arn:${partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole`,
-                  ]
+                      interpolate`arn:${partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole`,
+                    ]
                   : []),
-              ],
+              ]
             ),
           },
-          { parent },
-        ),
+          { parent }
+        )
       );
     }
 
@@ -2188,7 +2189,7 @@ export class Function extends Component implements Link.Linkable {
                 location: path.join(
                   $cli.paths.work,
                   "artifacts",
-                  `${name}-src`,
+                  `${name}-src`
                 ),
               },
               cacheFrom: [
@@ -2210,7 +2211,7 @@ export class Function extends Component implements Link.Linkable {
               ],
               platforms: [
                 architecture.apply((v) =>
-                  v === "arm64" ? "linux/arm64" : "linux/amd64",
+                  v === "arm64" ? "linux/arm64" : "linux/amd64"
                 ),
               ],
               push: true,
@@ -2222,9 +2223,9 @@ export class Function extends Component implements Link.Linkable {
                 })),
               ],
             },
-            { parent },
+            { parent }
           );
-        },
+        }
       );
     }
 
@@ -2257,7 +2258,7 @@ export class Function extends Component implements Link.Linkable {
             $cli.paths.work,
             "artifacts",
             name,
-            "code.zip",
+            "code.zip"
           );
           await fs.promises.mkdir(path.dirname(zipPath), {
             recursive: true,
@@ -2306,7 +2307,7 @@ export class Function extends Component implements Link.Linkable {
                 ...found.map((file) => ({
                   from: path.join(item.from, file),
                   to: path.join(item.to, file),
-                })),
+                }))
               );
             }
             files.sort((a, b) => a.to.localeCompare(b.to));
@@ -2333,7 +2334,7 @@ export class Function extends Component implements Link.Linkable {
           hash.update(await fs.promises.readFile(zipPath, "utf-8"));
           const hashValue = hash.digest("hex");
           const assetBucket = region.apply((region) =>
-            bootstrap.forRegion(region).then((d) => d.asset),
+            bootstrap.forRegion(region).then((d) => d.asset)
           );
           if (logGroupArn && sourcemaps) {
             let index = 0;
@@ -2342,12 +2343,12 @@ export class Function extends Component implements Link.Linkable {
                 `${name}Sourcemap${index}`,
                 {
                   key: interpolate`sourcemap/${logGroupArn}/${hashValue}.${path.basename(
-                    file,
+                    file
                   )}`,
                   bucket: assetBucket,
                   source: new asset.FileAsset(file),
                 },
-                { parent, retainOnDelete: true },
+                { parent, retainOnDelete: true }
               );
               index++;
             }
@@ -2360,9 +2361,9 @@ export class Function extends Component implements Link.Linkable {
               bucket: assetBucket,
               source: new asset.FileArchive(zipPath),
             },
-            { parent },
+            { parent }
           );
-        },
+        }
       );
     }
 
@@ -2376,12 +2377,13 @@ export class Function extends Component implements Link.Linkable {
             args.transform?.logGroup,
             `${name}LogGroup`,
             {
-              name: interpolate`/aws/lambda/${args.name ?? physicalName(64, `${name}Function`)
-                }`,
+              name: interpolate`/aws/lambda/${
+                args.name ?? physicalName(64, `${name}Function`)
+              }`,
               retentionInDays: RETENTION[logging.retention],
             },
-            { parent, ignoreChanges: ["name"] },
-          ),
+            { parent, ignoreChanges: ["name"] }
+          )
         );
       });
     }
@@ -2441,36 +2443,36 @@ export class Function extends Component implements Link.Linkable {
               reservedConcurrentExecutions: concurrency?.reserved,
               ...(isContainer
                 ? {
-                  packageType: "Image",
-                  imageUri: imageAsset!.ref.apply(
-                    (ref) => ref?.replace(":latest", ""),
-                  ),
-                  imageConfig: {
-                    commands: [
-                      all([handler, runtime]).apply(([handler, runtime]) => {
-                        // If a python container image we have to rewrite the handler path so lambdaric is happy
-                        // This means no leading . and replace all / with .
-                        if (isContainer && runtime.includes("python")) {
-                          return handler
-                            .replace(/\.\//g, "")
-                            .replace(/\//g, ".");
-                        }
-                        return handler;
-                      }),
-                    ],
-                  },
-                }
+                    packageType: "Image",
+                    imageUri: imageAsset!.ref.apply((ref) =>
+                      ref?.replace(":latest", "")
+                    ),
+                    imageConfig: {
+                      commands: [
+                        all([handler, runtime]).apply(([handler, runtime]) => {
+                          // If a python container image we have to rewrite the handler path so lambdaric is happy
+                          // This means no leading . and replace all / with .
+                          if (isContainer && runtime.includes("python")) {
+                            return handler
+                              .replace(/\.\//g, "")
+                              .replace(/\//g, ".");
+                          }
+                          return handler;
+                        }),
+                      ],
+                    },
+                  }
                 : {
-                  packageType: "Zip",
-                  s3Bucket: zipAsset!.bucket,
-                  s3Key: zipAsset!.key,
-                  handler: unsecret(handler),
-                  runtime: runtime.apply((v) =>
-                    v === "go" || v === "rust" ? "provided.al2023" : v,
-                  ),
-                }),
+                    packageType: "Zip",
+                    s3Bucket: zipAsset!.bucket,
+                    s3Key: zipAsset!.key,
+                    handler: unsecret(handler),
+                    runtime: runtime.apply((v) =>
+                      v === "go" || v === "rust" ? "provided.al2023" : v
+                    ),
+                  }),
             },
-            { parent },
+            { parent }
           );
           return new lambda.Function(
             transformed[0],
@@ -2478,19 +2480,19 @@ export class Function extends Component implements Link.Linkable {
               ...transformed[1],
               ...(dev
                 ? {
-                  description: transformed[1].description
-                    ? output(transformed[1].description).apply(
-                      (v) => `${v.substring(0, 240)} (live)`,
-                    )
-                    : "live",
-                  runtime: "provided.al2023",
-                  architectures: ["x86_64"],
-                }
+                    description: transformed[1].description
+                      ? output(transformed[1].description).apply(
+                          (v) => `${v.substring(0, 240)} (live)`
+                        )
+                      : "live",
+                    runtime: "provided.al2023",
+                    architectures: ["x86_64"],
+                  }
                 : {}),
             },
-            transformed[2],
+            transformed[2]
           );
-        },
+        }
       );
     }
 
@@ -2505,11 +2507,11 @@ export class Function extends Component implements Link.Linkable {
             functionName: fn.name,
             authorizationType: url.authorization === "iam" ? "AWS_IAM" : "NONE",
             invokeMode: streaming.apply((streaming) =>
-              streaming ? "RESPONSE_STREAM" : "BUFFERED",
+              streaming ? "RESPONSE_STREAM" : "BUFFERED"
             ),
             cors: url.cors,
           },
-          { parent },
+          { parent }
         );
         if (!url.route) return fnUrl.functionUrl;
 
@@ -2531,7 +2533,7 @@ export class Function extends Component implements Link.Linkable {
             })),
             purge: false,
           },
-          { parent },
+          { parent }
         );
         new KvRoutesUpdate(
           `${name}RoutesUpdate`,
@@ -2541,11 +2543,11 @@ export class Function extends Component implements Link.Linkable {
             key: "routes",
             entry: url.route.apply((route) =>
               ["url", routeNamespace, route.hostPattern, route.pathPrefix].join(
-                ",",
-              ),
+                ","
+              )
             ),
           },
-          { parent },
+          { parent }
         );
         return url.route.routerUrl;
       });
@@ -2560,7 +2562,7 @@ export class Function extends Component implements Link.Linkable {
 
           if (publish !== true) {
             throw new VisibleError(
-              `Provisioned concurrency requires function versioning. Set "versioning: true" to enable function versioning.`,
+              `Provisioned concurrency requires function versioning. Set "versioning: true" to enable function versioning.`
             );
           }
 
@@ -2571,9 +2573,9 @@ export class Function extends Component implements Link.Linkable {
               qualifier: fn.version,
               provisionedConcurrentExecutions: concurrency.provisioned,
             },
-            { parent },
+            { parent }
           );
-        },
+        }
       );
     }
 
@@ -2590,8 +2592,8 @@ export class Function extends Component implements Link.Linkable {
             functionName: fn.name,
             maximumRetryAttempts: args.retries,
           },
-          { parent },
-        ),
+          { parent }
+        )
       );
     }
   }
@@ -2627,7 +2629,7 @@ export class Function extends Component implements Link.Linkable {
     return this.urlEndpoint.apply((url) => {
       if (!url) {
         throw new VisibleError(
-          `Function URL is not enabled. Enable it with "url: true".`,
+          `Function URL is not enabled. Enable it with "url: true".`
         );
       }
       return url;
@@ -2678,7 +2680,7 @@ export class Function extends Component implements Link.Linkable {
         environment,
         region: getRegionOutput(undefined, { parent: this }).name,
       },
-      { parent: this },
+      { parent: this }
     );
   }
 
@@ -2688,7 +2690,7 @@ export class Function extends Component implements Link.Linkable {
     definition: Input<string | FunctionArgs>,
     override: Pick<FunctionArgs, "description" | "permissions">,
     argsTransform?: Transform<FunctionArgs>,
-    opts?: ComponentResourceOptions,
+    opts?: ComponentResourceOptions
   ) {
     return output(definition).apply((definition) => {
       if (typeof definition === "string") {
@@ -2697,8 +2699,8 @@ export class Function extends Component implements Link.Linkable {
             argsTransform,
             name,
             { handler: definition, ...override },
-            opts || {},
-          ),
+            opts || {}
+          )
         );
       } else if (definition.handler) {
         return new Function(
@@ -2716,8 +2718,8 @@ export class Function extends Component implements Link.Linkable {
                 ...(overridePermissions ?? []),
               ]),
             },
-            opts || {},
-          ),
+            opts || {}
+          )
         );
       }
       throw new Error(`Invalid function definition for the "${name}" Function`);

--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -554,7 +554,7 @@ export class Nextjs extends SsrSite {
   constructor(
     name: string,
     args: NextjsArgs = {},
-    opts: ComponentResourceOptions = {},
+    opts: ComponentResourceOptions = {}
   ) {
     super(__pulumiType, name, args, opts);
   }
@@ -568,7 +568,7 @@ export class Nextjs extends SsrSite {
           ? "open-next"
           : "@opennextjs/aws";
         return `npx --yes ${packageName}@${version} build`;
-      },
+      }
     );
   }
 
@@ -576,7 +576,7 @@ export class Nextjs extends SsrSite {
     outputPath: Output<string>,
     name: string,
     args: NextjsArgs,
-    { bucket }: { bucket: Bucket },
+    { bucket }: { bucket: Bucket }
   ): Output<Plan> {
     const parent = this;
 
@@ -587,7 +587,7 @@ export class Nextjs extends SsrSite {
 
         if (Object.entries(openNextOutput.edgeFunctions).length) {
           throw new VisibleError(
-            `Lambda@Edge runtime is deprecated. Update your OpenNext configuration to use the standard Lambda runtime and deploy to multiple regions using the "regions" option in your Nextjs component.`,
+            `Lambda@Edge runtime is deprecated. Update your OpenNext configuration to use the standard Lambda runtime and deploy to multiple regions using the "regions" option in your Nextjs component.`
           );
         }
 
@@ -625,7 +625,7 @@ export class Nextjs extends SsrSite {
               bundle: path.join(outputPath, serverOrigin.bundle),
               handler: serverOrigin.handler,
               streaming: serverOrigin.streaming,
-              runtime: "nodejs20.x" as const,
+              runtime: "nodejs22.x" as const,
               environment: {
                 CACHE_BUCKET_NAME: bucketName,
                 CACHE_BUCKET_KEY_PREFIX: "_cache",
@@ -708,7 +708,7 @@ export class Nextjs extends SsrSite {
                 description: `${name} image optimizer`,
                 handler: imageOptimizerOrigin.handler,
                 bundle: path.join(outputPath, imageOptimizerOrigin.bundle),
-                runtime: "nodejs20.x" as const,
+                runtime: "nodejs22.x" as const,
                 architecture: "arm64" as const,
                 environment: {
                   BUCKET_NAME: bucketName,
@@ -734,7 +734,7 @@ export class Nextjs extends SsrSite {
               to: "_cache",
             },
             buildId,
-          }),
+          })
         );
 
         return {
@@ -748,11 +748,11 @@ export class Nextjs extends SsrSite {
           const openNextOutputPath = path.join(
             outputPath,
             ".open-next",
-            "open-next.output.json",
+            "open-next.output.json"
           );
           if (!fs.existsSync(openNextOutputPath)) {
             throw new VisibleError(
-              `Could not load OpenNext output file at "${openNextOutputPath}". Make sure your Next.js app was built correctly with OpenNext.`,
+              `Could not load OpenNext output file at "${openNextOutputPath}". Make sure your Next.js app was built correctly with OpenNext.`
             );
           }
           const content = fs.readFileSync(openNextOutputPath).toString();
@@ -781,7 +781,7 @@ export class Nextjs extends SsrSite {
           } catch (e) {
             console.error(e);
             throw new VisibleError(
-              `Build ID not found in ".next/BUILD_ID" for site "${name}". Ensure your Next.js app was built successfully.`,
+              `Build ID not found in ".next/BUILD_ID" for site "${name}". Ensure your Next.js app was built successfully.`
             );
           }
         }
@@ -790,7 +790,7 @@ export class Nextjs extends SsrSite {
           try {
             const content = fs.readFileSync(
               path.join(outputPath, ".next", "routes-manifest.json"),
-              "utf-8",
+              "utf-8"
             );
             const json = JSON.parse(content) as {
               basePath: string;
@@ -799,7 +799,7 @@ export class Nextjs extends SsrSite {
           } catch (e) {
             console.error(e);
             throw new VisibleError(
-              `Base path configuration not found in ".next/routes-manifest.json" for site "${name}". Check your Next.js configuration.`,
+              `Base path configuration not found in ".next/routes-manifest.json" for site "${name}". Check your Next.js configuration.`
             );
           }
         }
@@ -808,7 +808,7 @@ export class Nextjs extends SsrSite {
           try {
             const content = fs
               .readFileSync(
-                path.join(outputPath, ".next/prerender-manifest.json"),
+                path.join(outputPath, ".next/prerender-manifest.json")
               )
               .toString();
             return JSON.parse(content) as {
@@ -838,14 +838,14 @@ export class Nextjs extends SsrSite {
                 },
               },
             },
-            { parent },
+            { parent }
           );
           const subscriber = queue.subscribe(
             {
               description: `${name} ISR revalidator`,
               handler: revalidationFunction.handler,
               bundle: path.join(outputPath, revalidationFunction.bundle),
-              runtime: "nodejs20.x",
+              runtime: "nodejs22.x",
               timeout: "30 seconds",
               permissions: [
                 {
@@ -869,7 +869,7 @@ export class Nextjs extends SsrSite {
                 },
               },
             },
-            { parent },
+            { parent }
           );
           return {
             revalidationQueue: queue,
@@ -903,7 +903,7 @@ export class Nextjs extends SsrSite {
                 },
               ],
             },
-            { parent, retainOnDelete: false },
+            { parent, retainOnDelete: false }
           );
         }
 
@@ -915,7 +915,7 @@ export class Nextjs extends SsrSite {
           // 1GB per 40,000, up to 10GB. This tends to use ~70% of the memory
           // provisioned when testing.
           const prerenderedRouteCount = Object.keys(
-            prerenderManifest?.routes ?? {},
+            prerenderManifest?.routes ?? {}
           ).length;
           const seedFn = new Function(
             `${name}RevalidationSeeder`,
@@ -925,13 +925,13 @@ export class Nextjs extends SsrSite {
                 openNextOutput.additionalProps.initializationFunction.handler,
               bundle: path.join(
                 outputPath,
-                openNextOutput.additionalProps.initializationFunction.bundle,
+                openNextOutput.additionalProps.initializationFunction.bundle
               ),
-              runtime: "nodejs20.x",
+              runtime: "nodejs22.x",
               timeout: "900 seconds",
               memory: `${Math.min(
                 10240,
-                Math.max(128, Math.ceil(prerenderedRouteCount / 4000) * 128),
+                Math.max(128, Math.ceil(prerenderedRouteCount / 4000) * 128)
               )} MB`,
               permissions: [
                 {
@@ -950,7 +950,7 @@ export class Nextjs extends SsrSite {
               _skipMetadata: true,
               _skipHint: true,
             },
-            { parent },
+            { parent }
           );
           new lambda.Invocation(
             `${name}RevalidationSeed`,
@@ -963,10 +963,10 @@ export class Nextjs extends SsrSite {
                 RequestType: "Create",
               }),
             },
-            { parent },
+            { parent }
           );
         }
-      },
+      }
     );
 
     this.revalidationQueue = ret.revalidationQueue;

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -225,7 +225,7 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
     /**
      * The runtime environment for the server function.
      *
-     * @default `"nodejs20.x"`
+     * @default `"nodejs22.x"`
      * @example
      * ```js
      * {
@@ -645,21 +645,21 @@ export abstract class SsrSite extends Component implements Link.Linkable {
   private prodUrl?: Output<string | undefined>;
 
   protected abstract normalizeBuildCommand(
-    args: SsrSiteArgs,
+    args: SsrSiteArgs
   ): Output<string> | void;
 
   protected abstract buildPlan(
     outputPath: Output<string>,
     name: string,
     args: SsrSiteArgs,
-    { bucket }: { bucket: Bucket },
+    { bucket }: { bucket: Bucket }
   ): Output<Plan>;
 
   constructor(
     type: string,
     name: string,
     args: SsrSiteArgs = {},
-    opts: ComponentResourceOptions = {},
+    opts: ComponentResourceOptions = {}
   ) {
     super(type, name, args, opts);
     const self = this;
@@ -696,14 +696,14 @@ export abstract class SsrSite extends Component implements Link.Linkable {
       name,
       args,
       sitePath,
-      buildCommand ?? undefined,
+      buildCommand ?? undefined
     );
     const bucket = createS3Bucket();
     const plan = validatePlan(
-      this.buildPlan(outputPath, name, args, { bucket }),
+      this.buildPlan(outputPath, name, args, { bucket })
     );
     const timeout = all([serverTimeout, plan.server]).apply(
-      ([argsTimeout, plan]) => argsTimeout ?? plan?.timeout ?? "20 seconds",
+      ([argsTimeout, plan]) => argsTimeout ?? plan?.timeout ?? "20 seconds"
     );
     const servers = createServers();
     const imageOptimizer = createImageOptimizer();
@@ -725,7 +725,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
       distribution = createDistribution();
       distributionId = distribution.nodes.distribution.id;
       prodUrl = distribution.domainUrl.apply((domainUrl) =>
-        output(domainUrl ?? distribution!.url),
+        output(domainUrl ?? distribution!.url)
       );
     }
 
@@ -754,7 +754,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
             enableAcceptEncodingGzip: true,
           },
         },
-        { parent: self },
+        { parent: self }
       );
     }
 
@@ -766,7 +766,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
         return new cloudfront.KeyValueStore(
           `${name}KvStore`,
           {},
-          { parent: self },
+          { parent: self }
         ).arn;
       });
     }
@@ -802,7 +802,7 @@ async function handler(event) {
   return event.request;
 }`,
           },
-          { parent: self },
+          { parent: self }
         );
       });
     }
@@ -827,7 +827,7 @@ async function handler(event) {
   return event.response;
 }`,
           },
-          { parent: self },
+          { parent: self }
         );
       });
     }
@@ -881,8 +881,8 @@ async function handler(event) {
               ]),
             },
           },
-          { parent: self },
-        ),
+          { parent: self }
+        )
       );
     }
 
@@ -913,7 +913,7 @@ async function handler(event) {
     function validateDeprecatedProps() {
       if (args.cdn !== undefined)
         throw new VisibleError(
-          `"cdn" prop is deprecated. Use the "route.router" prop instead to use an existing "Router" component to serve your site.`,
+          `"cdn" prop is deprecated. Use the "route.router" prop instead to use an existing "Router" component to serve your site.`
         );
     }
 
@@ -944,8 +944,8 @@ async function handler(event) {
         if (!fs.existsSync(sitePath)) {
           throw new VisibleError(
             `Site directory not found at "${path.resolve(
-              sitePath,
-            )}". Please check the path setting in your configuration.`,
+              sitePath
+            )}". Please check the path setting in your configuration.`
           );
         }
         return sitePath;
@@ -954,11 +954,11 @@ async function handler(event) {
 
     function normalizeRegions() {
       return output(
-        args.regions ?? [getRegionOutput(undefined, { parent: self }).name],
+        args.regions ?? [getRegionOutput(undefined, { parent: self }).name]
       ).apply((regions) => {
         if (regions.length === 0)
           throw new VisibleError(
-            "No deployment regions specified. Please specify at least one region in the 'regions' property.",
+            "No deployment regions specified. Please specify at least one region in the 'regions' property."
           );
 
         return regions.map((region) => {
@@ -975,12 +975,12 @@ async function handler(event) {
             ].includes(region)
           )
             throw new VisibleError(
-              `Region ${region} is not supported by this component. Please select a different AWS region.`,
+              `Region ${region} is not supported by this component. Please select a different AWS region.`
             );
 
           if (!Object.values(Region).includes(region as Region))
             throw new VisibleError(
-              `Invalid AWS region: "${region}". Please specify a valid AWS region.`,
+              `Invalid AWS region: "${region}". Please specify a valid AWS region.`
             );
           return region as Region;
         });
@@ -993,12 +993,12 @@ async function handler(event) {
       if (route) {
         if (args.domain)
           throw new VisibleError(
-            `Cannot provide both "domain" and "route". Use the "domain" prop on the "Router" component when serving your site through a Router.`,
+            `Cannot provide both "domain" and "route". Use the "domain" prop on the "Router" component when serving your site through a Router.`
           );
 
         if (args.edge)
           throw new VisibleError(
-            `Cannot provide both "edge" and "route". Use the "edge" prop on the "Router" component when serving your site through a Router.`,
+            `Cannot provide both "edge" and "route". Use the "edge" prop on the "Router" component when serving your site through a Router.`
           );
       }
 
@@ -1010,12 +1010,12 @@ async function handler(event) {
         ([edge, serverEdge]) => {
           if (serverEdge)
             throw new VisibleError(
-              `The "server.edge" prop is deprecated. Use the "edge" prop on the top level instead.`,
+              `The "server.edge" prop is deprecated. Use the "edge" prop on the top level instead.`
             );
 
           if (!edge) return edge;
           return edge;
-        },
+        }
       );
     }
 
@@ -1028,7 +1028,7 @@ async function handler(event) {
           getQuota("cloudfront-response-timeout").apply((quota) => {
             if (seconds > quota)
               throw new VisibleError(
-                `Server timeout for "${name}" is longer than the allowed CloudFront response timeout of ${quota} seconds. You can contact AWS Support to increase the timeout - ${CONSOLE_URL}`,
+                `Server timeout for "${name}" is longer than the allowed CloudFront response timeout of ${quota} seconds. You can contact AWS Support to increase the timeout - ${CONSOLE_URL}`
               );
           });
         }
@@ -1043,13 +1043,13 @@ async function handler(event) {
           `${name}DevServer`,
           {
             description: `${name} dev server`,
-            runtime: "nodejs20.x",
+            runtime: "nodejs22.x",
             timeout: "20 seconds",
             memory: "128 MB",
             bundle: path.join(
               $cli.paths.platform,
               "functions",
-              "empty-function",
+              "empty-function"
             ),
             handler: "index.handler",
             environment: args.environment,
@@ -1057,8 +1057,8 @@ async function handler(event) {
             link: args.link,
             dev: false,
           },
-          { parent: self },
-        ),
+          { parent: self }
+        )
       );
     }
 
@@ -1074,12 +1074,12 @@ async function handler(event) {
         if (route?.pathPrefix && route.pathPrefix !== "/") {
           if (!plan.base)
             throw new VisibleError(
-              `No base path found for site. You must configure the base path to match the route path prefix "${route.pathPrefix}".`,
+              `No base path found for site. You must configure the base path to match the route path prefix "${route.pathPrefix}".`
             );
 
           if (!plan.base.startsWith(route.pathPrefix))
             throw new VisibleError(
-              `The site base path "${plan.base}" must start with the route path prefix "${route.pathPrefix}".`,
+              `The site base path "${plan.base}" must start with the route path prefix "${route.pathPrefix}".`
             );
         }
 
@@ -1101,8 +1101,8 @@ async function handler(event) {
           args.transform?.assets,
           `${name}Assets`,
           { access: "cloudfront" },
-          { parent: self, retainOnDelete: false },
-        ),
+          { parent: self, retainOnDelete: false }
+        )
       );
     }
 
@@ -1120,14 +1120,14 @@ async function handler(event) {
                 ...planServer,
                 description: planServer.description ?? `${name} server`,
                 runtime: output(args.server?.runtime).apply(
-                  (v) => v ?? planServer.runtime ?? "nodejs20.x",
+                  (v) => v ?? planServer.runtime ?? "nodejs22.x"
                 ),
                 timeout,
                 memory: output(args.server?.memory).apply(
-                  (v) => v ?? planServer.memory ?? "1024 MB",
+                  (v) => v ?? planServer.memory ?? "1024 MB"
                 ),
                 architecture: output(args.server?.architecture).apply(
-                  (v) => v ?? planServer.architecture ?? "x86_64",
+                  (v) => v ?? planServer.architecture ?? "x86_64"
                 ),
                 vpc: args.vpc,
                 nodejs: {
@@ -1169,8 +1169,8 @@ async function handler(event) {
                 dev: false,
                 _skipHint: true,
               },
-              { provider, parent: self },
-            ),
+              { provider, parent: self }
+            )
           );
 
           if (args.warm) {
@@ -1182,7 +1182,7 @@ async function handler(event) {
                 job: {
                   description: `${name} warmer`,
                   bundle: path.join($cli.paths.platform, "dist", "ssr-warmer"),
-                  runtime: "nodejs20.x",
+                  runtime: "nodejs22.x",
                   handler: "index.handler",
                   timeout: "900 seconds",
                   memory: "128 MB",
@@ -1190,7 +1190,7 @@ async function handler(event) {
                   environment: {
                     FUNCTION_NAME: server.nodes.function.name,
                     CONCURRENCY: output(args.warm).apply((warm) =>
-                      warm.toString(),
+                      warm.toString()
                     ),
                   },
                   link: [server],
@@ -1205,7 +1205,7 @@ async function handler(event) {
                   },
                 },
               },
-              { provider, parent: self },
+              { provider, parent: self }
             );
 
             // Prewarm on deploy
@@ -1218,7 +1218,7 @@ async function handler(event) {
                 },
                 input: JSON.stringify({}),
               },
-              { provider, parent: self },
+              { provider, parent: self }
             );
           }
 
@@ -1249,7 +1249,7 @@ async function handler(event) {
             _skipMetadata: true,
             _skipHint: true,
           },
-          { parent: self },
+          { parent: self }
         );
       });
     }
@@ -1341,16 +1341,16 @@ async function handler(event) {
                         path.join(
                           copy.to,
                           route?.pathPrefix?.replace(/^\//, "") ?? "",
-                          file,
-                        ),
+                          file
+                        )
                       ),
                       hash,
                       cacheControl: fileOption.cacheControl,
                       contentType:
                         fileOption.contentType ?? getContentType(file, "UTF-8"),
                     };
-                  }),
-                )),
+                  })
+                ))
               );
               filesUploaded.push(...files);
             }
@@ -1364,9 +1364,9 @@ async function handler(event) {
               purge,
               region: getRegionOutput(undefined, { parent: self }).name,
             },
-            { parent: self },
+            { parent: self }
           );
-        },
+        }
       );
     }
 
@@ -1428,7 +1428,7 @@ async function handler(event) {
                     }
                     // Directory + NOT expand: add to route
                     dirs.push(toPosix(path.join("/", childPath, item.name)));
-                  },
+                  }
                 );
               };
               processDir();
@@ -1460,7 +1460,7 @@ async function handler(event) {
               },
             } satisfies KV_SITE_METADATA);
             return kvEntries;
-          }),
+          })
       );
 
       return new KvKeys(
@@ -1471,7 +1471,7 @@ async function handler(event) {
           entries,
           purge,
         },
-        { parent: self },
+        { parent: self }
       );
     }
 
@@ -1484,11 +1484,11 @@ async function handler(event) {
           key: "routes",
           entry: route!.apply((route) =>
             ["site", kvNamespace, route!.hostPattern, route!.pathPrefix].join(
-              ",",
-            ),
+              ","
+            )
           ),
         },
-        { parent: self },
+        { parent: self }
       );
     }
 
@@ -1517,7 +1517,7 @@ async function handler(event) {
             cachedS3Files.forEach((item) => {
               if (!item.versionedSubDir) return;
               invalidationPaths.push(
-                toPosix(path.join("/", item.to, item.versionedSubDir, "*")),
+                toPosix(path.join("/", item.to, item.versionedSubDir, "*"))
               );
             });
           } else {
@@ -1546,7 +1546,7 @@ async function handler(event) {
                   cwd: path.resolve(
                     outputPath,
                     item.from,
-                    item.versionedSubDir,
+                    item.versionedSubDir
                   ),
                 }).forEach((filePath) => hash.update(filePath));
               }
@@ -1565,9 +1565,9 @@ async function handler(event) {
                   hash.update(
                     fs.readFileSync(
                       path.resolve(outputPath, item.from, filePath),
-                      "utf-8",
-                    ),
-                  ),
+                      "utf-8"
+                    )
+                  )
                 );
               }
             });
@@ -1585,9 +1585,9 @@ async function handler(event) {
             {
               parent: self,
               dependsOn: [assetsUploaded, kvUpdated, ...invalidationDependsOn],
-            },
+            }
           );
-        },
+        }
       );
     }
   }
@@ -1600,7 +1600,7 @@ async function handler(event) {
    */
   public get url() {
     return all([this.prodUrl, this.devUrl]).apply(
-      ([prodUrl, devUrl]) => (prodUrl ?? devUrl)!,
+      ([prodUrl, devUrl]) => (prodUrl ?? devUrl)!
     );
   }
 

--- a/platform/src/global.d.ts
+++ b/platform/src/global.d.ts
@@ -119,7 +119,7 @@ declare global {
    * ```
    */
   export function $resolve<T extends Record<string, any>>(
-    val: T,
+    val: T
   ): util.Output<util.Unwrap<T>>;
   export function $resolve<T1, T2, T3, T4, T5, T6, T7, T8>(
     values: [
@@ -130,8 +130,8 @@ declare global {
       util.Input<T5>,
       util.Input<T6>,
       util.Input<T7>,
-      util.Input<T8>,
-    ],
+      util.Input<T8>
+    ]
   ): util.Output<
     [
       util.Unwrap<T1>,
@@ -141,7 +141,7 @@ declare global {
       util.Unwrap<T5>,
       util.Unwrap<T6>,
       util.Unwrap<T7>,
-      util.Unwrap<T8>,
+      util.Unwrap<T8>
     ]
   >;
   export function $resolve<T1, T2, T3, T4, T5, T6, T7>(
@@ -152,8 +152,8 @@ declare global {
       util.Input<T4>,
       util.Input<T5>,
       util.Input<T6>,
-      util.Input<T7>,
-    ],
+      util.Input<T7>
+    ]
   ): util.Output<
     [
       util.Unwrap<T1>,
@@ -162,7 +162,7 @@ declare global {
       util.Unwrap<T4>,
       util.Unwrap<T5>,
       util.Unwrap<T6>,
-      util.Unwrap<T7>,
+      util.Unwrap<T7>
     ]
   >;
   export function $resolve<T1, T2, T3, T4, T5, T6>(
@@ -172,8 +172,8 @@ declare global {
       util.Input<T3>,
       util.Input<T4>,
       util.Input<T5>,
-      util.Input<T6>,
-    ],
+      util.Input<T6>
+    ]
   ): util.Output<
     [
       util.Unwrap<T1>,
@@ -181,7 +181,7 @@ declare global {
       util.Unwrap<T3>,
       util.Unwrap<T4>,
       util.Unwrap<T5>,
-      util.Unwrap<T6>,
+      util.Unwrap<T6>
     ]
   >;
   export function $resolve<T1, T2, T3, T4, T5>(
@@ -190,25 +190,25 @@ declare global {
       util.Input<T2>,
       util.Input<T3>,
       util.Input<T4>,
-      util.Input<T5>,
-    ],
+      util.Input<T5>
+    ]
   ): util.Output<
     [
       util.Unwrap<T1>,
       util.Unwrap<T2>,
       util.Unwrap<T3>,
       util.Unwrap<T4>,
-      util.Unwrap<T5>,
+      util.Unwrap<T5>
     ]
   >;
   export function $resolve<T1, T2, T3, T4>(
-    values: [util.Input<T1>, util.Input<T2>, util.Input<T3>, util.Input<T4>],
+    values: [util.Input<T1>, util.Input<T2>, util.Input<T3>, util.Input<T4>]
   ): util.Output<[Unwrap<T1>, util.Unwrap<T2>, Unwrap<T3>, Unwrap<T4>]>;
   export function $resolve<T1, T2, T3>(
-    values: [util.Input<T1>, util.Input<T2>, util.Input<T3>],
+    values: [util.Input<T1>, util.Input<T2>, util.Input<T3>]
   ): util.Output<[util.Unwrap<T1>, util.Unwrap<T2>, util.Unwrap<T3>]>;
   export function $resolve<T1, T2>(
-    values: [util.Input<T1>, util.Input<T2>],
+    values: [util.Input<T1>, util.Input<T2>]
   ): util.Output<[Unwrap<T1>, util.Unwrap<T2>]>;
   /**
    * Use string interpolation on Output values.
@@ -322,7 +322,7 @@ declare global {
    * ```ts title="sst.config.ts"
    * $transform(sst.aws.Function, (args, opts, name) => {
    *   // Set the default if it's not set by the component
-   *   args.runtime ??= "nodejs20.x";
+   *   args.runtime ??= "nodejs22.x";
    * });
    * ```
    *

--- a/www/src/content/docs/docs/components.mdx
+++ b/www/src/content/docs/docs/components.mdx
@@ -199,7 +199,7 @@ For example, set a default `runtime` for your functions.
 ```ts title="sst.config.ts"
 $transform(sst.aws.Function, (args, opts) => {
   // Set the default if it's not set by the component
-  args.runtime ??= "nodejs18.x";
+  args.runtime ??= "nodejs20.x";
 });
 ```
 
@@ -214,11 +214,11 @@ new sst.aws.Function("MyFunctionA", {
 
 new sst.aws.Function("MyFunctionB", {
   handler: "src/lambdaB.handler",
-  runtime: "nodejs20.x"
+  runtime: "nodejs22.x"
 });
 ```
 
-So given the above transform, `MyFunctionA` will have a runtime of `nodejs18.x` and `MyFunctionB` will have a runtime of `nodejs20.x`.
+So given the above transform, `MyFunctionA` will have a runtime of `nodejs20.x` and `MyFunctionB` will have a runtime of `nodejs22.x`.
 
 :::note
 The `$transform` is only applied to components that are defined after it.


### PR DESCRIPTION
Hi SST team

Node.js 20 is being [deprecated on April 30, 2026](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported).

I suggest to set the default runtime for Node.js Lambda functions to `nodejs22.x`.

`nodejs24.x` will be soon available (Nov 2025), but is not by now. I would have added it as a supported runtime. But I guess, this will be something for another PR.