### PR TITLE
Fix tunnel not working after pulumi upgrade

### DIFF
--- a/pkg/project/completed.go
+++ b/pkg/project/completed.go
@@ -151,6 +151,10 @@ func parsePlaintext(input interface{}) interface{} {
 		var parsed any
 		json.Unmarshal([]byte(cast.Plaintext), &parsed)
 		return parsed
+	case *apitype.SecretV1:
+		var parsed any
+		json.Unmarshal([]byte(cast.Plaintext), &parsed)
+		return parsed
 	case map[string]interface{}:
 		for key, value := range cast {
 			cast[key] = parsePlaintext(value)


### PR DESCRIPTION
After the pulumi upgrade it seems the type for decrypted secret changed from `apitype.SecretV1` to `*apitype.SecretV1` . This broke the tunnel.

This PR just adds a case for handling when the type is a pointer, without removing or altering the existing logic.
As a result the tunnel works again: 

Before fix (the bug):

<img width="817" height="107" alt="image" src="https://github.com/user-attachments/assets/1c262b6f-861f-4cca-aff5-44ab95dbe4f1" />


After fix:

<img width="868" height="356" alt="image" src="https://github.com/user-attachments/assets/6d6d6eb4-313c-4b25-a7ad-466f4fcc7b66" />
