### PR TITLE
fix(vpc): use elastic IP for tunnel connection when available

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -680,14 +680,17 @@ export class Vpc extends Component implements Link.Linkable {
       self.registerOutputs({
         _tunnel: all([
           self.bastionInstance,
+          self.elasticIps,
           self.privateKeyValue,
           self._privateSubnets,
           self._publicSubnets,
         ]).apply(
-          ([bastion, privateKeyValue, privateSubnets, publicSubnets]) => {
+          ([bastion, elasticIps, privateKeyValue, privateSubnets, publicSubnets]) => {
             if (!bastion) return;
             return {
-              ip: bastion.publicIp,
+              // if we have elastic IPs, use the first one (NAT instance IP will be replaced
+              // by EIP after creation) with fallback to bastion public IP (should not happen)
+              ip: elasticIps.length ? elasticIps[0].publicIp : bastion.publicIp,
               username: "ec2-user",
               privateKey: privateKeyValue!,
               subnets: [...privateSubnets, ...publicSubnets].map(


### PR DESCRIPTION
When elastic IPs are configured, use the first elastic IP address for the tunnel connection instead of the bastion instance's public IP. This ensures the tunnel uses the stable NAT instance IP (which gets replaced by the EIP after creation) rather than a potentially changing public IP address.

Addresses #6305.