### PR TITLE
fix(Vpc): use self.natInstances in registerOutputs to fix Vpc.get() with bastion

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -690,7 +690,7 @@ export class Vpc extends Component implements Link.Linkable {
           ([bastion, elasticIps, privateKeyValue, privateSubnets, publicSubnets]) => {
             if (!bastion) return;
             return {
-              ip: natInstances.apply((instances) =>
+              ip: self.natInstances.apply((instances) =>
                 instances.length ? elasticIps[0]?.publicIp : bastion.publicIp,
               ),
               username: "ec2-user",


### PR DESCRIPTION
## Summary

- Fixes `Vpc.get()` failing with `ReferenceError: Cannot access 'natInstances' before initialization` when referencing a VPC created with `bastion: true`

## Problem

When using `sst.aws.Vpc.get()` to reference an existing VPC that was created with `bastion: true`, deployment fails with:

```
ReferenceError: Cannot access 'natInstances' before initialization
```

## Root Cause

In `platform/src/components/aws/vpc.ts`, the `registerOutputs()` function references the local variable `natInstances` instead of the class property `self.natInstances`.

When using `Vpc.get()` (the ref path, lines 370-386), `registerOutputs()` is called at line 385, but the local `const natInstances = createNatInstances();` is only defined at line 401 (after the ref code path returns).

In the ref path, `this.natInstances` is properly set from `ref.natInstances`, but the `registerOutputs()` function incorrectly references the local variable instead of the class property.

## Fix

Change `natInstances` to `self.natInstances` in the `registerOutputs()` function (line 693).

Fixes #6346

This is a regression from #5820