### PR TITLE
Set Node.js 24 as default runtime for everyone

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2538,7 +2538,7 @@ export class Function extends Component implements Link.Linkable {
                   ),
                 }),
             },
-            { parent, ignoreChanges: args.runtime ? [] : ["runtime"] },
+            { parent },
           );
           return new lambda.Function(
             transformed[0],


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6572 at the expense of automatically bumping the default node.js version for everyone who hasn't set the runtime manually as explained in https://github.com/anomalyco/sst/issues/6233#issuecomment-4025210932

should be fine since the old default's getting deprecated anyway

need to check with the team