### PR TITLE
fix(#6239): apigv2 stage depends on log group

### DIFF
--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -872,7 +872,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
               }),
             },
           },
-          { parent },
+          { parent, dependsOn: [logGroup] },
         ),
       );
     }


### PR DESCRIPTION
Fixes #6239 