### PR TITLE
Fix public lambdas and sites returning 403 on new AWS accounts

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2509,7 +2509,7 @@ export class Function extends Component implements Link.Linkable {
           },
           { parent },
         );
-        if (url.authorization !== "iam") {
+        if (url.authorization === "none") {
           new lambda.Permission(
             `${name}InvokeFunction`,
             {

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2509,6 +2509,17 @@ export class Function extends Component implements Link.Linkable {
           },
           { parent },
         );
+        if (url.authorization !== "iam") {
+          new lambda.Permission(
+            `${name}InvokeFunction`,
+            {
+              action: "lambda:InvokeFunction",
+              function: fn.name,
+              principal: "*",
+            },
+            { parent },
+          );
+        }
         if (!url.route) return fnUrl.functionUrl;
 
         // add router route

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -1064,6 +1064,16 @@ async function handler(event) {
               },
               { provider, parent: self },
             );
+            new lambda.Permission(
+              `${name}CloudFrontInvokeFunction${logicalName(region)}`,
+              {
+                action: "lambda:InvokeFunction",
+                function: server.nodes.function.name,
+                principal: "cloudfront.amazonaws.com",
+                sourceArn: dist.nodes.distribution.arn,
+              },
+              { provider, parent: self },
+            );
           }
         });
 
@@ -1088,6 +1098,16 @@ async function handler(event) {
               `${name}ImageOptimizerCloudFrontFunctionUrlAccess`,
               {
                 action: "lambda:InvokeFunctionUrl",
+                function: imgOptimizer.nodes.function.name,
+                principal: "cloudfront.amazonaws.com",
+                sourceArn: dist.nodes.distribution.arn,
+              },
+              { parent: self },
+            );
+            new lambda.Permission(
+              `${name}ImageOptimizerCloudFrontInvokeFunction`,
+              {
+                action: "lambda:InvokeFunction",
                 function: imgOptimizer.nodes.function.name,
                 principal: "cloudfront.amazonaws.com",
                 sourceArn: dist.nodes.distribution.arn,


### PR DESCRIPTION
AWS requires both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions for Lambda function URLs on accounts created after ~Oct 2024

we were missing `lambda:InvokeFunction` which caused 403 responses

closes #6397
closes #6198

<details>

<summary>proof of it working</summary>

### `aws-hono` example

| **Before** | **After** |
|------------|-----------|
|  <img width="2412" height="374" alt="CleanShot 2026-02-14 at 16 55 13@2x" src="https://github.com/user-attachments/assets/00baca46-25ed-4a80-87e6-bf6997d6dfb4" />         |  <img width="2412" height="374" alt="CleanShot 2026-02-14 at 16 56 33@2x" src="https://github.com/user-attachments/assets/c279bfa8-10d7-4590-b876-50279904f6e8" />        |

### `aws-nextjs` example

| **Before** | **After** |
|------------|-----------|
|  <img width="1850" height="990" alt="CleanShot 2026-02-14 at 17 06 33@2x" src="https://github.com/user-attachments/assets/9984d831-6a21-4775-8edf-efb764b84743" />         |   <img width="1850" height="990" alt="CleanShot 2026-02-14 at 17 09 10@2x" src="https://github.com/user-attachments/assets/7a7abf4c-5271-46fb-98ea-b5b623b09a8a" />       |

### `aws-nextjs` example with `protection: "oac"`

<img width="1850" height="990" alt="CleanShot 2026-02-14 at 17 24 21@2x" src="https://github.com/user-attachments/assets/5b68cdcd-5dc7-457a-b55a-4ba1637f2ded" />

</details>

note: as @anicusan mentions in the issue we'll be able to tighten the scope once #6259 is merged