### PR TITLE
Handle imported VPC and EIPs for tunnel

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -557,16 +557,6 @@ export class Vpc extends Component implements Link.Linkable {
             ),
         );
       });
-      const elasticIps = natGateways.apply((nats) =>
-        nats.map((nat, i) =>
-          ec2.Eip.get(
-            `${name}ElasticIp${i + 1}`,
-            nat.allocationId as Output<string>,
-            undefined,
-            { parent: self },
-          ),
-        ),
-      );
       const natInstances = ec2
         .getInstancesOutput(
           {
@@ -584,6 +574,38 @@ export class Vpc extends Component implements Link.Linkable {
             }),
           ),
         );
+      const elasticIps = all([natGateways, natInstances]).apply(
+        ([natGateways, natInstances]) => {
+          if (natGateways.length) {
+            return output(
+              natGateways.map((nat, i) =>
+                ec2.Eip.get(
+                  `${name}ElasticIp${i + 1}`,
+                  nat.allocationId as Output<string>,
+                  undefined,
+                  { parent: self },
+                ),
+              ),
+            );
+          }
+          return ec2
+            .getEipsOutput({
+              filters: [
+                {
+                  name: "instance-id",
+                  values: natInstances.map((instance) => instance.id),
+                },
+              ],
+            })
+            .allocationIds.apply((ids) =>
+              ids.map((id, i) =>
+                ec2.Eip.get(`${name}ElasticIp${i + 1}`, id, undefined, {
+                  parent: self,
+                }),
+              ),
+            );
+        },
+      );
       const bastionInstance = ec2
         .getInstancesOutput(
           {
@@ -683,16 +705,24 @@ export class Vpc extends Component implements Link.Linkable {
         _tunnel: all([
           self.bastionInstance,
           self.elasticIps,
+          self.natInstances,
           self.privateKeyValue,
           self._privateSubnets,
           self._publicSubnets,
         ]).apply(
-          ([bastion, elasticIps, privateKeyValue, privateSubnets, publicSubnets]) => {
+          ([
+            bastion,
+            elasticIps,
+            natInstances,
+            privateKeyValue,
+            privateSubnets,
+            publicSubnets,
+          ]) => {
             if (!bastion) return;
             return {
-              ip: self.natInstances.apply((instances) =>
-                instances.length ? elasticIps[0]?.publicIp : bastion.publicIp,
-              ),
+              ip: natInstances.length
+                ? elasticIps[0]?.publicIp
+                : bastion.publicIp,
               username: "ec2-user",
               privateKey: privateKeyValue!,
               subnets: [...privateSubnets, ...publicSubnets].map(
@@ -871,7 +901,12 @@ export class Vpc extends Component implements Link.Linkable {
     function createElasticIps() {
       return all([nat, publicSubnets]).apply(([nat, subnets]) => {
         if (!nat) return [];
-        if (nat?.ip) return [];
+        if (nat.ip)
+          return nat.ip.map((allocationId, i) =>
+            ec2.Eip.get(`${name}ElasticIp${i + 1}`, allocationId, undefined, {
+              parent: self,
+            }),
+          );
 
         return subnets.map(
           (_, i) =>

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -590,14 +590,19 @@ export class Vpc extends Component implements Link.Linkable {
           }
           if (natInstances.length) {
             return ec2
-              .getEipsOutput({
-                filters: [
-                  {
-                    name: "instance-id",
-                    values: natInstances.map((instance) => instance.id),
-                  },
-                ],
-              })
+              .getEipsOutput(
+                {
+                  filters: [
+                    {
+                      name: "instance-id",
+                      values: natInstances.map((instance) => instance.id),
+                    },
+                  ],
+                },
+                {
+                  parent: self,
+                },
+              )
               .allocationIds.apply((ids) =>
                 ids.map((id, i) =>
                   ec2.Eip.get(`${name}ElasticIp${i + 1}`, id, undefined, {


### PR DESCRIPTION
closes #6309 
This fixes a couple of issues with the tunnel using imported VPC (i.e through sst.aws.Vpc.get()) 

- Tunnel did not work for imported VPCs using Nat instances, as there was no way to query the elastic ip.
- Tunnel did not work for VPC and imported EIPs (i.e., EIP that were passed in via the nat.ip prop). Because the elastic ips were not fetched and saved in the output.
- Fix bug where the natInstances output was not being used.


Scenarios tested (test case is that the tunnel is able to connect and I am able to ping a private ip address in the vpc):
- VPC with no nat ✔️
- Shared VPC with no nat ✔️
- VPC with nat instances ✔️
- Shared VPC with nat instances ✔️
- VPC with nat instances and imported EIPS  ✔️
- Shared VPC with nat instances and imported EIPS ✔️
- VPC with managed nat gateway ✔️
- Shared VPC with managed nat gateway ✔️
- VPC with managed nat gateway and imported EIPS ✔️
- Shared VPC with managed nat gateway and imported EIPS ✔️