### PR TITLE
feat(bucket): support custom bucket lifecycle rule ids

### DIFF
--- a/examples/aws-bucket-lifecycle-rules/sst-env.d.ts
+++ b/examples/aws-bucket-lifecycle-rules/sst-env.d.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+import "sst"
+declare module "sst" {
+  export interface Resource {
+    MyBucket: {
+      name: string
+      type: "sst.aws.Bucket"
+    }
+  }
+}
+export {}

--- a/examples/aws-bucket-lifecycle-rules/sst.config.ts
+++ b/examples/aws-bucket-lifecycle-rules/sst.config.ts
@@ -1,9 +1,9 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
 /**
- * ## Bucket policy
+ * ## Bucket lifecycle policies
  *
- * Create an S3 bucket and transform its bucket policy.
+ * Configure S3 bucket lifecycle policies to expire objects automatically.
  */
 export default $config({
   app(input) {

--- a/examples/aws-bucket-lifecycle-rules/sst.config.ts
+++ b/examples/aws-bucket-lifecycle-rules/sst.config.ts
@@ -17,16 +17,15 @@ export default $config({
     const bucket = new sst.aws.Bucket("MyBucket", {
       lifecycle: [
         {
-          expiresIn: "30 days",
+          expiresIn: "60 days",
         },
         {
           id: "expire-tmp-files",
-          prefix: "tmp1/",
+          prefix: "tmp/",
           expiresIn: "30 days",
         },
         {
-          // id: "expire-tmp-files",
-          prefix: "tmp2/",
+          prefix: "data/",
           expiresAt: "2028-12-31",
         },
       ],

--- a/examples/aws-bucket-lifecycle-rules/sst.config.ts
+++ b/examples/aws-bucket-lifecycle-rules/sst.config.ts
@@ -1,0 +1,39 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * ## Bucket policy
+ *
+ * Create an S3 bucket and transform its bucket policy.
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "aws-bucket-lifecycle-rules",
+      home: "aws",
+      removal: input?.stage === "production" ? "retain" : "remove",
+    };
+  },
+  async run() {
+    const bucket = new sst.aws.Bucket("MyBucket", {
+      lifecycle: [
+        {
+          expiresIn: "30 days",
+        },
+        {
+          id: "expire-tmp-files",
+          prefix: "tmp1/",
+          expiresIn: "30 days",
+        },
+        {
+          // id: "expire-tmp-files",
+          prefix: "tmp2/",
+          expiresAt: "2028-12-31",
+        },
+      ],
+    });
+
+    return {
+      bucket: bucket.name,
+    };
+  },
+});


### PR DESCRIPTION
Based on the great work by @mkilp in #6209 I thought it would be helpful to be able to set custom lifecycle rule ids. Custom, descriptive ids are easier to recognize in logs and the aws console.

### Success
<img width="859" height="179" alt="Bildschirmfoto 2026-01-07 um 16 19 18" src="https://github.com/user-attachments/assets/55f603e3-0f60-452d-9799-c7a728abffbd" />
<img width="693" height="132" alt="Bildschirmfoto 2026-01-07 um 16 19 05" src="https://github.com/user-attachments/assets/91aaaf5c-4a81-4dac-a864-2f8c46e80e7a" />

### Error Message
...when using a duplicate id for example
<img width="858" height="210" alt="Bildschirmfoto 2026-01-07 um 16 18 18" src="https://github.com/user-attachments/assets/f9ceebe8-629c-4098-9a3b-02b01d933959" />

