### PR TITLE
Fix intersection types breaking docs generation

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -9,7 +9,8 @@ import { Queue } from "./queue.js";
 import { dynamodb, getRegionOutput, lambda } from "@pulumi/aws";
 import { isALteB } from "../../util/compare-semver.js";
 import { Plan, SsrSite, SsrSiteArgs } from "./ssr-site.js";
-import { Bucket } from "./bucket.js";
+import { Bucket, BucketArgs } from "./bucket.js";
+import { CdnArgs } from "./cdn.js";
 import { transform, Transform } from "../component.js";
 
 const DEFAULT_OPEN_NEXT_VERSION = "3.9.8";
@@ -479,7 +480,23 @@ export interface NextjsArgs extends SsrSiteArgs {
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
-  transform?: SsrSiteArgs["transform"] & {
+  transform?: {
+    /**
+     * Transform the Bucket resource used for uploading the assets.
+     */
+    assets?: Transform<BucketArgs>;
+    /**
+     * Transform the server Function resource.
+     */
+    server?: Transform<FunctionArgs>;
+    /**
+     * Transform the image optimizer Function resource.
+     */
+    imageOptimizer?: Transform<FunctionArgs>;
+    /**
+     * Transform the CloudFront CDN resource.
+     */
+    cdn?: Transform<CdnArgs>;
     /**
      * Transform the revalidation seeder Function resource used for ISR.
      */

--- a/platform/src/components/aws/queue-lambda-subscriber.ts
+++ b/platform/src/components/aws/queue-lambda-subscriber.ts
@@ -30,12 +30,7 @@ export interface Args extends QueueSubscriberArgs {
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
-  transform?: QueueSubscriberArgs["transform"] & {
-    /**
-     * Transform the subscriber Function resource.
-     */
-    function?: Transform<FunctionArgs>;
-  };
+  transform?: QueueSubscriberArgs["transform"];
 }
 
 /**

--- a/platform/src/components/aws/queue.ts
+++ b/platform/src/components/aws/queue.ts
@@ -289,6 +289,10 @@ export interface QueueSubscriberArgs {
      * Transform the Lambda Event Source Mapping resource.
      */
     eventSourceMapping?: Transform<lambda.EventSourceMappingArgs>;
+    /**
+     * Transform the subscriber Function resource.
+     */
+    function?: Transform<FunctionArgs>;
   };
 }
 
@@ -504,11 +508,7 @@ export class Queue extends Component implements Link.Linkable {
    */
   public subscribe(
     subscriber: Input<string | FunctionArgs | FunctionArn>,
-    args?: QueueSubscriberArgs & {
-      transform?: QueueSubscriberArgs["transform"] & {
-        function?: Transform<FunctionArgs>;
-      };
-    },
+    args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
     if (this.isSubscribed)
@@ -573,11 +573,7 @@ export class Queue extends Component implements Link.Linkable {
   public static subscribe(
     queueArn: Input<string>,
     subscriber: Input<string | FunctionArgs | FunctionArn>,
-    args?: QueueSubscriberArgs & {
-      transform?: QueueSubscriberArgs["transform"] & {
-        function?: Transform<FunctionArgs>;
-      };
-    },
+    args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
     return output(queueArn).apply((queueArn) =>
@@ -595,11 +591,7 @@ export class Queue extends Component implements Link.Linkable {
     name: string,
     queueArn: Input<string>,
     subscriber: Input<string | FunctionArgs | FunctionArn>,
-    args: QueueSubscriberArgs & {
-      transform?: QueueSubscriberArgs["transform"] & {
-        function?: Transform<FunctionArgs>;
-      };
-    } = {},
+    args: QueueSubscriberArgs = {},
     opts?: ComponentResourceOptions,
   ) {
     return output(queueArn).apply((queueArn) => {


### PR DESCRIPTION
#6107 breaks the docs by introducing intersection types for the `transform` properties

just flattened them as we do in the rest of the codebase