### PR TITLE
add node 24 as a lambda runtime

### DIFF
--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -23,6 +23,7 @@ var forceExternal = []string{
 }
 
 var targetMap = map[string]esbuild.Target{
+	"nodejs24.x": esbuild.ES2023,
 	"nodejs22.x": esbuild.ES2023,
 	"nodejs20.x": esbuild.ES2023,
 	"nodejs18.x": esbuild.ES2022,

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -311,7 +311,7 @@ export interface FunctionArgs {
    * @example
    * ```js
    * {
-   *   runtime: "nodejs22.x"
+   *   runtime: "nodejs24.x"
    * }
    * ```
    */
@@ -319,6 +319,7 @@ export interface FunctionArgs {
     | "nodejs18.x"
     | "nodejs20.x"
     | "nodejs22.x"
+    | "nodejs24.x"
     | "go"
     | "rust"
     | "provided.al2023"

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -230,12 +230,12 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
      * ```js
      * {
      *   server: {
-     *     runtime: "nodejs22.x"
+     *     runtime: "nodejs24.x"
      *   }
      * }
      * ```
      */
-    runtime?: Input<"nodejs18.x" | "nodejs20.x" | "nodejs22.x">;
+    runtime?: Input<"nodejs18.x" | "nodejs20.x" | "nodejs22.x" | "nodejs24.x";
     /**
      * The maximum amount of time the server function can run.
      *


### PR DESCRIPTION
Since AWS now supports nodejs 24 lts, we should add it as a runtime target.

I would like to update esbuild to 0.27.2 also because it ads ES2024 as a build target and because this is the node 24 es target we would have full access to all node 24 stuff.

We are running on esbuild 0.21.5 which was released back in 2024
i tried upgrading to the new esbuild and it seems to be working.
But that should probably be a breaking change since it might cause problems.

Fixed #6287