### PR TITLE
Add SSM permissions for tagging resources

### DIFF
--- a/www/src/content/docs/docs/iam-credentials.mdx
+++ b/www/src/content/docs/docs/iam-credentials.mdx
@@ -215,7 +215,9 @@ Let's start with an IAM policy you can _copy and paste_.
               "ssm:GetParameter",
               "ssm:GetParameters",
               "ssm:GetParametersByPath",
-              "ssm:PutParameter"
+              "ssm:PutParameter",
+              "ssm:AddTagsToResource",
+              "ssm:ListTagsForResource"
           ],
           "Resource": [
               "arn:aws:ssm:REGION:ACCOUNT:parameter/sst/*"


### PR DESCRIPTION
These permissions were required when adding a bastion.