### PR TITLE
Revert `policy.urn.apply` to `policy.apply` to fix premature exits

### DIFF
--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -891,7 +891,7 @@ export class Bucket extends Component implements Link.Linkable {
     // (ie. bucket.name). Also, a bucket can only have one policy. We want to ensure
     // the policy created here is created first. And SST will throw an error if
     // another policy is created after this one.
-    this.bucket = policy.urn.apply(() => bucket);
+    this.bucket = policy.apply(() => bucket);
 
     function normalizeAccess() {
       return all([args.public, args.access]).apply(([pub, access]) =>


### PR DESCRIPTION
closes #6153

explanation: `policy.urn.apply()` resolves as soon as Pulumi starts creating the BucketPolicy. `policy.apply()` waits until it's done. on large stacks, the early resolution lets Pulumi exit while AWS API calls are still in-flight