### PR TITLE
Undo disallow sst dev on non-personal stages

### DIFF
--- a/cmd/sst/cli/cli.go
+++ b/cmd/sst/cli/cli.go
@@ -352,12 +352,3 @@ func guessStage() string {
 	}
 	return stage
 }
-
-// PersonalStage returns the stored or guessed personal stage for a project.
-func PersonalStage(cfgPath string) string {
-	stage := project.LoadPersonalStage(cfgPath)
-	if stage != "" {
-		return stage
-	}
-	return guessStage()
-}

--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -152,24 +152,6 @@ func CmdMosaic(c *cli.Cli) error {
 		return util.NewReadableError(nil, "The dev command for this process does not look right. Check your dev script in package.json to make sure it is simply starting your process and not running `sst dev`. More info here: https://sst.dev/docs/reference/cli/#dev")
 	}
 
-	cfgPath, err := c.Discover()
-	if err != nil {
-		return err
-	}
-
-	stage, err := c.Stage(cfgPath)
-	if err != nil {
-		return err
-	}
-
-	personalStage := cli.PersonalStage(cfgPath)
-	if personalStage == "" {
-		return util.NewReadableError(nil, fmt.Sprintf("Cannot run `sst dev` with stage %q. Your personal stage is not set.", stage))
-	}
-	if stage != personalStage {
-		return util.NewReadableError(nil, fmt.Sprintf("Cannot run `sst dev` with stage %q. It can only be run in your personal stage %q.", stage, personalStage))
-	}
-
 	p, err := c.InitProject()
 	if err != nil {
 		return err


### PR DESCRIPTION
revert https://github.com/anomalyco/sst/pull/6559 since there are use cases for it (see https://github.com/anomalyco/sst/pull/6559#issuecomment-4031321933)

the main goal was to prevent `sst dev --stage production` from accidentally breaking your state

undoing the change until i come up with a better solution