### PR TITLE
Allow static imports in `sst.config.ts`

### DIFF
--- a/cmd/sst/mosaic/errors/errors.go
+++ b/cmd/sst/mosaic/errors/errors.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sst/sst/v3/cmd/sst/mosaic/aws"
 	"github.com/sst/sst/v3/cmd/sst/mosaic/aws/appsync"
 	"github.com/sst/sst/v3/internal/util"
-	"github.com/sst/sst/v3/pkg/js"
 	"github.com/sst/sst/v3/pkg/project"
 	"github.com/sst/sst/v3/pkg/project/provider"
 	"github.com/sst/sst/v3/pkg/server"
@@ -36,7 +35,6 @@ var transformers = []ErrorTransformer{
 	exact(project.ErrProtectedStage, "Cannot remove protected stage. To remove a protected stage edit your sst.config.ts and remove the `protect` property."),
 	exact(provider.ErrLockNotFound, "This app / stage is not locked"),
 	exact(aws.ErrAppsyncNotReady, "SST creates an appsync event api to power live lambda. After 10 seconds of waiting this cli could not connect to it."),
-	exact(js.ErrTopLevelImport, "Your sst.config.ts has top level imports - this is not allowed. Move imports inside the function they are used and do a dynamic import: `const mod = await import(\"./mod\")`"),
 	match(func(err *project.ErrBuildFailed) string {
 		result := "Failed to build sst.config.ts"
 		for _, msg := range err.Errors {

--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -11,8 +11,6 @@ import (
 	esbuild "github.com/evanw/esbuild/pkg/api"
 )
 
-var ErrTopLevelImport = fmt.Errorf("ErrTopLevelImport")
-
 type EvalOptions struct {
 	Dir     string
 	Outfile string
@@ -59,7 +57,6 @@ func Build(input EvalOptions) (esbuild.BuildResult, error) {
 		outfile = filepath.Join(input.Dir, ".sst", "platform", fmt.Sprintf("sst.config.%v.mjs", time.Now().UnixMilli()))
 	}
 	slog.Info("esbuild building", "out", outfile)
-	var err error
 	result := esbuild.Build(esbuild.BuildOptions{
 		Banner: map[string]string{
 			"js": `
@@ -85,14 +82,23 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 		},
 		Plugins: []esbuild.Plugin{
 			{
-				Name: "DisallowImports",
+				Name: "StubImports",
 				Setup: func(build esbuild.PluginBuild) {
 					build.OnResolve(esbuild.OnResolveOptions{Filter: ".*"}, func(args esbuild.OnResolveArgs) (esbuild.OnResolveResult, error) {
 						if input.Globals == "" && filepath.Base(args.Importer) == "sst.config.ts" && args.Kind == esbuild.ResolveJSImportStatement {
-							err = ErrTopLevelImport
-							return esbuild.OnResolveResult{}, ErrTopLevelImport
+							return esbuild.OnResolveResult{
+								Path:      args.Path,
+								Namespace: "stub",
+							}, nil
 						}
 						return esbuild.OnResolveResult{}, nil
+					})
+					build.OnLoad(esbuild.OnLoadOptions{Filter: ".*", Namespace: "stub"}, func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
+						contents := "module.exports = {}"
+						return esbuild.OnLoadResult{
+							Contents: &contents,
+							Loader:   esbuild.LoaderJS,
+						}, nil
 					})
 				},
 			},
@@ -138,9 +144,6 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 		Bundle:   true,
 		Metafile: true,
 	})
-	if err != nil {
-		return esbuild.BuildResult{}, err
-	}
 	if len(result.Errors) > 0 {
 		for _, err := range result.Errors {
 			slog.Error("esbuild error", "text", err.Text)


### PR DESCRIPTION
closes #6060 by stubbing imports when parsing the config just for the provider info

this has the side effect of static imports not working if used for the `app` field but seems less likely to be an issue

need to confirm this change with the core team