### PR TITLE
fix: prevent dev mode bundle deletion race condition

### DIFF
--- a/cmd/sst/mosaic/aws/function.go
+++ b/cmd/sst/mosaic/aws/function.go
@@ -189,7 +189,23 @@ func function(ctx context.Context, input input) {
 	getBuildOutput := func(functionID string) *runtime.BuildOutput {
 		build := builds[functionID]
 		if build != nil {
-			return build
+			// check that the handler file still exists on disk
+			handlerFile := build.Handler
+			if i := strings.LastIndex(handlerFile, "."); i > 0 {
+				handlerFile = handlerFile[:i]
+			}
+			matches, _ := filepath.Glob(filepath.Join(build.Out, handlerFile+".*"))
+			if len(matches) == 0 {
+				// also check without extension for compiled binaries
+				if _, err := os.Stat(filepath.Join(build.Out, handlerFile)); err != nil {
+					log.Info("build output missing, rebuilding", "functionID", functionID, "handler", build.Handler)
+					delete(builds, functionID)
+				} else {
+					return build
+				}
+			} else {
+				return build
+			}
 		}
 		target, _ := targets[functionID]
 		build, err := input.project.Runtime.Build(ctx, target)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -107,11 +107,14 @@ func (c *Collection) Build(ctx context.Context, input *BuildInput) (*BuildOutput
 	}
 
 	if input.Bundle == "" {
-		err := os.RemoveAll(out)
-		if err != nil {
-			return nil, err
+		// skip removing in dev mode so running workers don't lose their bundle files
+		if !input.Dev {
+			err := os.RemoveAll(out)
+			if err != nil {
+				return nil, err
+			}
 		}
-		err = os.MkdirAll(out, 0755)
+		err := os.MkdirAll(out, 0755)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Fixes #6416

In `sst dev`, `Build()` calls `os.RemoveAll` on the artifacts directory before every rebuild. In dev mode, esbuild maintains a persistent context and overwrites output files in place via `Rebuild()`, so the full directory wipe is unnecessary. When multiple Lambda bridge instances connect for the same function (common with CloudFront/Router), this creates a race condition where running workers lose their `bundle.mjs` mid-flight.

**Changes:**

- Skip `os.RemoveAll` on the artifacts output directory during dev mode rebuilds
- Validate cached build output in `getBuildOutput()` by checking the handler file still exists on disk before returning a cache hit — if missing, invalidate the cache and trigger a rebuild

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./pkg/...` passes
- [x] `go build ./cmd/sst` succeeds