### PR TITLE
Refactor Pulumi and AWS wildcard imports

### DIFF
--- a/platform/src/components/aws/kinesis-stream.ts
+++ b/platform/src/components/aws/kinesis-stream.ts
@@ -1,6 +1,5 @@
-import * as aws from "@pulumi/aws";
-
 import { ComponentResourceOptions, Output, all, output } from "@pulumi/pulumi";
+import { kinesis, lambda } from "@pulumi/aws";
 import { Component, Transform, transform } from "../component.js";
 import { Input } from "../input.js";
 import { Link } from "../link.js";
@@ -20,7 +19,7 @@ export interface KinesisStreamArgs {
     /**
      * Transform the Kinesis stream resource.
      */
-    stream?: Transform<aws.kinesis.StreamArgs>;
+    stream?: Transform<kinesis.StreamArgs>;
   };
 }
 
@@ -72,7 +71,7 @@ export interface KinesisStreamLambdaSubscriberArgs {
     /**
      * Transform the Lambda Event Source Mapping resource.
      */
-    eventSourceMapping?: Transform<aws.lambda.EventSourceMappingArgs>;
+    eventSourceMapping?: Transform<lambda.EventSourceMappingArgs>;
   };
 }
 
@@ -121,7 +120,7 @@ export interface KinesisStreamLambdaSubscriberArgs {
 export class KinesisStream extends Component implements Link.Linkable {
   private constructorName: string;
   private constructorOpts: ComponentResourceOptions;
-  private stream: aws.kinesis.Stream;
+  private stream: kinesis.Stream;
 
   constructor(
     name: string,
@@ -137,7 +136,7 @@ export class KinesisStream extends Component implements Link.Linkable {
     this.constructorOpts = opts;
 
     function createStream() {
-      return new aws.kinesis.Stream(
+      return new kinesis.Stream(
         ...transform(
           args?.transform?.stream,
           `${name}Stream`,

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -11,9 +11,8 @@ import {
   interpolate,
   ComponentResourceOptions,
   Resource,
+  asset as pulumiAsset,
 } from "@pulumi/pulumi";
-import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
 import { Cdn, CdnArgs } from "./cdn.js";
 import { Function, FunctionArgs, FunctionArn } from "./function.js";
 import { parseLambdaEdgeArn } from "./helpers/arn.js";
@@ -1285,7 +1284,7 @@ async function handler(event) {
         const timeout = edgeConfig?.timeout ? toSeconds(edgeConfig.timeout) : 5;
 
         // Create IAM role for Lambda@Edge using SST transform pattern
-        const edgeRole = new aws.iam.Role(
+        const edgeRole = new iam.Role(
           ...transform(
             undefined,
             `${name}EdgeFunctionRole`,
@@ -1314,7 +1313,7 @@ async function handler(event) {
         );
 
         // Create the Lambda@Edge function using SST transform pattern
-        const edgeFunction = new aws.lambda.Function(
+        const edgeFunction = new lambda.Function(
           ...transform(
             undefined,
             `${name}EdgeFunction`,
@@ -1322,7 +1321,7 @@ async function handler(event) {
               runtime: "nodejs22.x",
               handler: "index.handler",
               role: edgeRole.arn,
-              code: new pulumi.asset.FileArchive(
+              code: new pulumiAsset.FileArchive(
                 path.join($cli.paths.platform, "dist", "oac-edge-signer"),
               ),
               publish: true, // Required for Lambda@Edge

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -20,7 +20,7 @@ import { Vpc as VpcV1 } from "./vpc-v1";
 import { Link } from "../link";
 import { VisibleError } from "../error";
 import { PrivateKey } from "@pulumi/tls";
-import * as pulumi from "@pulumi/pulumi";
+import { rootStackResource } from "@pulumi/pulumi";
 
 export type { VpcArgs as VpcV1Args } from "./vpc-v1";
 
@@ -1031,7 +1031,7 @@ export class Vpc extends Component implements Link.Linkable {
               },
               {
                 parent: self,
-                aliases: [{ parent: pulumi.rootStackResource }],
+                aliases: [{ parent: rootStackResource }],
               },
             );
 


### PR DESCRIPTION
In search of circular references I came across this one and it seems like an odd thing to do:

1. It's not done in any other part of the code base
2. All imports for aws where already there
3. `asset as pulumiAsset` is already being done elsewhere

It also seems "dangerous" to include all of pulumi and aws.

I guess eslint rules would help here but for now this should already potentially prevent any issues