### PR TITLE
Start dev commands immediately using cached deployment state

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -273,9 +273,6 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
-						if evt.Old {
-							continue
-						}
 						for _, d := range evt.Devs {
 							if d.Command == "" {
 								continue
@@ -338,9 +335,6 @@ func CmdMosaic(c *cli.Cli) error {
 				case unknown := <-evts:
 					switch evt := unknown.(type) {
 					case *project.CompleteEvent:
-						if evt.Old {
-							continue
-						}
 						for _, d := range evt.Devs {
 							if d.Command == "" {
 								continue


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6518

## Summary

  - Restore the behavior where dev commands start immediately when running `sst dev`, using the cached deployment state from the previous run
  - This was a regression introduced in #6402 where the `evt.Old` check was added, causing dev commands to wait for the first deployment to complete (~2 minutes)

  ## Context

  Commit 2180e81d1 (#6402) fixed a race condition where the multiplexer could miss events by moving `bus.Subscribe` before `deployer.Start`. However, it also added an `if evt.Old { continue }` check that skips the cached
  `CompleteEvent`, which prevented dev commands from starting eagerly.

  The `evt.Old` check is unnecessary because `AddProcess` is already idempotent by key — if a process is already running, calling `AddProcess` again with the same key is a no-op. This means it's safe to start dev commands on
   the cached event and then receive the new event after deployment without any side effects.

  ## Before & After

  ### Before (depending on the number of resources, it can take up to two minutes for the dev command to start)

https://github.com/user-attachments/assets/5b9b666b-dc27-4dfb-aafa-09ba38ce8dab

  ### After (takes three seconds for the dev command to start)

https://github.com/user-attachments/assets/7c83fb80-eab0-4901-b38c-26e326fbc200

  ## Test plan (tested and verified)

  - Run `sst dev` in a project with dev commands configured
  - Verify dev commands appear in the sidebar and start running immediately, before deployment completes
  - Verify that after deployment completes, dev commands continue running without interruption