### PR TITLE
Add missing `ApiGatewayV2` account setup

### DIFF
--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -27,6 +27,7 @@ import {
 } from "../duration";
 import { ApiGatewayV2PrivateRoute } from "./apigatewayv2-private-route";
 import { Vpc } from "./vpc";
+import { setupApiGatewayAccount } from "./helpers/apigateway-account";
 
 interface ApiGatewayV2CorsArgs {
   /**
@@ -695,6 +696,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     const cors = normalizeCors();
     const vpc = normalizeVpc();
 
+    const apigAccount = setupApiGatewayAccount(name, opts);
     const vpcLink = createVpcLink();
     const api = createApi();
     const logGroup = createLogGroup();
@@ -870,7 +872,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
               }),
             },
           },
-          { parent },
+          { parent, dependsOn: apigAccount },
         ),
       );
     }


### PR DESCRIPTION
closes #6239 

<details>

<summary>proof of it working</summary>

<img width="1362" height="426" alt="CleanShot 2026-02-23 at 11 46 46@2x" src="https://github.com/user-attachments/assets/0af529e5-59d5-4b87-a6a2-23ab1d8c8d4b" />
</details>