### PR TITLE
Fix multiplexer missing events

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -220,11 +220,6 @@ func CmdMosaic(c *cli.Cli) error {
 		return server.Start(c.Context, p)
 	})
 
-	wg.Go(func() error {
-		defer c.Cancel()
-		return deployer.Start(c.Context, p, server)
-	})
-
 	currentExecutable, _ := os.Executable()
 
 	mode := c.String("mode")
@@ -235,6 +230,13 @@ func CmdMosaic(c *cli.Cli) error {
 			mode = "mono"
 		}
 	}
+
+	evts := bus.Subscribe(&project.CompleteEvent{})
+
+	wg.Go(func() error {
+		defer c.Cancel()
+		return deployer.Start(c.Context, p, server)
+	})
 
 	if mode == "multi" {
 		multi, err := multiplexer.New()
@@ -255,7 +257,6 @@ func CmdMosaic(c *cli.Cli) error {
 			multi.Start()
 		}()
 		wg.Go(func() error {
-			evts := bus.Subscribe(&project.CompleteEvent{})
 			defer c.Cancel()
 			for {
 				select {
@@ -264,6 +265,9 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
+						if evt.Old {
+							continue
+						}
 						for _, d := range evt.Devs {
 							if d.Command == "" {
 								continue
@@ -317,7 +321,6 @@ func CmdMosaic(c *cli.Cli) error {
 		})
 
 		wg.Go(func() error {
-			evts := bus.Subscribe(&project.CompleteEvent{})
 			defer c.Cancel()
 			for {
 				select {
@@ -326,6 +329,9 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
+						if evt.Old {
+							continue
+						}
 						for _, d := range evt.Devs {
 							if d.Command == "" {
 								continue

--- a/cmd/sst/mosaic/multiplexer/process.go
+++ b/cmd/sst/mosaic/multiplexer/process.go
@@ -39,7 +39,7 @@ type EventProcess struct {
 }
 
 func (s *Multiplexer) AddProcess(key string, args []string, icon string, title string, cwd string, killable bool, autostart bool, env ...string) {
-	s.screen.PostEvent(&EventProcess{
+	s.screen.PostEventWait(&EventProcess{
 		Key:       key,
 		Args:      args,
 		Icon:      icon,


### PR DESCRIPTION
closes #6011

1. subscribing to events before deployer starts
2. using `PostEventWait` instead of `PostEvent` to avoid dropping events

<details>

<summary>proof of it working</summary>

| **Before** | **After** |
|------------|-----------|
|  <img width="2768" height="2016" alt="CleanShot 2026-02-14 at 20 58 21@2x" src="https://github.com/user-attachments/assets/b7bdd7bd-4a47-47e5-a751-98e92c71e476" />         |  <img width="2768" height="2016" alt="CleanShot 2026-02-14 at 20 56 44@2x" src="https://github.com/user-attachments/assets/d7d8303f-2a39-41b4-a8f2-b14c083cf786" />        |

</details>