### PR TITLE
fix(vpc): add missing parent parameter to EipAssociation in createNat…

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1018,10 +1018,13 @@ export class Vpc extends Component implements Link.Linkable {
               ),
             );
 
-            new ec2.EipAssociation(`${name}NatInstanceEipAssociation${i + 1}`, {
+            new ec2.EipAssociation(`${name}NatInstanceEipAssociation${i + 1}`, 
+            {
               instanceId: instance.id,
               allocationId: elasticIps[i]?.id ?? nat.ip![i],
-            });
+            },
+            { parent: self }
+          );
 
             return instance;
           }),

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -133,6 +133,7 @@ export class Component extends ComponentResource {
               "aws:appsync/function:Function",
               "aws:appsync/resolver:Resolver",
               "aws:ec2/routeTableAssociation:RouteTableAssociation",
+              "aws:ec2/eipAssociation:EipAssociation",
               "aws:ecs/clusterCapacityProviders:ClusterCapacityProviders",
               "aws:efs/fileSystem:FileSystem",
               "aws:efs/mountTarget:MountTarget",


### PR DESCRIPTION
When creating a VPC in a secondary region using a custom provider, the `EipAssociation` for NAT instances was not inheriting the provider, causing it to attempt operations in the default region.

eg.

```ts
const secondaryRegionProvider = new aws.Provider("east-2", {
    region: "us-east-2"
})
```

```ts
new sst.aws.Vpc(`secondary-region`, {
    bastion: true,
    nat: {
        type: "ec2"
    },
}, {
    provider: secondaryRegionProvider,
})
```

Changes:

1. Adds { parent: self } to the EipAssociation creation in `vpc.ts` to properly inherit the provider
2. Adds `aws:ec2/eipAssociation:EipAssociation` to the exclusion list in `component.ts`(required for any resource using { parent: self } that doesn't need physical name prefixing)