### PR TITLE
Use `PULUMI_IGNORE_AMBIENT_PLUGINS` instead of path prefixing

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -249,13 +249,6 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 	}
 
 	env := os.Environ()
-	// Prepend SST's bin directory to PATH to ensure SST's Pulumi is used over system-installed versions
-	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
-			env[i] = "PATH=" + global.BinPath() + string(os.PathListSeparator) + strings.TrimPrefix(e, "PATH=")
-			break
-		}
-	}
 	for key, value := range p.Env() {
 		env = append(env, fmt.Sprintf("%v=%v", key, value))
 	}
@@ -270,6 +263,7 @@ func (p *Project) RunNext(ctx context.Context, input *StackInput) error {
 		"PULUMI_SKIP_UPDATE_CHECK=true",
 		"PULUMI_BACKEND_URL=file://"+filepath.ToSlash(workdir.Backend()),
 		"PULUMI_DEBUG_COMMANDS=true",
+		"PULUMI_IGNORE_AMBIENT_PLUGINS=true",
 		// "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
 		"NODE_OPTIONS=--enable-source-maps --no-deprecation",
 		"PULUMI_HOME="+global.ConfigDir(),


### PR DESCRIPTION
closes #6425

the fix in #6316 also made the bundled `bun` version take precedence over the local one by prepending the sst bin path to `PATH`

instead, we’ll pass `PULUMI_IGNORE_AMBIENT_PLUGINS`, which also solves the github actions issue and avoids modifying the user’s path

<details>

<summary>proof of it working</summary>

<img width="1052" height="924" alt="CleanShot 2026-02-19 at 15 49 43@2x" src="https://github.com/user-attachments/assets/5080977e-1be2-4f0f-9642-b22105835dd7" />

</details>