### PR TITLE
fix(cloudflare): fix cloudflare queue binding causing deployment error

### DIFF
--- a/platform/src/components/cloudflare/binding.ts
+++ b/platform/src/components/cloudflare/binding.ts
@@ -45,7 +45,7 @@ export interface PlainTextBinding {
 export interface QueueBinding {
   type: "queueBindings";
   properties: {
-    queue: Input<string>;
+    queueName: Input<string>;
   };
 }
 export interface R2BucketBinding {

--- a/platform/src/components/cloudflare/queue.ts
+++ b/platform/src/components/cloudflare/queue.ts
@@ -56,7 +56,7 @@ export class Queue extends Component implements Link.Linkable {
         binding({
           type: "queueBindings",
           properties: {
-            queue: this.queue.queueName,
+            queueName: this.queue.queueName,
           },
         }),
       ],


### PR DESCRIPTION
This PR corrects the output field for an queue binding definition to resolve deployment error when deploying an worker with an queue binding.