### PR TITLE
fix(platform): update bridge task url after github org rename

### DIFF
--- a/platform/scripts/build
+++ b/platform/scripts/build
@@ -21,7 +21,7 @@ cp ./functions/docker/python.Dockerfile ./dist/dockerfiles/python.Dockerfile
 cd ./support/bridge-task
 timestamp=$(date +%Y%m%d%H%M%S)
 docker buildx create --name multi --driver docker-container --use
-docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/sst/sst/bridge-task:$timestamp -t ghcr.io/sst/sst/bridge-task:latest $([ "$DOCKER_PUSH" = "true" ] && echo "--push") .
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/anomalyco/sst/bridge-task:$timestamp -t ghcr.io/anomalyco/sst/bridge-task:latest $([ "$DOCKER_PUSH" = "true" ] && echo "--push") .
 
 
 cd $ORIGINAL_DIR

--- a/platform/src/components/aws/task.ts
+++ b/platform/src/components/aws/task.ts
@@ -326,7 +326,9 @@ export class Task extends Component implements Link.Linkable {
             return [
               {
                 ...v[0],
-                image: output("ghcr.io/sst/sst/bridge-task:20241224005724"),
+                image: output(
+                  "ghcr.io/anomalyco/sst/bridge-task:20241224005724",
+                ),
                 environment: {
                   ...v[0].environment,
                   SST_TASK_ID: name,


### PR DESCRIPTION
## Overview

  The GitHub org was renamed from `sst` to `anomalyco`, making the `bridge-task` container image inaccessible at its hardcoded URL. This breaks Task dev mode (`sst dev` with `sst.aws.Task`) because ECS cannot pull the image.

  Production deployments are unaffected since they use the user's own Docker image.

  ### Changes

  - Update `bridge-task` image URL from `ghcr.io/sst/sst/` to `ghcr.io/anomalyco/sst/` in `platform/src/components/aws/task.ts`
  - Update build script to push to the new registry location in `platform/scripts/build`

  Fixes #6307

  ## Steps to reproduce

  1. Run `sst dev` with a Task component (e.g., `examples/aws-task`)
  2. Trigger the task via the linked Lambda function
  3. The ECS task fails with:
     CannotPullContainerError: failed to resolve ref ghcr.io/sst/sst/bridge-task:20241224005724:
     failed to authorize: 403 Forbidden

  ## Steps to validate the fix

  ```bash
  # Build and link the SDK
  cd sdk/js
  bun install
  bun run build
  bun link

  # Set up the example
  cd ../examples/aws-task
  bun link sst

  # Run dev mode
  go run ../../cmd/sst dev

  # Trigger the task via the Lambda URL shown in output
  curl <lambda-url>
  ```

  The task should execute successfully without the CannotPullContainerError.
