### PR TITLE
Add `secrets` property to Docker image build config

### DIFF
--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -467,6 +467,29 @@ export interface FargateBaseArgs {
          */
         args?: Input<Record<string, Input<string>>>;
         /**
+         * Key-value pairs of [build secrets](https://docs.docker.com/build/building/secrets/) to pass to the Docker build.
+         *
+         * Unlike build args, secrets are not persisted in the final image. They are
+         * available in the Dockerfile via [`--mount=type=secret`](https://docs.docker.com/build/building/secrets/#secret-mounts).
+         *
+         * @example
+         * ```js
+         * {
+         *   secrets: {
+         *     GITLAB_TOKEN: process.env.CI_JOB_TOKEN,
+         *   }
+         * }
+         * ```
+         *
+         * Then in the Dockerfile:
+         * ```dockerfile
+         * RUN --mount=type=secret,id=GITLAB_TOKEN \
+         *   export GITLAB_TOKEN=$(cat /run/secrets/GITLAB_TOKEN) && \
+         *   npm install
+         * ```
+         */
+        secrets?: Input<Record<string, Input<string>>>;
+        /**
          * Tags to apply to the Docker image.
          * @example
          * ```js
@@ -1054,7 +1077,9 @@ export function createTaskDefinition(
               context: { location: contextPath },
               dockerfile: { location: dockerfilePath },
               buildArgs: containerImage.args,
-              secrets: linkEnvs,
+              secrets: all([linkEnvs, containerImage.secrets ?? {}]).apply(
+                ([link, user]) => ({ ...link, ...user }),
+              ),
               target: container.image.target,
               platforms: [container.image.platform],
               tags: [container.name, ...(container.image.tags ?? [])].map(

--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -1083,7 +1083,7 @@ export function createTaskDefinition(
               dockerfile: { location: dockerfilePath },
               buildArgs: containerImage.args,
               secrets: all([linkEnvs, containerImage.secrets ?? {}]).apply(
-                ([link, user]) => ({ ...link, ...user }),
+                ([link, secrets]) => ({ ...link, ...secrets }),
               ),
               target: container.image.target,
               platforms: [container.image.platform],

--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -476,7 +476,7 @@ export interface FargateBaseArgs {
          * ```js
          * {
          *   secrets: {
-         *     GITLAB_TOKEN: process.env.CI_JOB_TOKEN,
+         *     GITLAB_TOKEN: "my-secret-token",
          *   }
          * }
          * ```

--- a/platform/src/components/aws/fargate.ts
+++ b/platform/src/components/aws/fargate.ts
@@ -476,16 +476,21 @@ export interface FargateBaseArgs {
          * ```js
          * {
          *   secrets: {
-         *     GITLAB_TOKEN: "my-secret-token",
+         *     MY_TOKEN: "my-secret-token",
          *   }
          * }
          * ```
          *
-         * Then in the Dockerfile:
-         * ```dockerfile
-         * RUN --mount=type=secret,id=GITLAB_TOKEN \
-         *   export GITLAB_TOKEN=$(cat /run/secrets/GITLAB_TOKEN) && \
-         *   npm install
+         * Then in the Dockerfile, reference it as a file:
+         * ```dockerfile title="Dockerfile"
+         * RUN --mount=type=secret,id=MY_TOKEN \
+         *   cat /run/secrets/MY_TOKEN
+         * ```
+         *
+         * Or as an environment variable:
+         * ```dockerfile title="Dockerfile"
+         * RUN --mount=type=secret,id=MY_TOKEN,env=MY_TOKEN \
+         *   echo $MY_TOKEN
          * ```
          */
         secrets?: Input<Record<string, Input<string>>>;


### PR DESCRIPTION
closes #6507
closes https://github.com/anomalyco/sst/issues/5960

<details>

<summary>proof of it working</summary>

deployed the aws hono container example with secrets

<img width="1550" height="712" alt="CleanShot 2026-03-02 at 17 43 48@2x" src="https://github.com/user-attachments/assets/3b51e51b-c103-4196-8eb7-94ea06c1fa7a" />

<img width="1674" height="660" alt="CleanShot 2026-03-02 at 17 43 54@2x" src="https://github.com/user-attachments/assets/a0aa2f0c-0866-4291-bcb3-8b69aeb679b4" />

</details>