### PR TITLE
Use `setsid` instead of `setpgid` to fix interactive dev commands

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -124,7 +124,7 @@ func CmdMosaic(c *cli.Cli) error {
 					for k, v := range nextEnv.Env {
 						cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 					}
-					process.Detach(cmd)
+					process.DetachSession(cmd)
 					cmd.Stdin = os.Stdin
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr

--- a/pkg/process/detach_unix.go
+++ b/pkg/process/detach_unix.go
@@ -16,3 +16,10 @@ func Detach(cmd *exec.Cmd) {
 	// clobbering any other existing SysProcAttr fields set by the caller.
 	cmd.SysProcAttr.Setpgid = true
 }
+
+func DetachSession(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/pkg/process/detach_windows.go
+++ b/pkg/process/detach_windows.go
@@ -7,3 +7,6 @@ import "os/exec"
 
 func Detach(cmd *exec.Cmd) {
 }
+
+func DetachSession(cmd *exec.Cmd) {
+}

--- a/pkg/process/kill_unix_test.go
+++ b/pkg/process/kill_unix_test.go
@@ -42,6 +42,35 @@ func TestKillTerminatesProcessGroup(t *testing.T) {
 	}
 }
 
+func TestKillTerminatesSessionGroup(t *testing.T) {
+	reset()
+	cmd := Command("sh", "-c", "sleep 60 & wait")
+	DetachSession(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	parentPid := cmd.Process.Pid
+
+	time.Sleep(100 * time.Millisecond)
+
+	// with Setsid the pgid equals the parent pid, same as Setpgid
+	childPid := findChildInGroup(t, parentPid)
+
+	if err := Kill(cmd.Process); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if err := syscall.Kill(parentPid, 0); err == nil {
+		t.Error("parent still alive after Kill")
+	}
+	if childPid != 0 {
+		if err := syscall.Kill(childPid, 0); err == nil {
+			t.Error("child still alive after group Kill")
+		}
+	}
+}
+
 func TestSendSignalInvalidPid(t *testing.T) {
 	p := &os.Process{}
 	// Pid 0 should be rejected


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6495

<details>

<summary>proof of it working</summary>

#### before

https://github.com/user-attachments/assets/e3ba2965-c5e2-41d1-a4f3-2fbaf97fb579

#### after

https://github.com/user-attachments/assets/2d00b7ae-02df-4326-8e1a-bf8b1de6381a

</details>

dev commands spawned with setpgid land in a background process group relative to the PTY's foreground group, so the kernel sends SIGTTIN and freezes any command that reads stdin

setsid detaches from the controlling terminal entirely, avoiding SIGTTIN while still allowing group kill via -pid