### PR TITLE
Allow esbuild options to be configured in Worker runtime

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -138,6 +138,19 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		},
 	}
 
+	// Apply user overrides for configurable esbuild options
+	if !build.ESBuild.KeepNames {
+		options.KeepNames = false
+	}
+
+	if build.ESBuild.Target != 0 {
+		options.Target = build.ESBuild.Target
+	}
+
+	if build.ESBuild.Sourcemap != 0 {
+		options.Sourcemap = build.ESBuild.Sourcemap
+	}
+
 	w.lock.RLock()
 	buildContext, ok := w.contexts[input.FunctionID]
 	w.lock.RUnlock()


### PR DESCRIPTION
Previously, KeepNames, Target, and Sourcemap options were hardcoded and ignored user configuration. This allows users to override these options via transform.server.build.esbuild to resolve issues like SSR hydration problems in TanStack Start applications.

Note: KeepNames defaults to true. Only override if user explicitly disables it. For Target and Sourcemap, check non-zero values as zero represents "not set" for these enums.

Fixes #6293