### PR TITLE
Add WAF support to `Router`

### DIFF
--- a/examples/aws-router-waf/api.ts
+++ b/examples/aws-router-waf/api.ts
@@ -1,0 +1,9 @@
+export const handler = async (event: any) => {
+  return {
+    statusCode: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ message: "Hello from WAF-protected Router!" }),
+  };
+};

--- a/examples/aws-router-waf/sst.config.ts
+++ b/examples/aws-router-waf/sst.config.ts
@@ -1,0 +1,44 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * ## Router with WAF
+ *
+ * Enable WAF (Web Application Firewall) for a Router to protect against common
+ * web exploits and bots.
+ *
+ * WAF includes rate limiting per IP, and AWS managed rules for core rule set,
+ * known bad inputs, and SQL injection protection.
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "aws-router-waf",
+      home: "aws",
+      removal: input?.stage === "production" ? "retain" : "remove",
+    };
+  },
+  async run() {
+    const api = new sst.aws.Function("MyApi", {
+      handler: "api.handler",
+      url: true,
+    });
+
+    const router = new sst.aws.Router("MyRouter", {
+      routes: {
+        "/*": api.url,
+      },
+      waf: {
+        rateLimitPerIp: 1000,
+        managedRules: {
+          coreRuleSet: true,
+          knownBadInputs: true,
+          sqlInjection: true,
+        },
+      },
+    });
+
+    return {
+      url: router.url,
+    };
+  },
+});

--- a/examples/aws-router-waf/sst.config.ts
+++ b/examples/aws-router-waf/sst.config.ts
@@ -8,6 +8,8 @@
  *
  * WAF includes rate limiting per IP, and AWS managed rules for core rule set,
  * known bad inputs, and SQL injection protection.
+ *
+ * You can also enable WAF logging to CloudWatch to monitor requests.
  */
 export default $config({
   app(input) {
@@ -34,6 +36,7 @@ export default $config({
           knownBadInputs: true,
           sqlInjection: true,
         },
+        logging: true,
       },
     });
 

--- a/platform/src/components/aws/cdn.ts
+++ b/platform/src/components/aws/cdn.ts
@@ -243,6 +243,17 @@ export interface CdnArgs {
    */
   tags?: Input<Record<string, Input<string>>>;
   /**
+   * The ARN of a WAF WebACL to associate with the CloudFront distribution.
+   *
+   * @example
+   * ```ts
+   * {
+   *   webAclArn: "arn:aws:wafv2:us-east-1:123456789012:global/webacl/my-acl/abc123"
+   * }
+   * ```
+   */
+  webAclArn?: Input<string>;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying resources.
    */
   transform?: {
@@ -402,6 +413,7 @@ export class Cdn extends Component {
             ),
             waitForDeployment: false,
             tags: args.tags,
+            webAclId: args.webAclArn,
           },
           { parent },
         ),

--- a/platform/src/components/aws/cdn.ts
+++ b/platform/src/components/aws/cdn.ts
@@ -413,6 +413,7 @@ export class Cdn extends Component {
             ),
             waitForDeployment: false,
             tags: args.tags,
+            // CloudFront API confusingly names the WAF ARN field "webAclId"
             webAclId: args.webAclArn,
           },
           { parent },

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -10,7 +10,8 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link";
 import type { Input } from "../input";
 import { Cdn, CdnArgs } from "./cdn";
-import { cloudfront } from "@pulumi/aws";
+import { cloudfront, wafv2 } from "@pulumi/aws";
+import { useProvider } from "./helpers/provider";
 import { hashStringToPrettyString, physicalName } from "../naming";
 import { Bucket } from "./bucket";
 import { OriginAccessControl } from "./providers/origin-access-control";
@@ -455,6 +456,59 @@ export interface RouterBucketRouteArgs extends RouteArgs {
   }>;
 }
 
+export interface WafArgs {
+  /**
+   * The rate limit per IP address. Requests from an IP that exceed this limit
+   * within a 5-minute window will be blocked.
+   *
+   * @default `2000`
+   * @example
+   * ```js
+   * {
+   *   waf: {
+   *     rateLimitPerIp: 1000
+   *   }
+   * }
+   * ```
+   */
+  rateLimitPerIp?: Input<number>;
+  /**
+   * Configure which AWS managed rule groups to enable.
+   *
+   * @default All managed rules enabled
+   * @example
+   * ```js
+   * {
+   *   waf: {
+   *     managedRules: {
+   *       coreRuleSet: true,
+   *       knownBadInputs: true,
+   *       sqlInjection: false
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  managedRules?: Input<{
+    /**
+     * Enable the AWS Core Rule Set (CRS) which provides protection against common
+     * web vulnerabilities.
+     * @default `true`
+     */
+    coreRuleSet?: Input<boolean>;
+    /**
+     * Enable protection against known bad inputs, including Log4j vulnerabilities.
+     * @default `true`
+     */
+    knownBadInputs?: Input<boolean>;
+    /**
+     * Enable SQL injection protection.
+     * @default `true`
+     */
+    sqlInjection?: Input<boolean>;
+  }>;
+}
+
 export interface RouterArgs {
   /**
    * Set a custom domain for your Router.
@@ -815,6 +869,43 @@ export interface RouterArgs {
   >;
 
   /**
+   * Enable AWS WAF (Web Application Firewall) to protect your Router from common
+   * web exploits and bots.
+   *
+   * :::tip
+   * WAF provides protection against SQL injection, cross-site scripting (XSS),
+   * and other common attacks.
+   * :::
+   *
+   * @default WAF is disabled
+   * @example
+   *
+   * Enable with sensible defaults.
+   *
+   * ```js
+   * {
+   *   waf: true
+   * }
+   * ```
+   *
+   * Or customize the configuration.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     rateLimitPerIp: 1000,
+   *     managedRules: {
+   *       coreRuleSet: true,
+   *       knownBadInputs: true,
+   *       sqlInjection: true
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  waf?: Input<boolean | WafArgs>;
+
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
@@ -827,6 +918,10 @@ export interface RouterArgs {
      * Transform the CloudFront CDN resource.
      */
     cdn?: Transform<CdnArgs>;
+    /**
+     * Transform the WAF WebACL resource.
+     */
+    waf?: Transform<wafv2.WebAclArgs>;
   };
   /**
    * @internal
@@ -1027,6 +1122,11 @@ export class Router extends Component implements Link.Linkable {
 
     const hasInlineRoutes = args.routes !== undefined;
 
+    const waf = createWaf();
+    // Extract the WAF ARN. When WAF is enabled, waf is WebAcl.
+    // When disabled, waf is undefined and we pass undefined to webAclArn.
+    const wafArn = waf?.arn;
+
     let cdn, kvStoreArn, kvNamespace;
     if (hasInlineRoutes) {
       cdn = handleInlineRoutes();
@@ -1069,6 +1169,145 @@ export class Router extends Component implements Link.Linkable {
         kvNamespace: tags.kvNamespace,
         hasInlineRoutes: tags.hasInlineRoutes,
       };
+    }
+
+    function createWaf(): wafv2.WebAcl | undefined {
+      // Return undefined if WAF is not configured
+      if (!args.waf) return undefined;
+
+      // Normalize the waf config - handle both boolean and object forms
+      const wafInput = output(args.waf);
+      const config = wafInput.apply((waf) =>
+        typeof waf === "boolean" || !waf ? {} : waf,
+      );
+      const rateLimitPerIp = config.apply((c) => c.rateLimitPerIp ?? 2000);
+      const managedRules = config.apply((c) => c.managedRules ?? {});
+      const enableCoreRuleSet = managedRules.apply(
+        (m) => m.coreRuleSet !== false,
+      );
+      const enableKnownBadInputs = managedRules.apply(
+        (m) => m.knownBadInputs !== false,
+      );
+      const enableSqlInjection = managedRules.apply(
+        (m) => m.sqlInjection !== false,
+      );
+
+      // Build rules array dynamically based on config
+      const rules = all([
+        rateLimitPerIp,
+        enableCoreRuleSet,
+        enableKnownBadInputs,
+        enableSqlInjection,
+      ]).apply(([rateLimit, coreRuleSet, knownBadInputs, sqlInjection]) => {
+        const r: wafv2.WebAclArgs["rules"] = [];
+        let priority = 0;
+
+        // Rate limiting rule
+        r.push({
+          name: "RateLimitPerIP",
+          priority: priority++,
+          action: { block: {} },
+          statement: {
+            rateBasedStatement: {
+              limit: rateLimit,
+              aggregateKeyType: "IP",
+            },
+          },
+          visibilityConfig: {
+            cloudwatchMetricsEnabled: true,
+            metricName: `${name}RateLimitPerIP`,
+            sampledRequestsEnabled: true,
+          },
+        });
+
+        // AWS Managed Rules - Core Rule Set (CRS)
+        if (coreRuleSet) {
+          r.push({
+            name: "AWSManagedRulesCommonRuleSet",
+            priority: priority++,
+            overrideAction: { none: {} },
+            statement: {
+              managedRuleGroupStatement: {
+                vendorName: "AWS",
+                name: "AWSManagedRulesCommonRuleSet",
+                // Set SizeRestrictions_BODY to COUNT to avoid blocking large request bodies
+                ruleActionOverrides: [
+                  {
+                    name: "SizeRestrictions_BODY",
+                    actionToUse: { count: {} },
+                  },
+                ],
+              },
+            },
+            visibilityConfig: {
+              cloudwatchMetricsEnabled: true,
+              metricName: `${name}AWSManagedRulesCommonRuleSet`,
+              sampledRequestsEnabled: true,
+            },
+          });
+        }
+
+        // AWS Managed Rules - Known Bad Inputs
+        if (knownBadInputs) {
+          r.push({
+            name: "AWSManagedRulesKnownBadInputsRuleSet",
+            priority: priority++,
+            overrideAction: { none: {} },
+            statement: {
+              managedRuleGroupStatement: {
+                vendorName: "AWS",
+                name: "AWSManagedRulesKnownBadInputsRuleSet",
+              },
+            },
+            visibilityConfig: {
+              cloudwatchMetricsEnabled: true,
+              metricName: `${name}AWSManagedRulesKnownBadInputsRuleSet`,
+              sampledRequestsEnabled: true,
+            },
+          });
+        }
+
+        // AWS Managed Rules - SQL Injection
+        if (sqlInjection) {
+          r.push({
+            name: "AWSManagedRulesSQLiRuleSet",
+            priority: priority++,
+            overrideAction: { none: {} },
+            statement: {
+              managedRuleGroupStatement: {
+                vendorName: "AWS",
+                name: "AWSManagedRulesSQLiRuleSet",
+              },
+            },
+            visibilityConfig: {
+              cloudwatchMetricsEnabled: true,
+              metricName: `${name}AWSManagedRulesSQLiRuleSet`,
+              sampledRequestsEnabled: true,
+            },
+          });
+        }
+
+        return r;
+      });
+
+      // WAF must be created in us-east-1 for CloudFront
+      return new wafv2.WebAcl(
+        ...transform(
+          args.transform?.waf,
+          `${name}Waf`,
+          {
+            scope: "CLOUDFRONT",
+            defaultAction: { allow: {} },
+            rules,
+            visibilityConfig: {
+              cloudwatchMetricsEnabled: true,
+              metricName: `${name}Waf`,
+              sampledRequestsEnabled: true,
+            },
+          },
+          { parent: self, provider: useProvider("us-east-1") },
+        ),
+      );
     }
 
     function registerOutputs() {
@@ -1394,6 +1633,7 @@ async function handler(event) {
                   .map((d) => d.behavior),
                 domain: args.domain,
                 wait: true,
+                webAclArn: wafArn,
               },
               { parent: self },
             ),
@@ -1658,6 +1898,7 @@ async function handler(event) {
                 "sst:ref:kv-namespace": kvNamespace,
                 "sst:ref:version": _refVersion.toString(),
               },
+              webAclArn: wafArn,
             },
             { parent: self },
           ),

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -565,7 +565,7 @@ export interface WafLoggingArgs {
          * }
          * ```
          */
-        headers?: Input<Input<string>[]>;
+        headers?: Input<string[]>;
       }
   >;
 }
@@ -1299,9 +1299,9 @@ export class Router extends Component implements Link.Linkable {
     const hasInlineRoutes = args.routes !== undefined;
 
     const waf = createWaf();
-    // Extract the WAF ARN. When WAF is enabled, waf is WebAcl.
-    // When disabled, waf is undefined and we pass undefined to webAclArn.
     const wafArn = waf?.arn;
+    const wafLogging = normalizeWafLogging();
+    createWafLogging();
 
     let cdn, kvStoreArn, kvNamespace;
     if (hasInlineRoutes) {
@@ -1348,10 +1348,8 @@ export class Router extends Component implements Link.Linkable {
     }
 
     function createWaf(): wafv2.WebAcl | undefined {
-      // Return undefined if WAF is not configured
       if (!args.waf) return undefined;
 
-      // Normalize the waf config - handle both boolean and object forms
       const wafInput = output(args.waf);
       const config = wafInput.apply((waf) =>
         typeof waf === "boolean" || !waf ? {} : waf,
@@ -1378,7 +1376,6 @@ export class Router extends Component implements Link.Linkable {
         const r: wafv2.WebAclArgs["rules"] = [];
         let priority = 0;
 
-        // Rate limiting rule
         r.push({
           name: "RateLimitPerIP",
           priority: priority++,
@@ -1396,7 +1393,6 @@ export class Router extends Component implements Link.Linkable {
           },
         });
 
-        // AWS Managed Rules - Core Rule Set (CRS)
         if (coreRuleSet) {
           r.push({
             name: "AWSManagedRulesCommonRuleSet",
@@ -1423,7 +1419,6 @@ export class Router extends Component implements Link.Linkable {
           });
         }
 
-        // AWS Managed Rules - Known Bad Inputs
         if (knownBadInputs) {
           r.push({
             name: "AWSManagedRulesKnownBadInputsRuleSet",
@@ -1443,7 +1438,6 @@ export class Router extends Component implements Link.Linkable {
           });
         }
 
-        // AWS Managed Rules - SQL Injection
         if (sqlInjection) {
           r.push({
             name: "AWSManagedRulesSQLiRuleSet",
@@ -1467,7 +1461,7 @@ export class Router extends Component implements Link.Linkable {
       });
 
       // WAF must be created in us-east-1 for CloudFront
-      const webAcl = new wafv2.WebAcl(
+      return new wafv2.WebAcl(
         ...transform(
           args.transform?.waf,
           `${name}Waf`,
@@ -1484,16 +1478,13 @@ export class Router extends Component implements Link.Linkable {
           { parent: self, provider: useProvider("us-east-1") },
         ),
       );
+    }
 
-      // Create WAF logging resources if logging is configured
-      // Normalize directly from args.waf (not from `config`) to keep apply
-      // depth at 2 — matching the step-functions.ts pattern. Resources inside
-      // deeper apply chains can be empty during preview with unknown inputs.
-      const loggingInput = output(args.waf).apply((waf) => {
+    function normalizeWafLogging() {
+      return output(args.waf).apply((waf) => {
         if (!waf || typeof waf === "boolean") return undefined;
         if (!waf.logging) return undefined;
         const l = typeof waf.logging === "boolean" ? {} : waf.logging;
-        // Default redact: query string + cookie/authorization headers (PII)
         const defaultRedact: NonNullable<WafLoggingArgs["redact"]> = {
           queryString: true,
           headers: ["cookie", "authorization"],
@@ -1504,18 +1495,22 @@ export class Router extends Component implements Link.Linkable {
           redact: l.redact === false ? undefined : (l.redact ?? defaultRedact),
         };
       });
+    }
 
-      loggingInput.apply((logConfig) => {
-        if (!logConfig) return;
+    function createWafLogging() {
+      if (!waf) return;
 
-        // CloudWatch Log Group - name MUST start with "aws-waf-logs-"
+      wafLogging.apply((logging) => {
+        if (!logging) return;
+
+        // CloudWatch Log Group name MUST start with "aws-waf-logs-"
         const logGroup = new cloudwatch.LogGroup(
           ...transform(
             args.transform?.wafLogGroup,
             `${name}WafLogGroup`,
             {
               name: `aws-waf-logs-${physicalName(64, name)}`,
-              retentionInDays: RETENTION[logConfig.retention],
+              retentionInDays: RETENTION[logging.retention],
             },
             {
               parent: self,
@@ -1525,9 +1520,8 @@ export class Router extends Component implements Link.Linkable {
           ),
         );
 
-        // Build redacted fields from the redact config
-        const redactedFields = logConfig.redact
-          ? output(logConfig.redact).apply((redact) => {
+        const redactedFields = logging.redact
+          ? output(logging.redact).apply((redact) => {
               const fields: wafv2.WebAclLoggingConfigurationArgs["redactedFields"] &
                 {}[] = [];
               if (redact?.method) fields.push({ method: {} });
@@ -1544,9 +1538,8 @@ export class Router extends Component implements Link.Linkable {
             })
           : undefined;
 
-        // Build logging filter: "blocked" -> only keep BLOCK actions
         const loggingFilter =
-          logConfig.include === "blocked"
+          logging.include === "blocked"
             ? {
                 defaultBehavior: "DROP",
                 filters: [
@@ -1565,13 +1558,12 @@ export class Router extends Component implements Link.Linkable {
               }
             : undefined;
 
-        // WebACL Logging Configuration
         new wafv2.WebAclLoggingConfiguration(
           ...transform(
             args.transform?.wafLogging,
             `${name}WafLogging`,
             {
-              resourceArn: webAcl.arn,
+              resourceArn: waf!.arn,
               logDestinationConfigs: [logGroup.arn],
               ...(redactedFields ? { redactedFields } : {}),
               ...(loggingFilter ? { loggingFilter } : {}),
@@ -1583,8 +1575,6 @@ export class Router extends Component implements Link.Linkable {
           ),
         );
       });
-
-      return webAcl;
     }
 
     function registerOutputs() {

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -10,7 +10,7 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link";
 import type { Input } from "../input";
 import { Cdn, CdnArgs } from "./cdn";
-import { cloudfront, wafv2 } from "@pulumi/aws";
+import { cloudfront, cloudwatch, wafv2 } from "@pulumi/aws";
 import { useProvider } from "./helpers/provider";
 import { hashStringToPrettyString, physicalName } from "../naming";
 import { Bucket } from "./bucket";
@@ -19,6 +19,7 @@ import { VisibleError } from "../error";
 import { RouterUrlRoute } from "./router-url-route";
 import { RouterBucketRoute } from "./router-bucket-route";
 import { DurationSeconds } from "../duration";
+import { RETENTION } from "./logging";
 
 interface InlineUrlRouteArgs extends InlineBaseRouteArgs {
   /**
@@ -456,6 +457,119 @@ export interface RouterBucketRouteArgs extends RouteArgs {
   }>;
 }
 
+export interface WafLoggingArgs {
+  /**
+   * Filter which requests are logged.
+   *
+   * - `"all"` logs every request evaluated by the WAF.
+   * - `"blocked"` only logs requests that were blocked.
+   *
+   * @default `"all"`
+   * @example
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       include: "blocked"
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  include?: Input<"all" | "blocked">;
+  /**
+   * The duration the WAF logs are kept in CloudWatch.
+   *
+   * @default `"1 month"`
+   * @example
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       retention: "3 months"
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  retention?: Input<keyof typeof RETENTION>;
+  /**
+   * Configure which parts of the request are redacted from the logs. Redacted
+   * fields are replaced with `REDACTED` in the log output.
+   *
+   * By default, the query string and the `cookie` and `authorization` headers
+   * are redacted since they commonly contain PII or credentials.
+   *
+   * Set to `false` to disable all redaction.
+   *
+   * @default `{ queryString: true, headers: ["cookie", "authorization"] }`
+   * @example
+   *
+   * Disable all redaction.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       redact: false
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * Redact everything.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       redact: {
+   *         queryString: true,
+   *         uriPath: true,
+   *         method: true,
+   *         headers: ["cookie", "authorization"]
+   *       }
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  redact?: Input<
+    | false
+    | {
+        /**
+         * Redact the query string from the logs. The query string is the
+         * part of a URL after the `?` and can contain tokens, user IDs,
+         * or other sensitive parameters.
+         * @default `true`
+         */
+        queryString?: Input<boolean>;
+        /**
+         * Redact the URI path from the logs. The URI path identifies the
+         * resource being accessed, like `/users/123/profile`.
+         * @default `false`
+         */
+        uriPath?: Input<boolean>;
+        /**
+         * Redact the HTTP method from the logs (GET, POST, etc.).
+         * @default `false`
+         */
+        method?: Input<boolean>;
+        /**
+         * A list of header names to redact from the logs. Must be lowercase.
+         * @default `["cookie", "authorization"]`
+         * @example
+         * ```js
+         * {
+         *   headers: ["cookie", "authorization", "x-api-key"]
+         * }
+         * ```
+         */
+        headers?: Input<Input<string>[]>;
+      }
+  >;
+}
+
 export interface WafArgs {
   /**
    * The rate limit per IP address. Requests from an IP that exceed this limit
@@ -507,6 +621,60 @@ export interface WafArgs {
      */
     sqlInjection?: Input<boolean>;
   }>;
+  /**
+   * Configure WAF logging to CloudWatch. When set to `true`, all WAF-evaluated
+   * requests are logged with a 1-month retention. Or pass in an object to
+   * customize what is logged, how long logs are retained, and which fields
+   * are redacted.
+   *
+   * :::tip
+   * WAF logging is off by default. Enabling it will incur additional
+   * [CloudWatch costs](https://aws.amazon.com/cloudwatch/pricing/) depending
+   * on log volume.
+   * :::
+   *
+   * @default Logging is disabled
+   * @example
+   *
+   * Enable with defaults.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     logging: true
+   *   }
+   * }
+   * ```
+   *
+   * Only log blocked requests.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       include: "blocked",
+   *       retention: "3 months"
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * Redact sensitive fields.
+   *
+   * ```js
+   * {
+   *   waf: {
+   *     logging: {
+   *       redact: {
+   *         queryString: true,
+   *         headers: ["cookie"]
+   *       }
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  logging?: Input<boolean | WafLoggingArgs>;
 }
 
 export interface RouterArgs {
@@ -922,6 +1090,14 @@ export interface RouterArgs {
      * Transform the WAF WebACL resource.
      */
     waf?: Transform<wafv2.WebAclArgs>;
+    /**
+     * Transform the CloudWatch LogGroup resource used for WAF logs.
+     */
+    wafLogGroup?: Transform<cloudwatch.LogGroupArgs>;
+    /**
+     * Transform the WAF WebACL logging configuration resource.
+     */
+    wafLogging?: Transform<wafv2.WebAclLoggingConfigurationArgs>;
   };
   /**
    * @internal
@@ -1291,7 +1467,7 @@ export class Router extends Component implements Link.Linkable {
       });
 
       // WAF must be created in us-east-1 for CloudFront
-      return new wafv2.WebAcl(
+      const webAcl = new wafv2.WebAcl(
         ...transform(
           args.transform?.waf,
           `${name}Waf`,
@@ -1308,6 +1484,107 @@ export class Router extends Component implements Link.Linkable {
           { parent: self, provider: useProvider("us-east-1") },
         ),
       );
+
+      // Create WAF logging resources if logging is configured
+      // Normalize directly from args.waf (not from `config`) to keep apply
+      // depth at 2 — matching the step-functions.ts pattern. Resources inside
+      // deeper apply chains can be empty during preview with unknown inputs.
+      const loggingInput = output(args.waf).apply((waf) => {
+        if (!waf || typeof waf === "boolean") return undefined;
+        if (!waf.logging) return undefined;
+        const l = typeof waf.logging === "boolean" ? {} : waf.logging;
+        // Default redact: query string + cookie/authorization headers (PII)
+        const defaultRedact: NonNullable<WafLoggingArgs["redact"]> = {
+          queryString: true,
+          headers: ["cookie", "authorization"],
+        };
+        return {
+          include: (l.include ?? "all") as "all" | "blocked",
+          retention: (l.retention ?? "1 month") as keyof typeof RETENTION,
+          redact: l.redact === false ? undefined : (l.redact ?? defaultRedact),
+        };
+      });
+
+      loggingInput.apply((logConfig) => {
+        if (!logConfig) return;
+
+        // CloudWatch Log Group - name MUST start with "aws-waf-logs-"
+        const logGroup = new cloudwatch.LogGroup(
+          ...transform(
+            args.transform?.wafLogGroup,
+            `${name}WafLogGroup`,
+            {
+              name: `aws-waf-logs-${physicalName(64, name)}`,
+              retentionInDays: RETENTION[logConfig.retention],
+            },
+            {
+              parent: self,
+              provider: useProvider("us-east-1"),
+              ignoreChanges: ["name"],
+            },
+          ),
+        );
+
+        // Build redacted fields from the redact config
+        const redactedFields = logConfig.redact
+          ? output(logConfig.redact).apply((redact) => {
+              const fields: wafv2.WebAclLoggingConfigurationArgs["redactedFields"] &
+                {}[] = [];
+              if (redact?.method) fields.push({ method: {} });
+              if (redact?.queryString) fields.push({ queryString: {} });
+              if (redact?.uriPath) fields.push({ uriPath: {} });
+              if (redact?.headers) {
+                for (const header of redact.headers ?? []) {
+                  fields.push({
+                    singleHeader: { name: header.toLowerCase() },
+                  });
+                }
+              }
+              return fields;
+            })
+          : undefined;
+
+        // Build logging filter: "blocked" -> only keep BLOCK actions
+        const loggingFilter =
+          logConfig.include === "blocked"
+            ? {
+                defaultBehavior: "DROP",
+                filters: [
+                  {
+                    behavior: "KEEP" as const,
+                    requirement: "MEETS_ANY" as const,
+                    conditions: [
+                      {
+                        actionCondition: {
+                          action: "BLOCK",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              }
+            : undefined;
+
+        // WebACL Logging Configuration
+        new wafv2.WebAclLoggingConfiguration(
+          ...transform(
+            args.transform?.wafLogging,
+            `${name}WafLogging`,
+            {
+              resourceArn: webAcl.arn,
+              logDestinationConfigs: [logGroup.arn],
+              ...(redactedFields ? { redactedFields } : {}),
+              ...(loggingFilter ? { loggingFilter } : {}),
+            },
+            {
+              parent: self,
+              provider: useProvider("us-east-1"),
+            },
+          ),
+        );
+      });
+
+      return webAcl;
     }
 
     function registerOutputs() {

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1481,20 +1481,36 @@ export class Router extends Component implements Link.Linkable {
     }
 
     function normalizeWafLogging() {
-      return output(args.waf).apply((waf) => {
-        if (!waf || typeof waf === "boolean") return undefined;
-        if (!waf.logging) return undefined;
-        const l = typeof waf.logging === "boolean" ? {} : waf.logging;
-        const defaultRedact: NonNullable<WafLoggingArgs["redact"]> = {
-          queryString: true,
-          headers: ["cookie", "authorization"],
-        };
-        return {
-          include: (l.include ?? "all") as "all" | "blocked",
-          retention: (l.retention ?? "1 month") as keyof typeof RETENTION,
-          redact: l.redact === false ? undefined : (l.redact ?? defaultRedact),
-        };
-      });
+      return output(args.waf)
+        .apply((waf) => {
+          if (!waf || typeof waf === "boolean") return undefined;
+          return output(waf.logging);
+        })
+        .apply((logging) => {
+          if (!logging) return undefined;
+          const l = (
+            typeof logging === "boolean" ? {} : logging
+          ) as WafLoggingArgs;
+          return all([
+            output(l.include ?? "all"),
+            output(l.retention ?? "1 month"),
+            output(l.redact),
+          ]);
+        })
+        .apply((resolved) => {
+          if (!resolved) return undefined;
+          const [include, retention, redact] = resolved;
+          const defaultRedact: NonNullable<WafLoggingArgs["redact"]> = {
+            queryString: true,
+            headers: ["cookie", "authorization"],
+          };
+          return {
+            include: include as "all" | "blocked",
+            retention: retention as keyof typeof RETENTION,
+            redact:
+              redact === false ? undefined : (redact ?? defaultRedact),
+          };
+        });
     }
 
     function createWafLogging() {

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1491,24 +1491,18 @@ export class Router extends Component implements Link.Linkable {
           const l = (
             typeof logging === "boolean" ? {} : logging
           ) as WafLoggingArgs;
-          return all([
-            output(l.include ?? "all"),
-            output(l.retention ?? "1 month"),
-            output(l.redact),
-          ]);
-        })
-        .apply((resolved) => {
-          if (!resolved) return undefined;
-          const [include, retention, redact] = resolved;
-          const defaultRedact: NonNullable<WafLoggingArgs["redact"]> = {
-            queryString: true,
-            headers: ["cookie", "authorization"],
+          const defaultRedact = {
+            queryString: true as boolean,
+            headers: ["cookie", "authorization"] as string[],
           };
+          const redact = l.redact;
           return {
-            include: include as "all" | "blocked",
-            retention: retention as keyof typeof RETENTION,
+            include: (l.include ?? "all") as "all" | "blocked",
+            retention: (l.retention ?? "1 month") as keyof typeof RETENTION,
             redact:
-              redact === false ? undefined : (redact ?? defaultRedact),
+              redact === false
+                ? undefined
+                : redact ?? defaultRedact,
           };
         });
     }
@@ -1538,13 +1532,14 @@ export class Router extends Component implements Link.Linkable {
 
         const redactedFields = logging.redact
           ? output(logging.redact).apply((redact) => {
+              if (!redact || typeof redact === "boolean") return [];
               const fields: wafv2.WebAclLoggingConfigurationArgs["redactedFields"] &
                 {}[] = [];
-              if (redact?.method) fields.push({ method: {} });
-              if (redact?.queryString) fields.push({ queryString: {} });
-              if (redact?.uriPath) fields.push({ uriPath: {} });
-              if (redact?.headers) {
-                for (const header of redact.headers ?? []) {
+              if (redact.method) fields.push({ method: {} });
+              if (redact.queryString) fields.push({ queryString: {} });
+              if (redact.uriPath) fields.push({ uriPath: {} });
+              if (redact.headers) {
+                for (const header of redact.headers) {
                   fields.push({
                     singleHeader: { name: header.toLowerCase() },
                   });

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -309,6 +309,7 @@ export class Component extends ComponentResource {
                   ),
               },
             ],
+            "aws:wafv2/webAcl:WebAcl": ["name", 64],
             "cloudflare:index/d1Database:D1Database": [
               "name",
               64,

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -173,6 +173,7 @@ export class Component extends ComponentResource {
               "aws:s3/bucketVersioning:BucketVersioning",
               "aws:s3/bucketWebsiteConfiguration:BucketWebsiteConfiguration",
               "aws:secretsmanager/secretVersion:SecretVersion",
+              "aws:wafv2/webAclLoggingConfiguration:WebAclLoggingConfiguration",
               "aws:ses/domainIdentityVerification:DomainIdentityVerification",
               "aws:sesv2/configurationSetEventDestination:ConfigurationSetEventDestination",
               "aws:sesv2/emailIdentity:EmailIdentity",

--- a/platform/test/components/router-waf.test.ts
+++ b/platform/test/components/router-waf.test.ts
@@ -62,9 +62,11 @@ function findResources(type: string) {
   return createdResources.filter((r) => r.type === type);
 }
 
-// Allow async Pulumi .apply() chains to settle
-function settle(ms = 500) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+// Flush event loop to let Pulumi .apply() chains settle without wall-clock delays
+async function settle() {
+  for (let i = 0; i < 50; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
 }
 
 describe("Router WAF Logging", function () {

--- a/platform/test/components/router-waf.test.ts
+++ b/platform/test/components/router-waf.test.ts
@@ -1,0 +1,216 @@
+import { describe, beforeAll, beforeEach, it, expect } from "vitest";
+import * as pulumi from "@pulumi/pulumi";
+
+// Suppress Pulumi "Trace events are unavailable" errors in test environment
+process.on("unhandledRejection", (err: any) => {
+  if (err?.code === "ERR_TRACE_EVENTS_UNAVAILABLE") return;
+  throw err;
+});
+
+// @ts-ignore
+global.$app = {
+  name: "app",
+  stage: "test",
+};
+global.$util = pulumi;
+
+interface CreatedResource {
+  type: string;
+  name: string;
+  inputs: any;
+}
+
+let createdResources: CreatedResource[] = [];
+
+pulumi.runtime.setMocks(
+  {
+    newResource: function (args: pulumi.runtime.MockResourceArgs): {
+      id: string;
+      state: any;
+    } {
+      createdResources.push({
+        type: args.type,
+        name: args.name,
+        inputs: args.inputs,
+      });
+      const arn =
+        args.type === "aws:wafv2/webAcl:WebAcl"
+          ? "arn:aws:wafv2:us-east-1:123456789012:global/webacl/test/abc-123"
+          : `arn:aws:mock:us-east-1:123456789012:${args.name}`;
+      return {
+        id: args.inputs.name + "_id",
+        state: { ...args.inputs, arn },
+      };
+    },
+    call: function (args: pulumi.runtime.MockCallArgs) {
+      return args.inputs;
+    },
+  },
+  "project",
+  "stack",
+  false,
+);
+
+const TYPES = {
+  webAcl: "aws:wafv2/webAcl:WebAcl",
+  logGroup: "aws:cloudwatch/logGroup:LogGroup",
+  loggingConfig:
+    "aws:wafv2/webAclLoggingConfiguration:WebAclLoggingConfiguration",
+};
+
+function findResources(type: string) {
+  return createdResources.filter((r) => r.type === type);
+}
+
+// Allow async Pulumi .apply() chains to settle
+function settle(ms = 500) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("Router WAF Logging", function () {
+  let Router: typeof import("./../../src/components/aws/router").Router;
+
+  beforeAll(async function () {
+    Router = (await import("./../../src/components/aws/router")).Router;
+  });
+
+  beforeEach(function () {
+    createdResources = [];
+  });
+
+  describe("no WAF configured", () => {
+    it("does not create WAF or logging resources", async () => {
+      new Router("NoWaf");
+      await settle();
+      expect(findResources(TYPES.webAcl)).toHaveLength(0);
+      expect(findResources(TYPES.logGroup)).toHaveLength(0);
+      expect(findResources(TYPES.loggingConfig)).toHaveLength(0);
+    });
+  });
+
+  describe("WAF without logging", () => {
+    it("creates WebAcl but no logging resources", async () => {
+      new Router("WafNoLog", { waf: true });
+      await settle();
+      expect(findResources(TYPES.webAcl)).toHaveLength(1);
+      expect(findResources(TYPES.logGroup)).toHaveLength(0);
+      expect(findResources(TYPES.loggingConfig)).toHaveLength(0);
+    });
+  });
+
+  describe("WAF with logging: true", () => {
+    it("creates WebAcl, LogGroup, and LoggingConfiguration", async () => {
+      new Router("WafLogTrue", { waf: { logging: true } });
+      await settle();
+      expect(findResources(TYPES.webAcl)).toHaveLength(1);
+      expect(findResources(TYPES.logGroup)).toHaveLength(1);
+      expect(findResources(TYPES.loggingConfig)).toHaveLength(1);
+    });
+
+    it("LogGroup name starts with aws-waf-logs-", async () => {
+      new Router("WafLogName", { waf: { logging: true } });
+      await settle();
+      const logGroups = findResources(TYPES.logGroup);
+      expect(logGroups[0].inputs.name).toMatch(/^aws-waf-logs-/);
+    });
+
+    it("LogGroup retention defaults to 30 days (1 month)", async () => {
+      new Router("WafLogRet", { waf: { logging: true } });
+      await settle();
+      const logGroups = findResources(TYPES.logGroup);
+      expect(logGroups[0].inputs.retentionInDays).toBe(30);
+    });
+
+    it("applies default PII redaction (queryString + cookie/authorization)", async () => {
+      new Router("WafLogRedact", { waf: { logging: true } });
+      await settle();
+      const configs = findResources(TYPES.loggingConfig);
+      expect(configs).toHaveLength(1);
+      const redacted = configs[0].inputs.redactedFields;
+      expect(redacted).toBeDefined();
+      expect(redacted).toContainEqual({ queryString: {} });
+      expect(redacted).toContainEqual({
+        singleHeader: { name: "cookie" },
+      });
+      expect(redacted).toContainEqual({
+        singleHeader: { name: "authorization" },
+      });
+    });
+  });
+
+  describe("logging filter", () => {
+    it("include: 'blocked' sets DROP default with KEEP for BLOCK", async () => {
+      new Router("WafFiltered", {
+        waf: { logging: { include: "blocked" } },
+      });
+      await settle();
+      const configs = findResources(TYPES.loggingConfig);
+      expect(configs).toHaveLength(1);
+      const filter = configs[0].inputs.loggingFilter;
+      expect(filter).toBeDefined();
+      expect(filter.defaultBehavior).toBe("DROP");
+      expect(filter.filters[0].behavior).toBe("KEEP");
+      expect(filter.filters[0].conditions[0].actionCondition.action).toBe(
+        "BLOCK",
+      );
+    });
+
+    it("include: 'all' does not set a logging filter", async () => {
+      new Router("WafAll", {
+        waf: { logging: { include: "all" } },
+      });
+      await settle();
+      const configs = findResources(TYPES.loggingConfig);
+      expect(configs).toHaveLength(1);
+      expect(configs[0].inputs.loggingFilter).toBeUndefined();
+    });
+  });
+
+  describe("retention", () => {
+    it("custom retention is applied", async () => {
+      new Router("WafRet3m", {
+        waf: { logging: { retention: "3 months" } },
+      });
+      await settle();
+      const logGroups = findResources(TYPES.logGroup);
+      expect(logGroups[0].inputs.retentionInDays).toBe(90);
+    });
+  });
+
+  describe("redact", () => {
+    it("redact: false disables all redaction", async () => {
+      new Router("WafNoRedact", {
+        waf: { logging: { redact: false } },
+      });
+      await settle();
+      const configs = findResources(TYPES.loggingConfig);
+      expect(configs).toHaveLength(1);
+      expect(configs[0].inputs.redactedFields).toBeUndefined();
+    });
+
+    it("custom redact fields are applied", async () => {
+      new Router("WafCustomRedact", {
+        waf: {
+          logging: {
+            redact: {
+              uriPath: true,
+              method: true,
+              headers: ["x-api-key"],
+            },
+          },
+        },
+      });
+      await settle();
+      const configs = findResources(TYPES.loggingConfig);
+      expect(configs).toHaveLength(1);
+      const redacted = configs[0].inputs.redactedFields;
+      expect(redacted).toContainEqual({ method: {} });
+      expect(redacted).toContainEqual({ uriPath: {} });
+      expect(redacted).toContainEqual({
+        singleHeader: { name: "x-api-key" },
+      });
+      // queryString not set, should not be in the list
+      expect(redacted).not.toContainEqual({ queryString: {} });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional WAF (Web Application Firewall) support to the Router component
- Rate limiting per IP (default: 2000 requests per 5-minute window)
- AWS Managed Rules: Core Rule Set, Known Bad Inputs, SQL Injection
- `SizeRestrictions_BODY` set to COUNT to avoid blocking large request bodies
- WAF automatically created in us-east-1 (required for CloudFront)
- Support for `transform.waf` to customize the WebACL

## Usage

```typescript
// Enable with defaults
new sst.aws.Router("MyRouter", {
  waf: true
});

// Or customize
new sst.aws.Router("MyRouter", {
  waf: {
    rateLimitPerIp: 1000,
    managedRules: {
      coreRuleSet: true,
      knownBadInputs: true,
      sqlInjection: false
    }
  }
});
```

## Test plan

- [x] Deployed Router with `waf: true` - WAF WebACL created successfully
- [x] Verified WAF is created in us-east-1
- [x] Verified CloudFront distribution references the WAF ARN
- [x] TypeScript compiles without errors

Fixes #5846

🤖 Generated with [Claude Code](https://claude.com/claude-code)