### PR TITLE
Exclude git submodules from type file generation

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -36,6 +36,12 @@ func Exists(path string) bool {
 	return err == nil
 }
 
+func IsGitSubmodule(dir string) bool {
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Stat(gitPath)
+	return err == nil && !info.IsDir()
+}
+
 func FindDown(dir, filename string) []string {
 	var result []string
 
@@ -46,6 +52,9 @@ func FindDown(dir, filename string) []string {
 		if info.IsDir() {
 			name := info.Name()
 			if name == "node_modules" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			if path != dir && IsGitSubmodule(path) {
 				return filepath.SkipDir
 			}
 		}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -72,10 +72,59 @@ func TestFindDown(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
+	t.Run("skips git submodules", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Normal nested dir — should be found
+		normal := filepath.Join(dir, "app")
+		os.MkdirAll(normal, 0755)
+		os.WriteFile(filepath.Join(normal, "package.json"), []byte("{}"), 0644)
+
+		// Submodule dir (has .git file) — should be skipped
+		sub := filepath.Join(dir, "submod")
+		os.MkdirAll(sub, 0755)
+		os.WriteFile(filepath.Join(sub, ".git"), []byte("gitdir: ../../.git/modules/submod"), 0644)
+		os.WriteFile(filepath.Join(sub, "package.json"), []byte("{}"), 0644)
+
+		results := fs.FindDown(dir, "package.json")
+		assert.Equal(t, []string{filepath.Join(normal, "package.json")}, results)
+	})
+
+	t.Run("does not skip dirs with .git directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Nested repo clone (has .git directory, not file) — should be walked
+		nested := filepath.Join(dir, "nested-repo")
+		os.MkdirAll(filepath.Join(nested, ".git"), 0755)
+		os.WriteFile(filepath.Join(nested, "package.json"), []byte("{}"), 0644)
+
+		results := fs.FindDown(dir, "package.json")
+		assert.Equal(t, []string{filepath.Join(nested, "package.json")}, results)
+	})
+
 	t.Run("not found returns empty", func(t *testing.T) {
 		dir := t.TempDir()
 		results := fs.FindDown(dir, "nope.txt")
 		assert.Empty(t, results)
+	})
+}
+
+func TestIsGitSubmodule(t *testing.T) {
+	t.Run("git file returns true", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: ../../.git/modules/foo"), 0644)
+		assert.True(t, fs.IsGitSubmodule(dir))
+	})
+
+	t.Run("git directory returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Mkdir(filepath.Join(dir, ".git"), 0755)
+		assert.False(t, fs.IsGitSubmodule(dir))
+	})
+
+	t.Run("no git entry returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.False(t, fs.IsGitSubmodule(dir))
 	})
 }
 


### PR DESCRIPTION
<details>

<summary>proof of it working</summary>

| **Before** | **After** |
|------------|-----------|
|  <img width="1976" height="1422" alt="CleanShot 2026-02-27 at 16 16 03@2x" src="https://github.com/user-attachments/assets/44f8f56c-48ae-49a6-9553-cbd0636fdec8" />         | <img width="1976" height="1422" alt="CleanShot 2026-02-27 at 16 16 55@2x" src="https://github.com/user-attachments/assets/17e4582b-07ea-453c-8eaa-065925c7b031" />         |

</details>