### PR TITLE
Fix displaying dev commands before default processes in the TUI sidebar

### DIFF
--- a/cmd/sst/mosaic/multiplexer/draw.go
+++ b/cmd/sst/mosaic/multiplexer/draw.go
@@ -137,6 +137,9 @@ func (s *Multiplexer) sort() {
 	}
 	key := s.selectedProcess().key
 	sort.Slice(s.processes, func(i, j int) bool {
+		if !s.processes[i].killable && s.processes[j].killable {
+			return true
+		}
 		if s.processes[i].killable && !s.processes[j].killable {
 			return false
 		}


### PR DESCRIPTION
dev commands like those from defining `dev` in a `Service` or via `sst.x.DevCommand` could show up before the default `SST` or `Functions` processes because a comparison case was missing

<details>

<summary>proof of it working</summary>

| **Before** | **After** |
|------------|-----------|
|  <img width="1920" height="1602" alt="CleanShot 2026-02-14 at 21 42 07@2x" src="https://github.com/user-attachments/assets/d880004c-f7cb-45ed-ad9d-ac91cff16870" />         |  <img width="1920" height="1602" alt="CleanShot 2026-02-14 at 21 43 40@2x" src="https://github.com/user-attachments/assets/00bab5c9-0ed7-49a6-b377-9612b4c702a6" />        |

</details>