### PR TITLE
Add a "Copy as Markdown" button for the docs pages.

### DIFF
--- a/www/src/components/PageTitle.astro
+++ b/www/src/components/PageTitle.astro
@@ -58,12 +58,26 @@ const isDocsPost = slug.startsWith('docs/');
   const buttons = document.querySelectorAll('[data-copy-as-markdown-button]');
 
   buttons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const body = (button as any).dataset.body;
-      if (body) navigator.clipboard.writeText(body);
+    button.addEventListener('click', async () => {
+      const body = button.dataset.body;
+      if (!body || button.disabled) return;
+
+      try {
+        await navigator.clipboard.writeText(body);
+
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.disabled = true;
+
+        setTimeout(() => {
+          button.textContent = originalText;
+          button.disabled = false;
+        }, 1000);
+      } catch (err) {
+        console.error('Failed to copy markdown:', err);
+      }
     });
   });
-
 </script>
 
 
@@ -85,22 +99,44 @@ p.page-description {
 .title-container {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
 }
 
 .copy-markdown-btn {
-  background: var(--sl-color-bg-accent);
-  color: var(--sl-color-white);
-  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--divider-color);
   border-radius: 4px;
   padding: 0.3rem 0.6rem;
   font-size: 0.875rem;
   cursor: pointer;
-  transition: background 0.2s ease;
+  /* Adding a fixed width to prevent layout shift on press */
+  width: 145px; 
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    opacity 0.2s ease;
 }
 
 .copy-markdown-btn:hover {
-  background: var(--sl-color-bg-accent-hover, #555);
+  color: var(--color-text);
+  border-color: var(--color-text-dimmed);
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-theme='light'] .copy-markdown-btn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Disabled “copied” state */
+.copy-markdown-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+  background: transparent;
+  border-color: var(--color-text-dimmed);
+  color: var(--color-text-dimmed);
 }
 
 h1.blog {

--- a/www/src/components/PageTitle.astro
+++ b/www/src/components/PageTitle.astro
@@ -41,17 +41,19 @@ const isDocsPost = slug.startsWith('docs/');
   : <Fragment>
       <div class="title-container">
         <h1 id="_top">{title}</h1>
-        {
-        isDocsPost ? <button
-          class="copy-markdown-btn"
-          data-copy-as-markdown-button
-          data-body={body}
-        >
-          Copy as Markdown
-        </button> : <Fragment></Fragment>
-        }
+        {isDocsPost ? (
+          <button
+            class="copy-markdown-btn"
+            data-copy-as-markdown-button
+            data-body={body}
+          >
+            Copy as Markdown
+          </button>
+        ) : (
+          <Fragment></Fragment>
+        )}
       </div>
-      { description && <p class="page-description">{description}</p> }
+      {description && <p class="page-description">{description}</p>}
     </Fragment>
 }
 <script>

--- a/www/src/components/PageTitle.astro
+++ b/www/src/components/PageTitle.astro
@@ -13,11 +13,13 @@ const {
 	lastUpdated,
 	entry: {
     data: { title, author },
+    body,
 	},
 } = Astro.locals.starlightRoute;
 const slug = Astro.url.pathname.replace(/^\//, "").replace(/\/$/, "");
 
 const isBlogPost = slug.startsWith('blog/');
+const isDocsPost = slug.startsWith('docs/');
 ---
 
 { isBlogPost
@@ -37,10 +39,33 @@ const isBlogPost = slug.startsWith('blog/');
       </div>
     </Fragment>
   : <Fragment>
-      <h1 id="_top">{title}</h1>
+      <div class="title-container">
+        <h1 id="_top">{title}</h1>
+        {
+        isDocsPost ? <button
+          class="copy-markdown-btn"
+          data-copy-as-markdown-button
+          data-body={body}
+        >
+          Copy as Markdown
+        </button> : <Fragment></Fragment>
+        }
+      </div>
       { description && <p class="page-description">{description}</p> }
     </Fragment>
 }
+<script>
+  const buttons = document.querySelectorAll('[data-copy-as-markdown-button]');
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const body = (button as any).dataset.body;
+      if (body) navigator.clipboard.writeText(body);
+    });
+  });
+
+</script>
+
 
 <style>
 h1 {
@@ -55,6 +80,27 @@ p.page-description {
   margin-top: 0.5rem;
   line-height: 1.5;
   color: var(--color-text-secondary);
+}
+
+.title-container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.copy-markdown-btn {
+  background: var(--sl-color-bg-accent);
+  color: var(--sl-color-white);
+  border: none;
+  border-radius: 4px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.copy-markdown-btn:hover {
+  background: var(--sl-color-bg-accent-hover, #555);
 }
 
 h1.blog {


### PR DESCRIPTION
Add a simple "Copy as Markdown" button next to the title for the docs pages.

I've gotten used to this feature on other docs sites and thought it'd be nice if sst had it. 

https://github.com/user-attachments/assets/3d17f592-5a94-4156-bdbe-8ab2338af44e

