### PR TITLE
Fix `sst diff` always reporting changes to `lambda.Permission` with qualified ARNs

### DIFF
--- a/platform/src/components/aws/apigateway-websocket-route.ts
+++ b/platform/src/components/aws/apigateway-websocket-route.ts
@@ -11,6 +11,7 @@ import { FunctionArgs, FunctionArn } from "./function";
 import { ApiGatewayWebSocketRouteArgs } from "./apigateway-websocket";
 import { apigatewayv2, lambda } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends ApiGatewayWebSocketRouteArgs {
   /**
@@ -94,7 +95,8 @@ export class ApiGatewayWebSocketRoute extends Component {
         `${name}Permissions`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/apigateway-websocket-route.ts
+++ b/platform/src/components/aws/apigateway-websocket-route.ts
@@ -96,7 +96,7 @@ export class ApiGatewayWebSocketRoute extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/apigatewayv1-authorizer.ts
+++ b/platform/src/components/aws/apigatewayv1-authorizer.ts
@@ -115,7 +115,7 @@ export class ApiGatewayV1Authorizer extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/authorizers/${authorizer.id}`,
         },

--- a/platform/src/components/aws/apigatewayv1-authorizer.ts
+++ b/platform/src/components/aws/apigatewayv1-authorizer.ts
@@ -10,6 +10,7 @@ import { VisibleError } from "../error";
 import { ApiGatewayV1AuthorizerArgs } from "./apigatewayv1";
 import { apigateway, lambda } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface AuthorizerArgs extends ApiGatewayV1AuthorizerArgs {
   /**
@@ -113,7 +114,8 @@ export class ApiGatewayV1Authorizer extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/authorizers/${authorizer.id}`,
         },

--- a/platform/src/components/aws/apigatewayv1-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv1-lambda-route.ts
@@ -80,7 +80,7 @@ export class ApiGatewayV1LambdaRoute extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/apigatewayv1-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv1-lambda-route.ts
@@ -14,6 +14,7 @@ import {
   createMethod,
 } from "./apigatewayv1-base-route";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends ApiGatewayV1BaseRouteArgs {
   /**
@@ -78,7 +79,8 @@ export class ApiGatewayV1LambdaRoute extends Component {
         `${name}Permissions`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/apigatewayv2-authorizer.ts
+++ b/platform/src/components/aws/apigatewayv2-authorizer.ts
@@ -10,6 +10,7 @@ import { apigatewayv2, lambda } from "@pulumi/aws";
 import { VisibleError } from "../error";
 import { toSeconds } from "../duration";
 import { functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface AuthorizerArgs extends ApiGatewayV2AuthorizerArgs {
   /**
@@ -154,7 +155,8 @@ export class ApiGatewayV2Authorizer extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/authorizers/${authorizer.id}`,
         },

--- a/platform/src/components/aws/apigatewayv2-authorizer.ts
+++ b/platform/src/components/aws/apigatewayv2-authorizer.ts
@@ -156,7 +156,7 @@ export class ApiGatewayV2Authorizer extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/authorizers/${authorizer.id}`,
         },

--- a/platform/src/components/aws/apigatewayv2-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv2-lambda-route.ts
@@ -84,7 +84,7 @@ export class ApiGatewayV2LambdaRoute extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/apigatewayv2-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv2-lambda-route.ts
@@ -13,6 +13,7 @@ import {
   createApiRoute,
 } from "./apigatewayv2-base-route";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends ApiGatewayV2BaseRouteArgs {
   /**
@@ -82,7 +83,8 @@ export class ApiGatewayV2LambdaRoute extends Component {
         `${name}Permissions`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "apigateway.amazonaws.com",
           sourceArn: interpolate`${api.executionArn}/*`,
         },

--- a/platform/src/components/aws/bucket-lambda-subscriber.ts
+++ b/platform/src/components/aws/bucket-lambda-subscriber.ts
@@ -10,6 +10,7 @@ import { Function, FunctionArgs } from "./function";
 import { BucketSubscriberArgs } from "./bucket";
 import { lambda, s3 } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends BucketSubscriberArgs {
   /**
@@ -101,7 +102,8 @@ export class BucketLambdaSubscriber extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "s3.amazonaws.com",
           sourceArn: bucket.arn,
         },

--- a/platform/src/components/aws/bucket-lambda-subscriber.ts
+++ b/platform/src/components/aws/bucket-lambda-subscriber.ts
@@ -103,7 +103,7 @@ export class BucketLambdaSubscriber extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "s3.amazonaws.com",
           sourceArn: bucket.arn,
         },

--- a/platform/src/components/aws/bucket-notification.ts
+++ b/platform/src/components/aws/bucket-notification.ts
@@ -8,6 +8,7 @@ import { Component, transform } from "../component";
 import { BucketNotificationsArgs } from "./bucket";
 import { iam, lambda, s3, sns } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 import { VisibleError } from "../error";
 import { SnsTopic } from "./sns-topic";
 import { Queue } from "./queue";
@@ -110,7 +111,8 @@ export class BucketNotification extends Component {
               `${name}Notification${n.name}Permission`,
               {
                 action: "lambda:InvokeFunction",
-                function: fn.arn,
+                function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+                qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
                 principal: "s3.amazonaws.com",
                 sourceArn: bucket.arn,
               },

--- a/platform/src/components/aws/bucket-notification.ts
+++ b/platform/src/components/aws/bucket-notification.ts
@@ -112,7 +112,7 @@ export class BucketNotification extends Component {
               {
                 action: "lambda:InvokeFunction",
                 function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-                qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+                qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
                 principal: "s3.amazonaws.com",
                 sourceArn: bucket.arn,
               },

--- a/platform/src/components/aws/bus-lambda-subscriber.ts
+++ b/platform/src/components/aws/bus-lambda-subscriber.ts
@@ -68,7 +68,7 @@ export class BusLambdaSubscriber extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "events.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/bus-lambda-subscriber.ts
+++ b/platform/src/components/aws/bus-lambda-subscriber.ts
@@ -10,6 +10,7 @@ import { Function, FunctionArgs } from "./function";
 import { BusBaseSubscriberArgs, createRule } from "./bus-base-subscriber";
 import { cloudwatch, lambda } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends BusBaseSubscriberArgs {
   /**
@@ -66,7 +67,8 @@ export class BusLambdaSubscriber extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "events.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -9,6 +9,7 @@ import { VisibleError } from "../error";
 import { cognito, lambda } from "@pulumi/aws";
 import { permission } from "./permission";
 import { functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 interface Triggers {
   /**
@@ -679,7 +680,8 @@ export class CognitoUserPool extends Component implements Link.Linkable {
                         `${name}Permission${key}`,
                         {
                           action: "lambda:InvokeFunction",
-                          function: fn.arn,
+                          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+                          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
                           principal: "cognito-idp.amazonaws.com",
                           sourceArn: userPool.arn,
                         },

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -681,7 +681,7 @@ export class CognitoUserPool extends Component implements Link.Linkable {
                         {
                           action: "lambda:InvokeFunction",
                           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-                          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+                          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
                           principal: "cognito-idp.amazonaws.com",
                           sourceArn: userPool.arn,
                         },

--- a/platform/src/components/aws/cron.ts
+++ b/platform/src/components/aws/cron.ts
@@ -293,7 +293,7 @@ export class Cron extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "events.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/cron.ts
+++ b/platform/src/components/aws/cron.ts
@@ -4,6 +4,7 @@ import { FunctionArgs, FunctionArn } from "./function";
 import { Input } from "../input.js";
 import { cloudwatch, iam, lambda } from "@pulumi/aws";
 import { functionBuilder, FunctionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 import { Task } from "./task";
 import { VisibleError } from "../error";
 
@@ -291,7 +292,8 @@ export class Cron extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "events.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/helpers/arn.ts
+++ b/platform/src/components/aws/helpers/arn.ts
@@ -11,6 +11,19 @@ export function parseFunctionArn(arn: string) {
   return { functionName };
 }
 
+export function splitQualifiedFunctionArn(arn: string) {
+  // Unqualified: arn:aws:lambda:region:account-id:function:function-name (7 parts)
+  // Qualified:   arn:aws:lambda:region:account-id:function:function-name:alias-or-version (8 parts)
+  const parts = arn.split(":");
+  if (parts.length <= 7) {
+    return { unqualifiedArn: arn, qualifier: undefined };
+  }
+  return {
+    unqualifiedArn: parts.slice(0, 7).join(":"),
+    qualifier: parts[7],
+  };
+}
+
 export function parseBucketArn(arn: string) {
   // arn:aws:s3:::bucket-name
   const bucketName = arn.split(":")[5];

--- a/platform/src/components/aws/helpers/arn.ts
+++ b/platform/src/components/aws/helpers/arn.ts
@@ -24,6 +24,7 @@ export function splitQualifiedFunctionArn(arn: string) {
   };
 }
 
+
 export function parseBucketArn(arn: string) {
   // arn:aws:s3:::bucket-name
   const bucketName = arn.split(":")[5];

--- a/platform/src/components/aws/realtime-lambda-subscriber.ts
+++ b/platform/src/components/aws/realtime-lambda-subscriber.ts
@@ -92,7 +92,7 @@ export class RealtimeLambdaSubscriber extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "iot.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/realtime-lambda-subscriber.ts
+++ b/platform/src/components/aws/realtime-lambda-subscriber.ts
@@ -11,7 +11,7 @@ import { RealtimeSubscriberArgs } from "./realtime";
 import { lambda } from "@pulumi/aws";
 import { iot } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
-import { parseFunctionArn } from "./helpers/arn";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends RealtimeSubscriberArgs {
   /**
@@ -91,7 +91,8 @@ export class RealtimeLambdaSubscriber extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn.apply((arn) => parseFunctionArn(arn).functionName),
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "iot.amazonaws.com",
           sourceArn: rule.arn,
         },

--- a/platform/src/components/aws/sns-topic-lambda-subscriber.ts
+++ b/platform/src/components/aws/sns-topic-lambda-subscriber.ts
@@ -10,6 +10,7 @@ import { Function, FunctionArgs } from "./function";
 import { SnsTopicSubscriberArgs } from "./sns-topic";
 import { lambda, sns } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
+import { splitQualifiedFunctionArn } from "./helpers/arn";
 
 export interface Args extends SnsTopicSubscriberArgs {
   /**
@@ -72,7 +73,8 @@ export class SnsTopicLambdaSubscriber extends Component {
         `${name}Permission`,
         {
           action: "lambda:InvokeFunction",
-          function: fn.arn,
+          function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
           principal: "sns.amazonaws.com",
           sourceArn: topic.arn,
         },

--- a/platform/src/components/aws/sns-topic-lambda-subscriber.ts
+++ b/platform/src/components/aws/sns-topic-lambda-subscriber.ts
@@ -74,7 +74,7 @@ export class SnsTopicLambdaSubscriber extends Component {
         {
           action: "lambda:InvokeFunction",
           function: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).unqualifiedArn),
-          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier),
+          qualifier: fn.arn.apply((arn) => splitQualifiedFunctionArn(arn).qualifier!),
           principal: "sns.amazonaws.com",
           sourceArn: topic.arn,
         },

--- a/platform/test/components/arn.test.ts
+++ b/platform/test/components/arn.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFunctionArn,
+  splitQualifiedFunctionArn,
+  parseBucketArn,
+  parseTopicArn,
+  parseQueueArn,
+  parseDynamoArn,
+  parseDynamoStreamArn,
+  parseKinesisStreamArn,
+  parseEventBusArn,
+  parseRoleArn,
+  parseLambdaEdgeArn,
+  parseElasticSearch,
+  parseOpenSearch,
+} from "../../src/components/aws/helpers/arn";
+
+describe("parseFunctionArn", () => {
+  it("parses unqualified ARN", () => {
+    expect(
+      parseFunctionArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+      ),
+    ).toEqual({ functionName: "my-func" });
+  });
+
+  it("parses qualified ARN (returns function name without qualifier)", () => {
+    expect(
+      parseFunctionArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:live",
+      ),
+    ).toEqual({ functionName: "my-func" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseFunctionArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("splitQualifiedFunctionArn", () => {
+  it("returns unqualified ARN as-is with no qualifier", () => {
+    const arn = "arn:aws:lambda:us-east-1:123456789012:function:my-func";
+    expect(splitQualifiedFunctionArn(arn)).toEqual({
+      unqualifiedArn: arn,
+      qualifier: undefined,
+    });
+  });
+
+  it("splits qualified ARN with alias", () => {
+    expect(
+      splitQualifiedFunctionArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:live",
+      ),
+    ).toEqual({
+      unqualifiedArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+      qualifier: "live",
+    });
+  });
+
+  it("splits qualified ARN with version number", () => {
+    expect(
+      splitQualifiedFunctionArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:42",
+      ),
+    ).toEqual({
+      unqualifiedArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+      qualifier: "42",
+    });
+  });
+
+  it("splits qualified ARN with $LATEST", () => {
+    expect(
+      splitQualifiedFunctionArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST",
+      ),
+    ).toEqual({
+      unqualifiedArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+      qualifier: "$LATEST",
+    });
+  });
+});
+
+describe("parseBucketArn", () => {
+  it("parses valid S3 ARN", () => {
+    expect(parseBucketArn("arn:aws:s3:::my-bucket")).toEqual({
+      bucketName: "my-bucket",
+    });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseBucketArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseTopicArn", () => {
+  it("parses valid SNS ARN", () => {
+    expect(
+      parseTopicArn("arn:aws:sns:us-east-1:123456789012:my-topic"),
+    ).toEqual({ topicName: "my-topic" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseTopicArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseQueueArn", () => {
+  it("parses valid SQS ARN", () => {
+    const result = parseQueueArn(
+      "arn:aws:sqs:us-east-1:123456789012:my-queue",
+    );
+    expect(result.queueName).toBe("my-queue");
+    expect(result.queueUrl).toBe(
+      "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
+    );
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseQueueArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseDynamoArn", () => {
+  it("parses valid DynamoDB ARN", () => {
+    expect(
+      parseDynamoArn(
+        "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable",
+      ),
+    ).toEqual({ tableName: "MyTable" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseDynamoArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseDynamoStreamArn", () => {
+  it("parses valid DynamoDB stream ARN", () => {
+    expect(
+      parseDynamoStreamArn(
+        "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable/stream/2024-02-25T23:17:55.264",
+      ),
+    ).toEqual({ tableName: "MyTable" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseDynamoStreamArn("not-an-arn")).toThrow();
+  });
+
+  it("throws on wrong service", () => {
+    expect(() =>
+      parseDynamoStreamArn("arn:aws:kinesis:us-east-1:123456789012:stream/s"),
+    ).toThrow();
+  });
+});
+
+describe("parseKinesisStreamArn", () => {
+  it("parses valid Kinesis stream ARN", () => {
+    expect(
+      parseKinesisStreamArn(
+        "arn:aws:kinesis:us-east-1:123456789012:stream/MyStream",
+      ),
+    ).toEqual({ streamName: "MyStream" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseKinesisStreamArn("not-an-arn")).toThrow();
+  });
+
+  it("throws on wrong service", () => {
+    expect(() =>
+      parseKinesisStreamArn(
+        "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable",
+      ),
+    ).toThrow();
+  });
+});
+
+describe("parseEventBusArn", () => {
+  it("parses valid EventBridge ARN", () => {
+    expect(
+      parseEventBusArn(
+        "arn:aws:events:us-east-1:123456789012:event-bus/my-bus",
+      ),
+    ).toEqual({ busName: "my-bus" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseEventBusArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseRoleArn", () => {
+  it("parses valid IAM role ARN", () => {
+    expect(
+      parseRoleArn("arn:aws:iam::123456789012:role/MyRole"),
+    ).toEqual({ roleName: "MyRole" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseRoleArn("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseLambdaEdgeArn", () => {
+  it("parses valid Lambda@Edge ARN", () => {
+    expect(
+      parseLambdaEdgeArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:1",
+      ),
+    ).toEqual({ functionName: "my-func", region: "us-east-1", version: "1" });
+  });
+
+  it("throws on wrong region", () => {
+    expect(() =>
+      parseLambdaEdgeArn(
+        "arn:aws:lambda:eu-west-1:123456789012:function:my-func:1",
+      ),
+    ).toThrow(/us-east-1/);
+  });
+
+  it("throws on unqualified ARN (no version)", () => {
+    expect(() =>
+      parseLambdaEdgeArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+      ),
+    ).toThrow(/qualified/);
+  });
+
+  it("throws on $LATEST", () => {
+    expect(() =>
+      parseLambdaEdgeArn(
+        "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST",
+      ),
+    ).toThrow(/qualified/);
+  });
+});
+
+describe("parseElasticSearch", () => {
+  it("parses valid ElasticSearch domain ARN", () => {
+    expect(
+      parseElasticSearch(
+        "arn:aws:es:us-east-1:123456789012:domain/my-domain",
+      ),
+    ).toEqual({ tableName: "my-domain" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseElasticSearch("not-an-arn")).toThrow();
+  });
+});
+
+describe("parseOpenSearch", () => {
+  it("parses valid OpenSearch domain ARN", () => {
+    expect(
+      parseOpenSearch(
+        "arn:aws:opensearch:us-east-1:123456789012:domain/my-domain",
+      ),
+    ).toEqual({ tableName: "my-domain" });
+  });
+
+  it("throws on invalid ARN", () => {
+    expect(() => parseOpenSearch("not-an-arn")).toThrow();
+  });
+});


### PR DESCRIPTION
closes #6154

<details>

<summary>proof of it working</summary>

| **Before** | **After** |
|------------|-----------|
|  <img width="2626" height="1170" alt="CleanShot 2026-03-01 at 19 22 16@2x" src="https://github.com/user-attachments/assets/1e0d8ef5-98e8-4008-a80c-a87efa9cb907" />         |  <img width="2648" height="836" alt="CleanShot 2026-03-01 at 19 22 47@2x" src="https://github.com/user-attachments/assets/57e2c0c2-5edb-4c0e-a62c-ec076213480a" />        |

</details>

when sst components pass a qualified lambda arn (e.g. ...function:myfn:live) to lambda.permission's function field, aws quietly splits it into function=...function:myfn plus qualifier=live. on the next sst diff, pulumi notices the stored state doesn't line up with what you asked for, so it flags a change every single time — even though nothing really moved

the fix is to split the qualified arn before handing it to pulumi, feeding function and qualifier separately so the desired state lines up with what aws keeps