### PR TITLE
fix windows panic when copying template files

### DIFF
--- a/pkg/project/create.go
+++ b/pkg/project/create.go
@@ -235,8 +235,11 @@ func Create(templateName string, home string) ([]string, error) {
 			break
 
 		case "copy":
-			templateFilesPath := filepath.Join("templates", templateName, "files")
+			templateFilesPath := path.Join("templates", templateName, "files")
 			err = fs.WalkDir(platform.Templates, templateFilesPath, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
 				if d.IsDir() {
 					// Create the directory if it doesn't exist
 					dir := filepath.Join(".", strings.TrimPrefix(path, templateFilesPath))


### PR DESCRIPTION
Closes #5742 

Platform.templates is an embedded filesystem and expects forward slashes regardless of os. so filepath.join() was not working on windows. 

Tested on windows and linux:

Windows:
<img width="610" height="528" alt="Screenshot 2026-02-03 215800" src="https://github.com/user-attachments/assets/acb92ef7-30a4-4ff8-8a29-4a493e371867" />

Linux:
<img width="756" height="646" alt="image" src="https://github.com/user-attachments/assets/26340c03-f67a-44c2-9683-7b9ce799ceca" />
