### PR TITLE
Bump up @pulumi/aws to suppor nodejs24.x runtime

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-ssm": "3.478.0",
     "@aws-sdk/client-sts": "3.478.0",
     "@aws-sdk/middleware-retry": "3.374.0",
-    "@pulumi/aws": "6.66.2",
+    "@pulumi/aws": "7.17.0",
     "@pulumi/cloudflare": "6.10.0",
     "@pulumi/command": "1.0.1",
     "@pulumi/docker-build": "0.0.8",


### PR DESCRIPTION
@pulumi/aws has recently added support for new lambda runtimes. https://github.com/pulumi/pulumi-aws/pull/6154