### PR TITLE
Use qualified Lambda ARN in API Gateway integrations when versioning is enabled

### DIFF
--- a/platform/src/components/aws/helpers/function-builder.ts
+++ b/platform/src/components/aws/helpers/function-builder.ts
@@ -32,6 +32,32 @@ export function functionBuilder(
   argsTransform?: Transform<FunctionArgs>,
   opts?: ComponentResourceOptions,
 ): FunctionBuilder {
+  function buildResult(fn: Function) {
+    const lambdaFn = fn.nodes.function;
+    return {
+      getFunction: () => fn,
+      arn: all([lambdaFn.publish, lambdaFn.qualifiedArn, lambdaFn.arn]).apply(
+        ([publish, qualifiedArn, arn]) => (publish ? qualifiedArn : arn),
+      ),
+      invokeArn: all([
+        lambdaFn.publish,
+        lambdaFn.qualifiedInvokeArn,
+        lambdaFn.invokeArn,
+      ]).apply(([publish, qualifiedInvokeArn, invokeArn]) =>
+        publish ? qualifiedInvokeArn : invokeArn,
+      ),
+      responseStreamingInvokeArn: all([
+        lambdaFn.publish,
+        lambdaFn.arn,
+        lambdaFn.qualifiedArn,
+        lambdaFn.responseStreamingInvokeArn,
+      ]).apply(([publish, arn, qualifiedArn, streamingArn]) => {
+        if (!publish) return streamingArn;
+        return streamingArn.replace(arn, qualifiedArn);
+      }),
+    };
+  }
+
   return output(definition).apply((definition) => {
     if (typeof definition === "string") {
       // Case 1: The definition is an ARN
@@ -62,13 +88,7 @@ export function functionBuilder(
           opts || {},
         ),
       );
-      return {
-        getFunction: () => fn,
-        arn: fn.arn,
-        invokeArn: fn.nodes.function.invokeArn,
-        responseStreamingInvokeArn:
-          fn.nodes.function.responseStreamingInvokeArn,
-      };
+      return buildResult(fn);
     }
 
     // Case 3: The definition is a FunctionArgs
@@ -104,13 +124,7 @@ export function functionBuilder(
           opts || {},
         ),
       );
-      return {
-        getFunction: () => fn,
-        arn: fn.arn,
-        invokeArn: fn.nodes.function.invokeArn,
-        responseStreamingInvokeArn:
-          fn.nodes.function.responseStreamingInvokeArn,
-      };
+      return buildResult(fn);
     }
     throw new Error(`Invalid function definition for the "${name}" Function`);
   });


### PR DESCRIPTION
closes #6390 by following aws guidelines:

<img width="1884" height="338" alt="CleanShot 2026-03-04 at 15 05 33@2x" src="https://github.com/user-attachments/assets/eb7aec82-e3d7-471e-af51-104de4776905" />