### PR TITLE
Bumping default version of OpenNext to 3.9.14

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -11,7 +11,7 @@ import { isALteB } from "../../util/compare-semver.js";
 import { Plan, SsrSite, SsrSiteArgs } from "./ssr-site.js";
 import { Bucket } from "./bucket.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.9.8";
+const DEFAULT_OPEN_NEXT_VERSION = "3.9.14";
 
 type BaseFunction = {
   handler: string;


### PR DESCRIPTION
Bumping the default version of OpenNext to 3.9.14, after an issue reported was here: https://github.com/anomalyco/sst/pull/6334#issuecomment-3823532208