### PR TITLE
fix: Component resource sending input args to pulumi breaks some sst components

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -273,7 +273,6 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 		// "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
 		"NODE_OPTIONS=--enable-source-maps --no-deprecation",
 		"PULUMI_HOME="+global.ConfigDir(),
-		"PULUMI_NODEJS_SKIP_COMPONENT_INPUTS=true",
 	)
 	if input.ServerPort != 0 {
 		env = append(env, "SST_SERVER=http://127.0.0.1:"+fmt.Sprint(input.ServerPort))

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -273,6 +273,7 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 		// "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
 		"NODE_OPTIONS=--enable-source-maps --no-deprecation",
 		"PULUMI_HOME="+global.ConfigDir(),
+		"PULUMI_NODEJS_SKIP_COMPONENT_INPUTS=true",
 	)
 	if input.ServerPort != 0 {
 		env = append(env, "SST_SERVER=http://127.0.0.1:"+fmt.Sprint(input.ServerPort))

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -62,7 +62,7 @@ export class Component extends ComponentResource {
     for (const transform of transforms) {
       transform({ name, props: args, opts });
     }
-    super(type, name, args, {
+    super(type, name, {}, {
       transformations: [
         // Ensure logical and physical names are prefixed
         (args) => {


### PR DESCRIPTION
Closes #6353
 
Pulumi v3.202.0 introduced a change (https://github.com/pulumi/pulumi/pull/20357) that sends component resource inputs to the engine to be saved in state. 

This change causes two issues in SST that we know of:

Issue 1: "Component name is not unique" when using Linkable.wrap()
Issue 2: Step functions Out of memory errors

This is due to pulumi serialising/traversing the input args which has some side affects of causing issues in our transforms where a component is transformed twice, and step function components where there is some circular dependency issues.

Solution

<del>Added
`PULUMI_NODEJS_SKIP_COMPONENT_INPUTS=true` which was added in https://github.com/pulumi/pulumi/pull/20842
Which is a feature flag for disabling this behaviour for backwards compatibility.</del>


Updated SST Component class to not pass any args to pulumi ComponentResource. Effectlvely replicating the behaviour pre-2.202.0
