### PR TITLE
Fix missing AWS Cognito example

### DIFF
--- a/examples/aws-cognito/sst.config.ts
+++ b/examples/aws-cognito/sst.config.ts
@@ -1,8 +1,8 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 /**
- * ## AWS Cogito User Pool
+ * ## AWS Cognito User Pool
  *
- * Create a Cognito User Pool with triggers and identity pool.
+ * Create a Cognito user pool with triggers and identity pool.
  *
  */
 export default $config({

--- a/examples/aws-cognito/sst.config.ts
+++ b/examples/aws-cognito/sst.config.ts
@@ -1,5 +1,10 @@
 /// <reference path="./.sst/platform/config.d.ts" />
-
+/**
+ * ## AWS Cogito User Pool
+ *
+ * Create a Cognito User Pool with triggers and identity pool.
+ *
+ */
 export default $config({
   app(input) {
     return {


### PR DESCRIPTION
Hi all, I have noticed the AWS Cogito example is not rendered on the [https://sst.dev/docs/examples/](https://sst.dev/docs/examples/) because of a missing JS doc at the top. I have added it and now it will render properly. (I have run `/www generate.ts` and confirmed it's there now). 
<img width="730" height="638" alt="image" src="https://github.com/user-attachments/assets/8c8b8b5f-6079-4d71-86e2-0b4e23edee12" />


- Should I include in my PR the generated examples.mdx or do you have another process of generating it? As I see there are more changes than mine in the diff. 