### PR TITLE
fix: race condition in basic mode server startup

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -302,6 +302,7 @@ func CmdMosaic(c *cli.Cli) error {
 
 	if mode == "basic" {
 		wg.Go(func() error {
+			<-server.Ready
 			return CmdUI(c)
 		})
 	}


### PR DESCRIPTION
Race condition causing sst dev --mode=basic to hang on startup

In basic mode, the UI client was attempting to connect to the HTTP server before it was ready to accept connections, resulting in "connection refused" errors and causing the application to hang
indefinitely.

Root cause: server.Start() runs in a goroutine while CmdUI() immediately tries to connect, creating a race between server initialization and client connection.

Solution:

• Added a Ready channel to the Server struct that signals when the server is listening
• Modified basic mode to wait on <-server.Ready before starting the UI
• Close the Ready channel after net.Listen() succeeds (and on error to prevent infinite hangs)

fixes #3990