### PR TITLE
fix: ReferenceError when AWS Router's viewerRequest injection uses await

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1485,9 +1485,8 @@ async function handler(event) {
   ${blockCloudfrontUrlInjection}
   ${CF_ROUTER_INJECTION}
 
-  const routerNS = "${kvNamespace}";
-
   async function getRoutes() {
+    const routerNS = "${kvNamespace}";
     let routes = [];
     try {
       const v = await cf.kvs().get(routerNS + ":routes");


### PR DESCRIPTION
Fixes #6331

## Problem
When using `await` in `edge.viewerRequest.injection`, accessing `routerNS` inside `getRoutes()` throws a `ReferenceError:  cannot access variable before initialization` due to temporal dead zone (TDZ) issues in the generated CloudFront Function code.

## Solution
Moved the `routerNS` declaration inside the `getRoutes()` function where it's actually used.  This prevents the TDZ issue when the injected code contains `await` statements.

## Changes
- Modified `platform/src/components/aws/router.ts`
- Moved `const routerNS = "${kvNamespace}";` from outside `getRoutes()` to inside it

## Testing
- Verified code compiles successfully with `bun run build`
- The fix matches the workaround mentioned in the issue that resolves the problem