### PR TITLE
Fix caching for Next.js images based on the `Accept` header

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2009,6 +2009,7 @@ async function routeSite(kvNamespace, metadata) {
 
   // Route to image optimizer
   if (metadata.image && baselessUri.startsWith(metadata.image.route)) {
+    setNextjsCacheKey();
     setUrlOrigin(metadata.image.host, metadata.image.originAccessControlConfig ? { originAccessControlConfig: metadata.image.originAccessControlConfig } : undefined);
     return;
   }


### PR DESCRIPTION
closes #6404 

<details>

<summary>proof of it working</summary>

| **Before** | **After** |
|------------|-----------|
| <img width="1956" height="626" alt="CleanShot 2026-02-19 at 19 47 59@2x" src="https://github.com/user-attachments/assets/3fefb750-6540-4d20-91a5-d29a07f02a57" />         | <img width="1914" height="516" alt="CleanShot 2026-02-19 at 19 37 43@2x" src="https://github.com/user-attachments/assets/fa8c8846-0422-4ac0-8575-3a2b06973613" /> |

</details>