### PR TITLE
Run site build during `sst refresh` to fix missing build artifacts

### DIFF
--- a/platform/src/components/aws/helpers/site-builder.ts
+++ b/platform/src/components/aws/helpers/site-builder.ts
@@ -22,7 +22,7 @@ export function siteBuilder(
 
     // When running `sst diff`, `local.Command`'s `create` and `update` are not called.
     // So we will also run `local.runOutput` to get the output of the command.
-    if ($cli.command === "diff") {
+    if ($cli.command === "diff" || $cli.command === "refresh") {
       waitOn = local.runOutput(
         {
           command: args.create!,

--- a/platform/src/components/aws/helpers/site-builder.ts
+++ b/platform/src/components/aws/helpers/site-builder.ts
@@ -20,8 +20,8 @@ export function siteBuilder(
     const command = new local.Command(name, args, opts);
     waitOn = command.urn;
 
-    // When running `sst diff`, `local.Command`'s `create` and `update` are not called.
-    // So we will also run `local.runOutput` to get the output of the command.
+    // When running `sst diff` or `sst refresh`, `local.Command`'s `create` and `update` are not called.
+    // So we also run `local.runOutput` to get the output of the command.
     if ($cli.command === "diff" || $cli.command === "refresh") {
       waitOn = local.runOutput(
         {


### PR DESCRIPTION
closes #6502

during `sst refresh`, pulumi doesn't call `local.Command` create/update hooks, so the site build never runs and build artifacts like `.next/routes-manifest.json` are missing

this fix adds refresh to the same special case already used for diff, running the build inline via `local.runOutput` so the artifacts exist when the component reads them