### PR TITLE
Fix docs when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ go run ../../cmd/sst <command>
 If you want to build the CLI, you can run `go build ./cmd/sst` from the root. This will create a
 `sst` binary that you can use.
 
+For building the docs, you need to run `bun generate` and `bun dev` inside the `www` directory.
+
 ---
 
 **Join our community** [Discord](https://sst.dev/discord) | [YouTube](https://www.youtube.com/c/sst-dev) | [X.com](https://x.com/SST_dev)

--- a/platform/src/components/aws/permission.ts
+++ b/platform/src/components/aws/permission.ts
@@ -1,3 +1,19 @@
+/**
+ * The AWS Permission Linkable helper is used to define the AWS permissions included with the
+ * [`sst.Linkable`](/docs/component/linkable/) component.
+ *
+ * @example
+ *
+ * ```ts
+ * sst.aws.permission({
+ *   actions: ["lambda:InvokeFunction"],
+ *   resources: ["*"]
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
 import { Prettify } from "../component.js";
 import { FunctionPermissionArgs } from "./function.js";
 

--- a/platform/src/components/cloudflare/kv.ts
+++ b/platform/src/components/cloudflare/kv.ts
@@ -114,6 +114,13 @@ export class Kv extends Component implements Link.Linkable {
   }
 
   /**
+   * The generated ID of the KV namespace.
+   */
+  public get namespaceId() {
+    return this.namespace.id;
+  }
+
+  /**
    * The underlying [resources](/docs/components/#nodes) this component creates.
    */
   public get nodes() {


### PR DESCRIPTION
when checking #5819 i found the docs can't be tested locally because the JSDoc extraction broke for two files:

- `aws/permission.ts`: needs a global `@packageDocumentation` since we create a page via `useModuleComment`
- `cloudflare/kv.ts`: needs a getter for `namespaceId` since  `getSSTLink` props are iterated

i've also added instructions on how to run the docs locally in the README.md

proof of them working now:

https://github.com/user-attachments/assets/d792f67b-a41e-4551-9fcf-91709a240628
