### PR TITLE
Fix binary request body corruption in React and Remix Lambda handlers

### DIFF
--- a/platform/functions/react-server/server.mjs
+++ b/platform/functions/react-server/server.mjs
@@ -13,10 +13,6 @@ function convertLambdaRequestToNode(event) {
 
   const search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
   const url = new URL(event.rawPath + search, `https://${event.headers.host}`);
-  const isFormData = event.headers["content-type"]?.includes(
-    "multipart/form-data",
-  );
-
   // Build headers
   const headers = new Headers();
   for (let [header, value] of Object.entries(event.headers)) {
@@ -30,9 +26,7 @@ function convertLambdaRequestToNode(event) {
     headers,
     body:
       event.body && event.isBase64Encoded
-        ? isFormData
-          ? Buffer.from(event.body, "base64")
-          : Buffer.from(event.body, "base64").toString()
+        ? Buffer.from(event.body, "base64")
         : event.body,
   });
 }

--- a/platform/functions/remix-server/regional-server.mjs
+++ b/platform/functions/remix-server/regional-server.mjs
@@ -3,72 +3,6 @@
 
 import { createRequestHandler as createNodeRequestHandler } from "@remix-run/node";
 
-/**
- * Common binary MIME types
- */
-const binaryTypes = [
-  "application/octet-stream",
-  // Docs
-  "application/epub+zip",
-  "application/msword",
-  "application/pdf",
-  "application/rtf",
-  "application/vnd.amazon.ebook",
-  "application/vnd.ms-excel",
-  "application/vnd.ms-powerpoint",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  // Fonts
-  "font/otf",
-  "font/woff",
-  "font/woff2",
-  // Images
-  "image/bmp",
-  "image/gif",
-  "image/jpeg",
-  "image/png",
-  "image/tiff",
-  "image/vnd.microsoft.icon",
-  "image/webp",
-  // Audio
-  "audio/3gpp",
-  "audio/aac",
-  "audio/basic",
-  "audio/mpeg",
-  "audio/ogg",
-  "audio/wavaudio/webm",
-  "audio/x-aiff",
-  "audio/x-midi",
-  "audio/x-wav",
-  // Video
-  "video/3gpp",
-  "video/mp2t",
-  "video/mpeg",
-  "video/ogg",
-  "video/quicktime",
-  "video/webm",
-  "video/x-msvideo",
-  // Archives
-  "application/java-archive",
-  "application/vnd.apple.installer+xml",
-  "application/x-7z-compressed",
-  "application/x-apple-diskimage",
-  "application/x-bzip",
-  "application/x-bzip2",
-  "application/x-gzip",
-  "application/x-java-archive",
-  "application/x-rar-compressed",
-  "application/x-tar",
-  "application/x-zip",
-  "application/zip",
-];
-
-function isBinaryType(contentType) {
-  if (!contentType) return false;
-  return binaryTypes.some((t) => contentType.includes(t));
-}
-
 function convertApigRequestToNode(event) {
   if (event.headers["x-forwarded-host"]) {
     event.headers.host = event.headers["x-forwarded-host"];
@@ -76,10 +10,6 @@ function convertApigRequestToNode(event) {
 
   const search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
   const url = new URL(event.rawPath + search, `https://${event.headers.host}`);
-  const isFormData = event.headers["content-type"]?.includes(
-    "multipart/form-data",
-  );
-
   // Build headers
   const headers = new Headers();
   for (let [header, value] of Object.entries(event.headers)) {
@@ -93,9 +23,7 @@ function convertApigRequestToNode(event) {
     headers,
     body:
       event.body && event.isBase64Encoded
-        ? isFormData
-          ? Buffer.from(event.body, "base64")
-          : Buffer.from(event.body, "base64").toString()
+        ? Buffer.from(event.body, "base64")
         : event.body,
   });
 }


### PR DESCRIPTION
closes #6275

<details>

<summary>proof of it working</summary>

### before

<img width="3416" height="264" alt="CleanShot 2026-02-20 at 14 16 54@2x" src="https://github.com/user-attachments/assets/a23d95f0-15af-4f17-a1f1-6801d971358a" />

### after

<img width="3442" height="280" alt="CleanShot 2026-02-20 at 14 20 47@2x" src="https://github.com/user-attachments/assets/fda17742-9371-4d97-a933-5248b3a49beb" />

</details>