### PR TITLE
Fix dev command timeout / restart

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -74,6 +74,8 @@ func CmdMosaic(c *cli.Cli) error {
 		var last *dev.EnvResponse
 		processExited := make(chan bool)
 		timeout := time.Minute * 50
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
 
 		for {
 			select {
@@ -82,12 +84,13 @@ func CmdMosaic(c *cli.Cli) error {
 			case <-processExited:
 				c.Cancel()
 				continue
-			case <-time.After(timeout):
+			case <-timer.C:
 				last = nil
 				go func() {
 					evts <- true
 				}()
 				fmt.Println("[timeout]")
+				timer.Reset(timeout)
 				continue
 			case _, ok := <-evts:
 				if !ok {


### PR DESCRIPTION
closes #6345 

The timeout timer was being recreated every time a deployment completion event happened as the timer was initilised within the event loop, this means if you are changing stack code and deploying within the ~50 minute window, then the timer would reset, even though the dev task is still running.

To reproduce the original issue:

set `timeout := time.Seconds * 30`

With a long running task, e.g.:
```
   new sst.x.DevCommand("Hi", {
      dev: {
        command: "sleep 60",
      },
    });
```

Save / touch the sst.config.ts file, which causes a deployment from the watcher.

Note that the timeout and restart never occurs, and the command eventually exits.

With the change in this PR, this issue is resolved and the dev command restarts as expected after 30 seconds, regardless of deployments completing.
 