### PR TITLE
Update migration notes for v3 by removing Auth

### DIFF
--- a/www/src/content/docs/docs/migrate-from-v2.mdx
+++ b/www/src/content/docs/docs/migrate-from-v2.mdx
@@ -32,7 +32,7 @@ While the goal with v3 is to support most of what's in v2, there are a few thing
 | Construct | GitHub Issue |
 |----------|-------|
 | `Script` | [#811](https://github.com/sst/sst/issues/4323) |
-| `Function` non-Node.js runtimes | [Python](https://github.com/sst/sst/issues/4669), [Container](https://github.com/sst/sst/issues/4462), [Custom](https://github.com/sst/sst/issues/4826) |
+| `Function` non-Node.js runtimes | [Container](https://github.com/sst/sst/issues/4462), [Custom](https://github.com/sst/sst/issues/4826) |
 
 Feel free to let us know via the linked GitHub issues if these are blockers for you. It'll help us prioritize this list.
 

--- a/www/src/content/docs/docs/migrate-from-v2.mdx
+++ b/www/src/content/docs/docs/migrate-from-v2.mdx
@@ -31,7 +31,6 @@ While the goal with v3 is to support most of what's in v2, there are a few thing
 
 | Construct | GitHub Issue |
 |----------|-------|
-| `Auth` | [In beta](https://github.com/sst/sst/issues/4893) |
 | `Script` | [#811](https://github.com/sst/sst/issues/4323) |
 | `Function` non-Node.js runtimes | [Python](https://github.com/sst/sst/issues/4669), [Container](https://github.com/sst/sst/issues/4462), [Custom](https://github.com/sst/sst/issues/4826) |
 


### PR DESCRIPTION
Removed the Auth construct from the migration table. Support for this was added a while back (see https://github.com/anomalyco/sst/issues/4893#issuecomment-2867859906)