### PR TITLE
Add license info to packages

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sst/sst.git"
+    "url": "git+https://github.com/anomalyco/sst.git"
   },
   "license": "MIT",
   "exports": {

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/sst/sst.git"
   },
+  "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
     "./auth": "./dist/auth/index.js",

--- a/sdk/js/scripts/release.ts
+++ b/sdk/js/scripts/release.ts
@@ -49,11 +49,8 @@ for (const artifact of artifacts) {
       {
         name,
         version: nextPkg.version,
-        license: "MIT",
-        repository: {
-          "type": "git",
-          "url": "git+https://github.com/sst/sst.git"
-        },
+        license: nextPkg.license,
+        repository: nextPkg.repository,
         os: [os],
         cpu: [cpu],
       },

--- a/sdk/js/scripts/release.ts
+++ b/sdk/js/scripts/release.ts
@@ -49,6 +49,11 @@ for (const artifact of artifacts) {
       {
         name,
         version: nextPkg.version,
+        license: "MIT",
+        repository: {
+          "type": "git",
+          "url": "git+https://github.com/sst/sst.git"
+        },
         os: [os],
         cpu: [cpu],
       },


### PR DESCRIPTION
I'm currently building a license list for a project. It would be great if sst could include the license specifier and a link to the repo in the generated `package.json` fields - currently, packages like `sst-win32-x86` look a bit suspicious ([see on npmjs](https://www.npmjs.com/package/sst-win32-x86?activeTab=code)), it's just a tiny `package.json` with one large binary 😅 

This PR adds the license field to the base package and license + repository info to the generated packages.