### PR TITLE
fix(aws): add InvokeFunction permission for public Function URLs

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2509,6 +2509,27 @@ export class Function extends Component implements Link.Linkable {
           },
           { parent },
         );
+
+        // Starting Oct 2025, public (auth NONE) Function URLs require an explicit
+        // lambda:InvokeFunction permission in addition to lambda:InvokeFunctionUrl.
+        //
+        // The lambda:InvokeFunctionUrl statement is added by Lambda or by the
+        // provider, but the lambda:InvokeFunction statement is not (for older
+        // deployments). This can be removed after migrating to @pulumi/aws v7
+        // (where Lambda/provider behavior matches the current AWS console policy).
+        //
+        // Note: The AWS console scopes this with lambda:InvokedViaFunctionUrl=true.
+        if (url.authorization === "none") {
+          new lambda.Permission(
+            `${name}UrlPublicInvokeFunction`,
+            {
+              action: "lambda:InvokeFunction",
+              function: fn.name,
+              principal: "*",
+            },
+            { parent, dependsOn: fnUrl },
+          );
+        }
         if (!url.route) return fnUrl.functionUrl;
 
         // add router route


### PR DESCRIPTION
Fixes https://github.com/anomalyco/sst/issues/6198

  ## What this PR changes

  - When `sst.aws.Function` is configured with `url.authorization: "none"`, SST now adds an explicit resource-based permission:
    - `action: "lambda:InvokeFunction"`
    - `principal: "*"`
    - `function: <function name>`

  This matches the AWS console guidance for public Function URLs and fixes existing stacks without requiring a manual policy edit.

  ## Notes / follow-ups

  - The AWS console scopes the `InvokeFunction` statement with `lambda:InvokedViaFunctionUrl=true`.
  - This PR adds the minimal required permission via `aws.lambda.Permission` and includes an inline comment to remove it after we migrate to `@pulumi/aws` v7 (where Lambda/provider behavior matches the current
  console policy).

  ## Repro

  ```ts
  new sst.aws.Function("Api", {
    handler: "src/lambda.handler",
    url: { authorization: "none" },
  });

  Deploy and hit the function URL; before this change you'll get 403