### PR TITLE
Fix false positive "Interrupted" messages

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -588,6 +588,7 @@ loop:
 		}
 	}
 
+	// fallback: re-read the event log if the tailing loop missed SummaryEvent
 	if !finished {
 		if data, err := os.ReadFile(eventlogPath); err == nil {
 			for _, line := range strings.Split(string(data), "\n") {

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -588,6 +588,21 @@ loop:
 		}
 	}
 
+	if !finished {
+		if data, err := os.ReadFile(eventlogPath); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				if line == "" {
+					continue
+				}
+				var ev events.EngineEvent
+				if json.Unmarshal([]byte(line), &ev) == nil && ev.SummaryEvent != nil {
+					finished = true
+					break
+				}
+			}
+		}
+	}
+
 	log.Info("parsing state")
 	complete, err := getCompletedEvent(context.Background(), passphrase, workdir)
 	if err != nil {


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6491

<details>

<summary>proof of it working</summary>

#### before (sometimes)

<img width="1846" height="1448" alt="CleanShot 2026-02-27 at 14 49 18@2x" src="https://github.com/user-attachments/assets/69d22640-335f-4bf5-9f08-acce1907a13c" />

#### after

<img width="1882" height="1530" alt="CleanShot 2026-02-27 at 14 49 27@2x" src="https://github.com/user-attachments/assets/ac0f0257-690c-4017-810e-63cb58c06972" />

</details>

i've tested this a lot and it's very hard to pin point why this happens. however with the added fallback i've not managed to reproduce the issue

considering that this can happen for the new v3 to v4 migration i believe it is worth it