### PR TITLE
fix(router): handle trailing-slash routes in path segment boundary check

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1537,7 +1537,7 @@ async function handler(event) {
         || (host.includes("*") && new RegExp(host).test(requestHostRegexPattern));
       if (!hostMatches) return;
 
-      const pathMatches = event.request.uri.startsWith(path) && (event.request.uri === path || event.request.uri[path.length] === '/' || path === '/');
+      const pathMatches = event.request.uri.startsWith(path) && (event.request.uri === path || path.endsWith('/') || event.request.uri[path.length] === '/' || path === '/');
       if (!pathMatches) return;
 
       match = {

--- a/platform/test/components/router-path-matching.test.ts
+++ b/platform/test/components/router-path-matching.test.ts
@@ -16,6 +16,7 @@ describe("Router path matching", () => {
     return (
       requestUri.startsWith(routePath) &&
       (requestUri === routePath ||
+        routePath.endsWith("/") ||
         requestUri[routePath.length] === "/" ||
         routePath === "/")
     );
@@ -120,6 +121,17 @@ describe("Router path matching", () => {
       // /api-docs/intro should only match /api-docs
       expect(pathMatches("/api-docs/intro", "/api")).toBe(false);
       expect(pathMatches("/api-docs/intro", "/api-docs")).toBe(true);
+    });
+  });
+
+  describe("trailing-slash routes", () => {
+    it("should match subpaths under trailing-slash route", () => {
+      expect(pathMatches("/public/2025-11/image.jpg", "/public/")).toBe(true);
+      expect(pathMatches("/public/", "/public/")).toBe(true);
+    });
+
+    it("should NOT match non-segment continuations", () => {
+      expect(pathMatches("/publicfile", "/public/")).toBe(false);
     });
   });
 


### PR DESCRIPTION
closes #6412

<details>

<summary>proof of it working</summary>

<img width="1188" height="866" alt="CleanShot 2026-02-16 at 23 26 59@2x" src="https://github.com/user-attachments/assets/7df669bf-1951-4899-ab26-d281024df893" />

<img width="1598" height="724" alt="CleanShot 2026-02-16 at 23 27 22@2x" src="https://github.com/user-attachments/assets/23eb2890-0ba9-4bf2-8cd9-6e7ebcd8fba5" />

<img width="1598" height="724" alt="CleanShot 2026-02-16 at 23 27 36@2x" src="https://github.com/user-attachments/assets/9b7cd733-6457-4401-9faf-407c2cf73728" />

<img width="1598" height="724" alt="CleanShot 2026-02-16 at 23 27 50@2x" src="https://github.com/user-attachments/assets/7f547635-0329-4674-802d-547aa2f4bcaa" />

<img width="1278" height="1742" alt="CleanShot 2026-02-16 at 23 30 49@2x" src="https://github.com/user-attachments/assets/a5bd9dc3-92d8-490c-978e-79dd84094624" />

</details>