### PR TITLE
Add `ctrl-g` to scroll to bottom in multiplexer

### DIFF
--- a/cmd/sst/mosaic/multiplexer/draw.go
+++ b/cmd/sst/mosaic/multiplexer/draw.go
@@ -57,13 +57,13 @@ func (s *Multiplexer) draw() {
 	if s.focused {
 		hotkeys["ctrl-z"] = "sidebar"
 	}
-	if selected != nil && selected.isScrolling() && (s.focused || !selected.killable) {
-		hotkeys["enter"] = "reset"
-	}
 	if selected != nil && selected.vt.HasSelection() {
 		hotkeys["enter"] = "copy"
 	}
 	hotkeys["ctrl-u/d"] = "scroll"
+	if selected != nil && selected.isScrolling() {
+		hotkeys["ctrl-g"] = "bottom"
+	}
 	hotkeys["ctrl-l"] = "clear"
 	// sort hotkeys
 	keys := make([]string, 0, len(hotkeys))

--- a/cmd/sst/mosaic/multiplexer/multiplexer.go
+++ b/cmd/sst/mosaic/multiplexer/multiplexer.go
@@ -329,12 +329,6 @@ func (s *Multiplexer) Start() {
 						s.draw()
 						return
 					}
-					if selected != nil && selected.isScrolling() && (s.focused || !selected.killable) {
-						selected.scrollReset()
-						s.draw()
-						s.screen.Sync()
-						return
-					}
 					if !s.focused {
 						if selected.killable {
 							if selected.dead {
@@ -358,6 +352,13 @@ func (s *Multiplexer) Start() {
 				case tcell.KeyCtrlZ:
 					if s.focused {
 						s.blur()
+						return
+					}
+				case tcell.KeyCtrlG:
+					if selected != nil && selected.isScrolling() {
+						selected.scrollReset()
+						s.draw()
+						s.screen.Sync()
 						return
 					}
 				case tcell.KeyCtrlL:


### PR DESCRIPTION
this replaces the confusing `enter` to reset view

`ctrl+g` works in both focused and unfocused and matches vim keybindings

https://github.com/user-attachments/assets/03a63667-da6d-46f2-a34f-c99c2b372425

