### PR TITLE
Bumping default version of OpenNext to 3.9.8

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -11,7 +11,7 @@ import { isALteB } from "../../util/compare-semver.js";
 import { Plan, SsrSite, SsrSiteArgs } from "./ssr-site.js";
 import { Bucket } from "./bucket.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.6.6";
+const DEFAULT_OPEN_NEXT_VERSION = "3.9.8";
 
 type BaseFunction = {
   handler: string;


### PR DESCRIPTION
The current default version (3.6.6) was released in June, so I think it's time to bump this to the latest version.