### PR TITLE
Fix `Function.addEnvironment` not updating on redeploy

### DIFF
--- a/pkg/server/resource/aws-function-environment-update.go
+++ b/pkg/server/resource/aws-function-environment-update.go
@@ -16,9 +16,7 @@ type FunctionEnvironmentUpdateInputs struct {
 	Region       string            `json:"region"`
 }
 
-type FunctionEnvironmentUpdateOutputs struct {
-	Updated bool `json:"updated"`
-}
+type FunctionEnvironmentUpdateOutputs struct{}
 
 func (r *FunctionEnvironmentUpdate) Create(input *FunctionEnvironmentUpdateInputs, output *CreateResult[FunctionEnvironmentUpdateOutputs]) error {
 	if err := r.updateEnvironment(input); err != nil {
@@ -27,9 +25,6 @@ func (r *FunctionEnvironmentUpdate) Create(input *FunctionEnvironmentUpdateInput
 
 	*output = CreateResult[FunctionEnvironmentUpdateOutputs]{
 		ID: input.FunctionName,
-		Outs: FunctionEnvironmentUpdateOutputs{
-			Updated: true,
-		},
 	}
 	return nil
 }
@@ -39,27 +34,13 @@ func (r *FunctionEnvironmentUpdate) Update(input *UpdateInput[FunctionEnvironmen
 		return err
 	}
 
-	*output = UpdateResult[FunctionEnvironmentUpdateOutputs]{
-		Outs: FunctionEnvironmentUpdateOutputs{
-			Updated: true,
-		},
-	}
+	*output = UpdateResult[FunctionEnvironmentUpdateOutputs]{}
 	return nil
 }
 
 func (r *FunctionEnvironmentUpdate) Read(input *ReadInput[FunctionEnvironmentUpdateInputs], output *ReadResult[FunctionEnvironmentUpdateOutputs]) error {
 	*output = ReadResult[FunctionEnvironmentUpdateOutputs]{
 		ID: input.ID,
-		Outs: FunctionEnvironmentUpdateOutputs{
-			Updated: false,
-		},
-	}
-	return nil
-}
-
-func (r *FunctionEnvironmentUpdate) Diff(input *DiffInput[FunctionEnvironmentUpdateInputs, FunctionEnvironmentUpdateOutputs], output *DiffResult) error {
-	*output = DiffResult{
-		Changes: input.Olds.Updated != true,
 	}
 	return nil
 }
@@ -74,7 +55,7 @@ func (r *FunctionEnvironmentUpdate) updateEnvironment(input *FunctionEnvironment
 	if input.Region != "" {
 		cfg.Region = input.Region
 	}
-	
+
 	client := lambda.NewFromConfig(cfg)
 
 	// Get the current function configuration to preserve other settings
@@ -87,14 +68,14 @@ func (r *FunctionEnvironmentUpdate) updateEnvironment(input *FunctionEnvironment
 
 	// Create environment variables map
 	envVars := make(map[string]string)
-	
+
 	// If the function already has environment variables, preserve them
 	if functionConfig.Environment != nil && functionConfig.Environment.Variables != nil {
 		for k, v := range functionConfig.Environment.Variables {
 			envVars[k] = v
 		}
 	}
-	
+
 	// Add or update with the new environment variables
 	for k, v := range input.Environment {
 		envVars[k] = v
@@ -107,6 +88,6 @@ func (r *FunctionEnvironmentUpdate) updateEnvironment(input *FunctionEnvironment
 			Variables: envVars,
 		},
 	})
-	
+
 	return err
-} 
+}


### PR DESCRIPTION
closes #6264

the diff logic was incorrect because

removing `Diff` entirely lets Pulumi use its default input comparison, which correctly detects when the `environment` changes. we are already doing something similar for the `aws-function-code-updater.go`

<details>

<summary>proof of it working</summary>

```ts
const api = new sst.aws.Function("MyFunction", {
  url: true,
  handler: "index.handler"
});

api.addEnvironment({
  TEST: "1234"
})
```

<img width="1346" height="324" alt="CleanShot 2026-01-20 at 11 49 10@2x" src="https://github.com/user-attachments/assets/a51cc81f-74f3-4948-ab68-3ffbe43a8bda" />

change `TEST=5678` and redeploy:

<img width="1288" height="304" alt="CleanShot 2026-01-20 at 11 49 47@2x" src="https://github.com/user-attachments/assets/47a6f801-ffb4-4184-ad09-a074d0fc14d6" />

</details>