### PR TITLE
Fix `sst add` crash when providers is not an object literal

### DIFF
--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -587,7 +587,7 @@ var root = &cli.Command{
 				}
 				err = p.Add(entry.Name, entry.Version)
 				if err != nil {
-					return err
+					return util.NewReadableError(err, err.Error())
 				}
 				spin.Suffix = "  Downloading provider..."
 				p, err = project.New(&project.ProjectConfig{

--- a/pkg/project/add.go
+++ b/pkg/project/add.go
@@ -1,18 +1,29 @@
 package project
 
 import (
+	"bytes"
+	"fmt"
 	"github.com/sst/sst/v3/pkg/process"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func (p *Project) Add(pkg string, version string) error {
+	var stderr bytes.Buffer
 	cmd := process.Command("node", filepath.Join(p.PathPlatformDir(), "src/ast/add.mjs"),
 		p.PathConfig(),
 		pkg,
 		version,
 	)
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+		return err
+	}
+	return nil
 }

--- a/platform/src/ast/add.mjs
+++ b/platform/src/ast/add.mjs
@@ -52,6 +52,13 @@ if (!providersProperty) {
   returnStatement.expression.properties.push(providersProperty);
 }
 
+if (!ts.isObjectLiteralExpression(providersProperty.initializer)) {
+  console.error(
+    'The "providers" property must be a plain object, not a dynamic expression like a ternary or variable.'
+  );
+  process.exit(1);
+}
+
 if (
   providersProperty.initializer.properties.find(
     (property) => property.name.getText().replaceAll('"', "") === pkg,


### PR DESCRIPTION
closes #6366

<details>

<summary>proof of it working</summary>

https://github.com/user-attachments/assets/426b3b3d-7b0a-4fe2-865f-09066a1657ed

</details>