### PR TITLE
feat(aws): enable overriding cpu / memory / storage when running ECS tasks

### DIFF
--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -78,15 +78,15 @@ export module task {
      */
     capacity?: "fargate" | "spot";
     /**
-     * The amount of memory allocated for this task. This value overrides the memory allocated in the task definition.
+     * Overrides the memory allocated for this task in the task definition.
      */
-    memory?: string;
+    memory?: `${number} GB`;
     /**
-     * The amount of CPU allocated for this task. This value overrides the CPU allocated in the task definition.
+     * Overrides the CPU allocated for this task in the task definition.
      */
-    cpu?: string;
+    cpu?: `${number} vCPU`;
     /**
-     * Ephemeral storage size in GiB allocated for this task. This value overrides the ephemeral storage allocated in the task definition.
+     * Overrides the ephemeral storage (in GiB) allocated for this task in the task definition.
      */
     storage?: number;
   }

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -1,5 +1,4 @@
 import { AwsOptions, client } from "./client.js";
-
 /**
  * The `task` client SDK is available through the following.
  *
@@ -78,8 +77,17 @@ export module task {
      * @default `"fargate"`
      */
     capacity?: "fargate" | "spot";
-    memory?: number;
-    cpu?: number;
+    /**
+     * The amount of memory allocated for this task. This value overrides the memory allocated in the task definition.
+     */
+    memory?: string;
+    /**
+     * The amount of CPU allocated for this task. This value overrides the CPU allocated in the task definition.
+     */
+    cpu?: string;
+    /**
+     * Ephemeral storage size in GiB allocated for this task. This value overrides the ephemeral storage allocated in the task definition.
+     */
     storage?: number;
   }
 

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -252,7 +252,9 @@ export module task {
         overrides: {
           ...(options?.cpu ? { cpu: options.cpu } : {}),
           ...(options?.memory ? { memory: options.memory } : {}),
-          ...(options?.storage ? { storage: options.storage } : {}),
+          ...(options?.storage
+            ? { ephemeralStorage: { sizeInGiB: options.storage } }
+            : {}),
           containerOverrides: resource.containers.map((name) => ({
             name,
             environment: Object.entries(environment ?? {}).map(

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -86,9 +86,9 @@ export module task {
      */
     cpu?: `${number} vCPU`;
     /**
-     * Overrides the ephemeral storage (in GiB) allocated for this task in the task definition.
+     * Overrides the ephemeral storage allocated for this task in the task definition.
      */
-    storage?: number;
+    storage?: `${number} GB`;
   }
 
   interface Task {
@@ -258,11 +258,10 @@ export module task {
           },
         },
         overrides: {
-          ...(options?.cpu ? { cpu: options.cpu } : {}),
-          ...(options?.memory ? { memory: options.memory } : {}),
-          ...(options?.storage
-            ? { ephemeralStorage: { sizeInGiB: options.storage } }
-            : {}),
+          ...(options?.cpu ? { cpu: (parseFloat(options.cpu.replace(" vCPU", "")) * 1024).toString() } : {}),
+          ...(options?.memory ? { memory: (parseFloat(options.memory.replace(" GB", "")) * 1024).toString() } : {}),
+          ...(options?.storage ? { ephemeralStorage: { sizeInGiB: parseInt(options.storage.replace(" GB", "")) } } : {}),
+
           containerOverrides: resource.containers.map((name) => ({
             name,
             environment: Object.entries(environment ?? {}).map(

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -78,6 +78,9 @@ export module task {
      * @default `"fargate"`
      */
     capacity?: "fargate" | "spot";
+    memory?: number;
+    cpu?: number;
+    storage?: number;
   }
 
   interface Task {
@@ -247,6 +250,9 @@ export module task {
           },
         },
         overrides: {
+          ...(options?.cpu ? { cpu: options.cpu } : {}),
+          ...(options?.memory ? { memory: options.memory } : {}),
+          ...(options?.storage ? { storage: options.storage } : {}),
           containerOverrides: resource.containers.map((name) => ({
             name,
             environment: Object.entries(environment ?? {}).map(


### PR DESCRIPTION
Often, you need to override an existing ECS task definition's CPU / memory settings based your workload at runtime.

This change allows `sst.task.run` to pass these values through to the AWS SDK. 
Hopefully, this can help others save some time and optimize their ECS costs. 

PS: this is my first contribution to sst so please lmk if I missed something I would be happy to learn!