### PR TITLE
fix: Docker image pull for bridge-task

### DIFF
--- a/platform/src/components/aws/task.ts
+++ b/platform/src/components/aws/task.ts
@@ -326,7 +326,7 @@ export class Task extends Component implements Link.Linkable {
             return [
               {
                 ...v[0],
-                image: output("ghcr.io/sst/sst/bridge-task:20241224005724"),
+                image: output("ghcr.io/anomalyco/sst/bridge-task:latest"),
                 environment: {
                   ...v[0].environment,
                   SST_TASK_ID: name,


### PR DESCRIPTION
It appears that the organisation rename breaks the ghcr.io pulls. :( 

Tasks are failing in development;

<img width="1442" height="146" alt="image" src="https://github.com/user-attachments/assets/bbac3228-b751-4640-ad98-a6dc42ea2703" />
