### PR TITLE
Fix `DELETE` requests when `protection: "oac-with-edge-signing"` 

### DIFF
--- a/platform/functions/oac-edge-signer/index.ts
+++ b/platform/functions/oac-edge-signer/index.ts
@@ -9,7 +9,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
   const request = event.Records[0].cf.request;
 
   // Only process requests that need SHA256 signing (methods with body)
-  if (!["POST", "PUT", "PATCH", "DELETE"].includes(request.method)) {
+  if (!["POST", "PUT", "PATCH"].includes(request.method)) {
     return request;
   }
 


### PR DESCRIPTION
closes #6427 

Lambda@Edge doesn't forward body for DELETE requests, so the edge signer hashed an empty body while CloudFront OAC used a different hash → signature mismatch

<details>

<summary>proof of it working</summary>

<img width="1512" height="856" alt="CleanShot 2026-02-19 at 15 09 47@2x" src="https://github.com/user-attachments/assets/e84ca4c2-f2b9-4b4a-96c9-24969a8e412a" />

</details>