### PR TITLE
fix: prioritise SST's Pulumi over system-installed versions

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -249,6 +249,13 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 	}
 
 	env := os.Environ()
+	// Prepend SST's bin directory to PATH to ensure SST's Pulumi is used over system-installed versions
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + global.BinPath() + string(os.PathListSeparator) + strings.TrimPrefix(e, "PATH=")
+			break
+		}
+	}
 	for key, value := range p.Env() {
 		env = append(env, fmt.Sprintf("%v=%v", key, value))
 	}


### PR DESCRIPTION
## Summary

- Prepend SST's bin directory to PATH when spawning Pulumi processes
- Ensures SST uses its bundled Pulumi binaries instead of system-installed versions

## Problem

Fixes deployment failures on GitHub Actions `ubuntu-latest` runners where Pulumi v3.214.0+ is pre-installed. The newer Pulumi removed the `-root` flag from `pulumi-language-nodejs`, causing compatibility issues with SST's bundled Pulumi SDK (v3.210.0).

Closes https://github.com/sst/sst/issues/6314

## Test plan

- [x] `go build ./cmd/sst` - builds successfully
- [x] `go fmt` / `go vet` - no issues
- [ ] Test deployment on GitHub Actions with `ubuntu-latest`