### PR TITLE
Add callbackUrls to aws cognito userpool client args

### DIFF
--- a/examples/aws-cognito/sst.config.ts
+++ b/examples/aws-cognito/sst.config.ts
@@ -16,7 +16,11 @@ export default $config({
         },
       },
     });
-    const client = userPool.addClient("Web");
+
+    const client = userPool.addClient("Web", {
+      callbackUrls: ['https://example.com/auth/callback']
+    });
+
     const identityPool = new sst.aws.CognitoIdentityPool("MyIdentityPool", {
       userPools: [
         {

--- a/platform/src/components/aws/cognito-user-pool-client.ts
+++ b/platform/src/components/aws/cognito-user-pool-client.ts
@@ -63,7 +63,7 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
               "openid",
               "aws.cognito.signin.user.admin",
             ],
-            callbackUrls: this.callbackUrls,
+            callbackUrls: callbackUrls,
             supportedIdentityProviders: providers,
           },
           { parent },

--- a/platform/src/components/aws/cognito-user-pool-client.ts
+++ b/platform/src/components/aws/cognito-user-pool-client.ts
@@ -42,8 +42,8 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
     }
 
     function normalizeCallbackUrls() {
-      if(!args.callbackUrls) return ["https://example.com"]
-      return output(args.callbackUrls)
+      if (!args.callbackUrls) return ["https://example.com"];
+      return output(args.callbackUrls);
     }
 
     function createClient() {

--- a/platform/src/components/aws/cognito-user-pool-client.ts
+++ b/platform/src/components/aws/cognito-user-pool-client.ts
@@ -32,12 +32,18 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
 
     const providers = normalizeProviders();
     const client = createClient();
+    const callbackUrls = normalizeCallbackUrls();
 
     this.client = client;
 
     function normalizeProviders() {
       if (!args.providers) return ["COGNITO"];
       return output(args.providers);
+    }
+
+    function normalizeCallbackUrls() {
+      if(!args.callbackUrls) return ["https://example.com"]
+      return output(args.callbackUrls)
     }
 
     function createClient() {
@@ -57,7 +63,7 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
               "openid",
               "aws.cognito.signin.user.admin",
             ],
-            callbackUrls: args.callbackUrls,
+            callbackUrls: this.callbackUrls,
             supportedIdentityProviders: providers,
           },
           { parent },

--- a/platform/src/components/aws/cognito-user-pool-client.ts
+++ b/platform/src/components/aws/cognito-user-pool-client.ts
@@ -31,8 +31,8 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
     const parent = this;
 
     const providers = normalizeProviders();
-    const client = createClient();
     const callbackUrls = normalizeCallbackUrls();
+    const client = createClient();
 
     this.client = client;
 

--- a/platform/src/components/aws/cognito-user-pool-client.ts
+++ b/platform/src/components/aws/cognito-user-pool-client.ts
@@ -57,7 +57,7 @@ export class CognitoUserPoolClient extends Component implements Link.Linkable {
               "openid",
               "aws.cognito.signin.user.admin",
             ],
-            callbackUrls: ["https://example.com"],
+            callbackUrls: args.callbackUrls,
             supportedIdentityProviders: providers,
           },
           { parent },

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -406,6 +406,10 @@ export interface CognitoUserPoolClientArgs {
    */
   providers?: Input<Input<string>[]>;
   /**
+   * List of allowed callback URLs for the identity providers.
+   */
+  callbackUrls?: Input<Input<string>[]>;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */


### PR DESCRIPTION
Hi all, while implementing an AWS User Pool in AWS Cognito I ran into a small inconvenience with the `addClient` method. AFAIK, the `callbackUrl` is required for the managed login flow to redirect back to your app, but it isn’t exposed as an input parameter, so you currently have to rely on a small `transform` workaround:

My current code:
```TypeScript
    const webClient = userPool.addClient("Web", {
      transform: {
        client: (args: UserPoolClientArgs) => {
          args.callbackUrls = [adminUI.url.apply(url => `${url}/auth/callback`)];
        },
      },
    });
```
While I believe it's quite convenient requirement, so it could look like this:

```TypeScript
    const webClient = userPool.addClient("Web", {
      callbackUrls: [adminUI.url.apply(url => `${url}/auth/callback`)]
    });
``` 

Please let me know if that makes sense for you to expose it. 