### PR TITLE
Add `--exclude` flag to CLI commands

### DIFF
--- a/cmd/sst/deploy.go
+++ b/cmd/sst/deploy.go
@@ -29,6 +29,12 @@ var CmdDeploy = &cli.Command{
 			"sst deploy --target MyComponent",
 			"```",
 			"",
+			"Alternatively, exclude a specific component from the deploy.",
+			"",
+			"```bash frame=\"none\"",
+			"sst deploy --exclude MyComponent",
+			"```",
+			"",
 			"All the resources are deployed as concurrently as possible, based on their dependencies.",
 			"For resources like your container images, sites, and functions; it first builds them and then deploys the generated assets.",
 			"",
@@ -90,6 +96,14 @@ var CmdDeploy = &cli.Command{
 			},
 		},
 		{
+			Name: "exclude",
+			Type: "string",
+			Description: cli.Description{
+				Short: "Exclude a component",
+				Long:  "Exclude the specified component from the operation.",
+			},
+		},
+		{
 			Name: "continue",
 			Type: "bool",
 			Description: cli.Description{
@@ -126,6 +140,11 @@ var CmdDeploy = &cli.Command{
 			target = strings.Split(c.String("target"), ",")
 		}
 
+		exclude := []string{}
+		if c.String("exclude") != "" {
+			exclude = strings.Split(c.String("exclude"), ",")
+		}
+
 		var wg errgroup.Group
 		defer wg.Wait()
 		out := make(chan interface{})
@@ -152,6 +171,7 @@ var CmdDeploy = &cli.Command{
 		err = p.Run(c.Context, &project.StackInput{
 			Command:    "deploy",
 			Target:     target,
+			Exclude:    exclude,
 			Dev:        c.Bool("dev"),
 			ServerPort: s.Port,
 			Verbose:    c.Bool("verbose"),

--- a/cmd/sst/diff.go
+++ b/cmd/sst/diff.go
@@ -39,6 +39,12 @@ var CmdDiff = &cli.Command{
 			"sst diff --target MyComponent",
 			"```",
 			"",
+			"Alternatively, exclude a specific component from the diff.",
+			"",
+			"```bash frame=\"none\"",
+			"sst diff --exclude MyComponent",
+			"```",
+			"",
 			"By default, this compares to the last deploy of the given stage as it would be",
 			"deployed using `sst deploy`. But if you are working in dev mode using `sst dev`,",
 			"you can use the `--dev` flag.",
@@ -56,6 +62,14 @@ var CmdDiff = &cli.Command{
 			Description: cli.Description{
 				Short: "Run it only for a component",
 				Long:  "Only run it for the given component.",
+			},
+		},
+		{
+			Name: "exclude",
+			Type: "string",
+			Description: cli.Description{
+				Short: "Exclude a component",
+				Long:  "Exclude the specified component from the operation.",
 			},
 		},
 		{
@@ -87,6 +101,11 @@ var CmdDiff = &cli.Command{
 		target := []string{}
 		if c.String("target") != "" {
 			target = strings.Split(c.String("target"), ",")
+		}
+
+		exclude := []string{}
+		if c.String("exclude") != "" {
+			exclude = strings.Split(c.String("exclude"), ",")
 		}
 
 		var wg errgroup.Group
@@ -121,6 +140,7 @@ var CmdDiff = &cli.Command{
 			ServerPort: s.Port,
 			Dev:        c.Bool("dev"),
 			Target:     target,
+			Exclude:    exclude,
 			Verbose:    c.Bool("verbose"),
 		})
 		if err != nil {

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -805,6 +805,12 @@ var root = &cli.Command{
 					"```bash frame=\"none\"",
 					"sst remove --target MyComponent",
 					"```",
+					"",
+					"Alternatively, exclude a specific component from the remove.",
+					"",
+					"```bash frame=\"none\"",
+					"sst remove --exclude MyComponent",
+					"```",
 				}, "\n"),
 			},
 			Flags: []cli.Flag{
@@ -814,6 +820,14 @@ var root = &cli.Command{
 					Description: cli.Description{
 						Short: "Run it only for a component",
 						Long:  "Only run it for the given component.",
+					},
+				},
+				{
+					Name: "exclude",
+					Type: "string",
+					Description: cli.Description{
+						Short: "Exclude a component",
+						Long:  "Exclude the specified component from the operation.",
 					},
 				},
 			},
@@ -968,6 +982,12 @@ var root = &cli.Command{
 					"sst refresh --target MyComponent",
 					"```",
 					"",
+					"Alternatively, exclude a specific component from the refresh.",
+					"",
+					"```bash frame=\"none\"",
+					"sst refresh --exclude MyComponent",
+					"```",
+					"",
 					"This is useful for cases where you want to ensure that your local state is in sync with your cloud provider. [Learn more about how state works](/docs/providers/#how-state-works).",
 				}, "\n"),
 			},
@@ -978,6 +998,14 @@ var root = &cli.Command{
 					Description: cli.Description{
 						Short: "Run it only for a component",
 						Long:  "Only run it for the given component.",
+					},
+				},
+				{
+					Name: "exclude",
+					Type: "string",
+					Description: cli.Description{
+						Short: "Exclude a component",
+						Long:  "Exclude the specified component from the operation.",
 					},
 				},
 			},

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -805,12 +805,6 @@ var root = &cli.Command{
 					"```bash frame=\"none\"",
 					"sst remove --target MyComponent",
 					"```",
-					"",
-					"Alternatively, exclude a specific component from the remove.",
-					"",
-					"```bash frame=\"none\"",
-					"sst remove --exclude MyComponent",
-					"```",
 				}, "\n"),
 			},
 			Flags: []cli.Flag{
@@ -820,14 +814,6 @@ var root = &cli.Command{
 					Description: cli.Description{
 						Short: "Run it only for a component",
 						Long:  "Only run it for the given component.",
-					},
-				},
-				{
-					Name: "exclude",
-					Type: "string",
-					Description: cli.Description{
-						Short: "Exclude a component",
-						Long:  "Exclude the specified component from the operation.",
 					},
 				},
 			},

--- a/cmd/sst/refresh.go
+++ b/cmd/sst/refresh.go
@@ -23,6 +23,11 @@ func CmdRefresh(c *cli.Cli) error {
 		target = strings.Split(c.String("target"), ",")
 	}
 
+	exclude := []string{}
+	if c.String("exclude") != "" {
+		exclude = strings.Split(c.String("exclude"), ",")
+	}
+
 	var wg errgroup.Group
 	defer wg.Wait()
 	ui := ui.New(c.Context)
@@ -47,6 +52,7 @@ func CmdRefresh(c *cli.Cli) error {
 	err = p.Run(c.Context, &project.StackInput{
 		Command:    "refresh",
 		Target:     target,
+		Exclude:    exclude,
 		ServerPort: s.Port,
 		Verbose:    c.Bool("verbose"),
 	})

--- a/cmd/sst/remove.go
+++ b/cmd/sst/remove.go
@@ -23,6 +23,11 @@ func CmdRemove(c *cli.Cli) error {
 		target = strings.Split(c.String("target"), ",")
 	}
 
+	exclude := []string{}
+	if c.String("exclude") != "" {
+		exclude = strings.Split(c.String("exclude"), ",")
+	}
+
 	var wg errgroup.Group
 	defer wg.Wait()
 	ui := ui.New(c.Context)
@@ -47,6 +52,7 @@ func CmdRemove(c *cli.Cli) error {
 	err = p.Run(c.Context, &project.StackInput{
 		Command:    "remove",
 		Target:     target,
+		Exclude:    exclude,
 		ServerPort: s.Port,
 		Verbose:    c.Bool("verbose"),
 	})

--- a/cmd/sst/remove.go
+++ b/cmd/sst/remove.go
@@ -23,11 +23,6 @@ func CmdRemove(c *cli.Cli) error {
 		target = strings.Split(c.String("target"), ",")
 	}
 
-	exclude := []string{}
-	if c.String("exclude") != "" {
-		exclude = strings.Split(c.String("exclude"), ",")
-	}
-
 	var wg errgroup.Group
 	defer wg.Wait()
 	ui := ui.New(c.Context)
@@ -52,7 +47,6 @@ func CmdRemove(c *cli.Cli) error {
 	err = p.Run(c.Context, &project.StackInput{
 		Command:    "remove",
 		Target:     target,
-		Exclude:    exclude,
 		ServerPort: s.Port,
 		Verbose:    c.Bool("verbose"),
 	})

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -337,6 +337,21 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 		}
 	}
 
+	if input.Exclude != nil {
+		for _, item := range input.Exclude {
+			index := slices.IndexFunc(completed.Resources, func(res apitype.ResourceV3) bool {
+				return res.URN.Name() == item
+			})
+			if index == -1 {
+				return util.NewReadableError(nil, fmt.Sprintf("Exclude target not found: %v", item))
+			}
+			args = append(args, "--exclude", string(completed.Resources[index].URN))
+		}
+		if len(input.Exclude) > 0 {
+			args = append(args, "--exclude-dependents")
+		}
+	}
+
 	cmd := process.Command(pulumiPath, args...)
 	process.Detach(cmd)
 	cmd.Env = env

--- a/pkg/project/stack.go
+++ b/pkg/project/stack.go
@@ -16,6 +16,7 @@ type BuildFailedEvent struct {
 type StackInput struct {
 	Command    string
 	Target     []string
+	Exclude    []string
 	ServerPort int
 	Dev        bool
 	Verbose    bool


### PR DESCRIPTION
closes #5953

<details>

<summary>proof of it working</summary>

deploying the `aws-hono` example:

<img width="2048" height="1288" alt="CleanShot 2026-01-20 at 17 04 04@2x" src="https://github.com/user-attachments/assets/490f4eae-9b20-44a9-88c0-049a575a7de4" />

---

change something in the bucket, and redeploy with `--exclude Hono`:

<img width="2160" height="782" alt="CleanShot 2026-01-20 at 17 13 20@2x" src="https://github.com/user-attachments/assets/828c8f71-a65c-4deb-bfae-7ffe3c6f5414" />

---

running `sst refresh --exclude Hono`:

<img width="2186" height="862" alt="CleanShot 2026-01-20 at 17 35 11@2x" src="https://github.com/user-attachments/assets/f4f6a999-6efc-4015-9634-706321f815a5" />

---

running `sst diff --exclude Hono`:

<img width="1392" height="496" alt="CleanShot 2026-01-20 at 17 37 35@2x" src="https://github.com/user-attachments/assets/266d9100-3727-4805-a02b-601530acbd83" />

---

excluding multiple components:

<img width="1670" height="648" alt="CleanShot 2026-01-20 at 17 43 40@2x" src="https://github.com/user-attachments/assets/e4f3dd21-6423-46fd-a7b8-6543a52f8df0" />

</details>