### PR TITLE
Update default `Postgres.v1` version to 17

### DIFF
--- a/platform/src/components/aws/postgres-v1.ts
+++ b/platform/src/components/aws/postgres-v1.ts
@@ -20,11 +20,11 @@ function parseACU(acu: ACU) {
 export interface PostgresArgs {
   /**
    * The Postgres engine version. Check out the [available versions in your region](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.ServerlessV2.html#Concepts.Aurora_Fea_Regions_DB-eng.Feature.ServerlessV2.apg).
-   * @default `"15.5"`
+   * @default `"17"`
    * @example
    * ```js
    * {
-   *   version: "13.9"
+   *   version: "15.5"
    * }
    * ```
    */
@@ -284,7 +284,7 @@ export class Postgres extends Component implements Link.Linkable {
     }
 
     function normalizeVersion() {
-      return output(args.version).apply((version) => version ?? "15.5");
+      return output(args.version).apply((version) => version ?? "17");
     }
 
     function normalizeDatabaseName() {
@@ -328,7 +328,10 @@ export class Postgres extends Component implements Link.Linkable {
                 ? undefined
                 : output(args.vpc).securityGroups,
           },
-          { parent },
+          {
+            parent,
+            ignoreChanges: args.version ? [] : ["engineVersion"],
+          },
         ),
       );
     }
@@ -345,7 +348,10 @@ export class Postgres extends Component implements Link.Linkable {
             engineVersion: cluster.engineVersion,
             dbSubnetGroupName: subnetGroup?.name,
           },
-          { parent },
+          {
+            parent,
+            ignoreChanges: args.version ? [] : ["engineVersion"],
+          },
         ),
       );
     }


### PR DESCRIPTION
did this to avoid accidental `Vector` deployments failing

same pattern as https://github.com/anomalyco/sst/pull/6207