### PR TITLE
Add `cache` option to disable Docker build ECR caching

### DIFF
--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -189,7 +189,7 @@ func (r *PythonRuntime) CreateBuildAsset(ctx context.Context, input *runtime.Bui
 
 	type Properties struct {
 		Architecture string `json:"architecture"`
-		Container    bool   `json:"container"`
+		Container    json.RawMessage `json:"container"`
 	}
 	var props Properties
 	if err := json.Unmarshal(input.Properties, &props); err != nil {

--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -195,6 +195,12 @@ export interface FargateContainerArgs {
          * The stage to build up to. Same as the top-level [`image.target`](#image-target).
          */
         target?: Input<string>;
+        /**
+         * Controls whether Docker build cache is enabled. Same as the top-level
+         * [`image.cache`](#image-cache).
+         * @default `true`
+         */
+        cache?: Input<boolean>;
       }
   >;
   /**
@@ -480,6 +486,21 @@ export interface FargateBaseArgs {
          * ```
          */
         target?: Input<string>;
+        /**
+         * Controls whether Docker build cache is enabled.
+         * @default `true`
+         * @example
+         * Disable Docker build caching, useful for environments like Localstack where
+         * ECR cache export is not supported.
+         * ```js
+         * {
+         *   image: {
+         *     cache: false
+         *   }
+         * }
+         * ```
+         */
+        cache?: Input<boolean>;
       }
   >;
   /**
@@ -1053,23 +1074,27 @@ export function createTaskDefinition(
                     username: authToken.userName,
                   })),
               ],
-              cacheFrom: [
-                {
-                  registry: {
-                    ref: interpolate`${bootstrapData.assetEcrUrl}:${container.name}-cache`,
-                  },
-                },
-              ],
-              cacheTo: [
-                {
-                  registry: {
-                    ref: interpolate`${bootstrapData.assetEcrUrl}:${container.name}-cache`,
-                    imageManifest: true,
-                    ociMediaTypes: true,
-                    mode: "max",
-                  },
-                },
-              ],
+              ...(container.image.cache !== false
+                ? {
+                    cacheFrom: [
+                      {
+                        registry: {
+                          ref: interpolate`${bootstrapData.assetEcrUrl}:${container.name}-cache`,
+                        },
+                      },
+                    ],
+                    cacheTo: [
+                      {
+                        registry: {
+                          ref: interpolate`${bootstrapData.assetEcrUrl}:${container.name}-cache`,
+                          imageManifest: true,
+                          ociMediaTypes: true,
+                          mode: "max",
+                        },
+                      },
+                    ],
+                  }
+                : {}),
               push: true,
             },
             { parent },

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1169,7 +1169,28 @@ export interface FunctionArgs {
      *
      * You can refer to [this example of using a container image](/docs/examples/#aws-lambda-python-container).
      */
-    container?: Input<boolean>;
+    container?: Input<
+      | boolean
+      | {
+          /**
+           * Controls whether Docker build cache is enabled.
+           * @default `true`
+           * @example
+           * Disable Docker build caching, useful for environments like Localstack where
+           * ECR cache export is not supported.
+           * ```js
+           * {
+           *   python: {
+           *     container: {
+           *       cache: false
+           *     }
+           *   }
+           * }
+           * ```
+           */
+          cache?: Input<boolean>;
+        }
+    >;
   }>;
   /**
    * Add additional files to copy into the function package. Takes a list of objects
@@ -1682,7 +1703,12 @@ export class Function extends Component implements Link.Linkable {
     const parent = this;
     const dev = normalizeDev();
     const isContainer = all([args.python, dev]).apply(
-      ([python, dev]) => !dev && (python?.container ?? false),
+      ([python, dev]) => !dev && !!python?.container,
+    );
+    const containerCache = all([args.python]).apply(([python]) =>
+      typeof python?.container === "object"
+        ? (python.container.cache ?? true)
+        : true,
     );
     const partition = getPartitionOutput({}, opts).partition;
     const region = getRegionOutput({}, opts).name;
@@ -2205,11 +2231,12 @@ export class Function extends Component implements Link.Linkable {
       // The build artifact directory already exists, with all the user code and
       // config files. It also has the dockerfile, we need to now just build and push to
       // the container registry.
-      return all([isContainer, dev, bundle]).apply(
+      return all([isContainer, dev, bundle, containerCache]).apply(
         ([
           isContainer,
           dev,
           bundle, // We need the bundle to be resolved because of implicit dockerfiles even though we don't use it here
+          containerCache,
         ]) => {
           if (!isContainer || dev) return;
 
@@ -2228,23 +2255,27 @@ export class Function extends Component implements Link.Linkable {
                   `${name}-src`,
                 ),
               },
-              cacheFrom: [
-                {
-                  registry: {
-                    ref: $interpolate`${bootstrapData.assetEcrUrl}:${name}-cache`,
-                  },
-                },
-              ],
-              cacheTo: [
-                {
-                  registry: {
-                    ref: $interpolate`${bootstrapData.assetEcrUrl}:${name}-cache`,
-                    imageManifest: true,
-                    ociMediaTypes: true,
-                    mode: "max",
-                  },
-                },
-              ],
+              ...(containerCache !== false
+                ? {
+                    cacheFrom: [
+                      {
+                        registry: {
+                          ref: $interpolate`${bootstrapData.assetEcrUrl}:${name}-cache`,
+                        },
+                      },
+                    ],
+                    cacheTo: [
+                      {
+                        registry: {
+                          ref: $interpolate`${bootstrapData.assetEcrUrl}:${name}-cache`,
+                          imageManifest: true,
+                          ociMediaTypes: true,
+                          mode: "max",
+                        },
+                      },
+                    ],
+                  }
+                : {}),
               platforms: [
                 architecture.apply((v) =>
                   v === "arm64" ? "linux/arm64" : "linux/amd64",


### PR DESCRIPTION
partially closes https://github.com/anomalyco/sst/issues/6433

<details>

<summary>proof of it working</summary>

deployed aws python container example:

<img width="1604" height="380" alt="CleanShot 2026-02-23 at 16 15 51@2x" src="https://github.com/user-attachments/assets/45cd9e23-2cd7-409a-9c0e-af627b038176" />

</details>