### PR TITLE
Update VPC component to better accommodate end-user route and rule changes

### DIFF
--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1170,20 +1170,17 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PublicRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
+                routes: [],
               },
               { parent: self },
             ),
           );
 
-          new ec2.Route(
-            `${name}PublicRoute${i + 1}`,
-            {
-              routeTableId: routeTable.id,
-              destinationCidrBlock: "0.0.0.0/0",
-              gatewayId: internetGateway.id,
-            },
-            { parent: self, deleteBeforeReplace: true },
-          );
+          new ec2.Route(`${name}PublicRoute${i + 1}`, {
+            routeTableId: routeTable.id,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: internetGateway.id,
+          });
 
           new ec2.RouteTableAssociation(
             `${name}PublicRouteTableAssociation${i + 1}`,
@@ -1226,6 +1223,7 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PrivateRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
+                routes: [],
               },
               { parent: self },
             ),
@@ -1246,16 +1244,11 @@ export class Vpc extends Component implements Link.Linkable {
               }
 
               if (natInstances[i]) {
-                new ec2.Route(
-                  `${name}PrivateNetworkInterfaceRoute${i + 1}`,
-                  {
-                    routeTableId: routeTable.id,
-                    destinationCidrBlock: "0.0.0.0/0",
-                    networkInterfaceId:
-                      natInstances[i].primaryNetworkInterfaceId,
-                  },
-                  { parent: self },
-                );
+                new ec2.Route(`${name}PrivateNetworkInterfaceRoute${i + 1}`, {
+                  routeTableId: routeTable.id,
+                  destinationCidrBlock: "0.0.0.0/0",
+                  networkInterfaceId: natInstances[i].primaryNetworkInterfaceId,
+                });
               }
             },
           );

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1129,20 +1129,20 @@ export class Vpc extends Component implements Link.Linkable {
                 ),
               );
 
-            new ec2.EipAssociation(
-              `${name}NatInstanceEipAssociation${i + 1}`,
-              {
-                instanceId: instance.id,
-                allocationId: elasticIps[i]?.id ?? nat.ip![i],
-              },
-              {
-                parent: self,
-                aliases: [{ parent: rootStackResource }],
-              },
-            );
+              new ec2.EipAssociation(
+                `${name}NatInstanceEipAssociation${i + 1}`,
+                {
+                  instanceId: instance.id,
+                  allocationId: elasticIps[i]?.id ?? nat.ip![i],
+                },
+                {
+                  parent: self,
+                  aliases: [{ parent: rootStackResource }],
+                },
+              );
 
-            return instance;
-          }),
+              return instance;
+            }),
         );
       });
     }
@@ -1222,30 +1222,29 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PrivateRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
-                routes: all([natGateways, natInstances]).apply(
-                  ([natGateways, natInstances]) => [
-                    ...(natGateways[i]
-                      ? [
-                          {
-                            cidrBlock: "0.0.0.0/0",
-                            natGatewayId: natGateways[i].id,
-                          },
-                        ]
-                      : []),
-                    ...(natInstances[i]
-                      ? [
-                          {
-                            cidrBlock: "0.0.0.0/0",
-                            networkInterfaceId:
-                              natInstances[i].primaryNetworkInterfaceId,
-                          },
-                        ]
-                      : []),
-                  ],
-                ),
               },
               { parent: self },
             ),
+          );
+
+          all([natGateways, natInstances]).apply(
+            ([natGateways, natInstances]) => {
+              if (natGateways[i]) {
+                new ec2.Route(`${name}PrivateNatGatewayRoute${i + 1}`, {
+                  routeTableId: routeTable.id,
+                  destinationCidrBlock: "0.0.0.0/0",
+                  natGatewayId: natGateways[i].id,
+                });
+              }
+
+              if (natInstances[i]) {
+                new ec2.Route(`${name}PrivateNetworkInterfaceRoute${i + 1}`, {
+                  routeTableId: routeTable.id,
+                  destinationCidrBlock: "0.0.0.0/0",
+                  networkInterfaceId: natInstances[i].primaryNetworkInterfaceId,
+                });
+              }
+            },
           );
 
           new ec2.RouteTableAssociation(
@@ -1301,53 +1300,53 @@ export class Vpc extends Component implements Link.Linkable {
             ),
           );
 
-          const instanceProfile = output(
-            bastion.instanceProfileName,
-          ).apply((instanceProfileName) => {
-            if (instanceProfileName) {
-              if (instanceProfileName.startsWith("arn:")) {
-                throw new VisibleError(
-                  "Bastion instance profile must be a name, not an ARN.",
+          const instanceProfile = output(bastion.instanceProfileName).apply(
+            (instanceProfileName) => {
+              if (instanceProfileName) {
+                if (instanceProfileName.startsWith("arn:")) {
+                  throw new VisibleError(
+                    "Bastion instance profile must be a name, not an ARN.",
+                  );
+                }
+
+                return iam.InstanceProfile.get(
+                  `${name}BastionProfile`,
+                  instanceProfileName,
+                  {},
+                  { parent: self },
                 );
               }
 
-              return iam.InstanceProfile.get(
-                `${name}BastionProfile`,
-                instanceProfileName,
-                {},
+              const role = new iam.Role(
+                `${name}BastionRole`,
+                {
+                  assumeRolePolicy: iam.getPolicyDocumentOutput({
+                    statements: [
+                      {
+                        actions: ["sts:AssumeRole"],
+                        principals: [
+                          {
+                            type: "Service",
+                            identifiers: ["ec2.amazonaws.com"],
+                          },
+                        ],
+                      },
+                    ],
+                  }).json,
+                  managedPolicyArns: [
+                    interpolate`arn:${partition}:iam::aws:policy/AmazonSSMManagedInstanceCore`,
+                  ],
+                },
                 { parent: self },
               );
-            }
 
-            const role = new iam.Role(
-              `${name}BastionRole`,
-              {
-                assumeRolePolicy: iam.getPolicyDocumentOutput({
-                  statements: [
-                    {
-                      actions: ["sts:AssumeRole"],
-                      principals: [
-                        {
-                          type: "Service",
-                          identifiers: ["ec2.amazonaws.com"],
-                        },
-                      ],
-                    },
-                  ],
-                }).json,
-                managedPolicyArns: [
-                  interpolate`arn:${partition}:iam::aws:policy/AmazonSSMManagedInstanceCore`,
-                ],
-              },
-              { parent: self },
-            );
-
-            return new iam.InstanceProfile(
-              `${name}BastionProfile`,
-              { role: role.name },
-              { parent: self },
-            );
-          });
+              return new iam.InstanceProfile(
+                `${name}BastionProfile`,
+                { role: role.name },
+                { parent: self },
+              );
+            },
+          );
 
           const ami = ec2.getAmiOutput(
             {
@@ -1376,9 +1375,7 @@ export class Vpc extends Component implements Link.Linkable {
                 ami: ami.id,
                 subnetId: publicSubnets.apply((v) => v[0].id),
                 vpcSecurityGroupIds: [sg.id],
-                iamInstanceProfile: instanceProfile.apply(
-                  (ip) => ip.name,
-                ),
+                iamInstanceProfile: instanceProfile.apply((ip) => ip.name),
                 keyName: keyPair?.keyName,
                 tags: {
                   "sst:is-bastion": "true",

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -15,7 +15,6 @@ import {
   route53,
   servicediscovery,
   ssm,
-  vpc as _vpc,
 } from "@pulumi/aws";
 import { Vpc as VpcV1 } from "./vpc-v1";
 import { Link } from "../link";
@@ -936,33 +935,34 @@ export class Vpc extends Component implements Link.Linkable {
     }
 
     function createSecurityGroup() {
-      const defaultSecurityGroup = new ec2.DefaultSecurityGroup(
+      return new ec2.DefaultSecurityGroup(
         ...transform(
           args.transform?.securityGroup,
           `${name}SecurityGroup`,
           {
             description: "Managed by SST",
             vpcId: vpc.id,
-            egress: [],
-            ingress: [],
+            egress: [
+              {
+                fromPort: 0,
+                toPort: 0,
+                protocol: "-1",
+                cidrBlocks: ["0.0.0.0/0"],
+              },
+            ],
+            ingress: [
+              {
+                fromPort: 0,
+                toPort: 0,
+                protocol: "-1",
+                // Restricts inbound traffic to only within the VPC
+                cidrBlocks: [vpc.cidrBlock],
+              },
+            ],
           },
           { parent: self },
         ),
       );
-
-      new _vpc.SecurityGroupEgressRule(`${name}SecurityGroupEgressRule`, {
-        securityGroupId: defaultSecurityGroup.id,
-        ipProtocol: "-1",
-        cidrIpv4: "0.0.0.0/0",
-      });
-
-      new _vpc.SecurityGroupIngressRule(`${name}SecurityGroupIngressRule`, {
-        securityGroupId: defaultSecurityGroup.id,
-        ipProtocol: "-1",
-        cidrIpv4: vpc.cidrBlock,
-      });
-
-      return defaultSecurityGroup;
     }
 
     function createElasticIps() {

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1182,7 +1182,7 @@ export class Vpc extends Component implements Link.Linkable {
               destinationCidrBlock: "0.0.0.0/0",
               gatewayId: internetGateway.id,
             },
-            { parent: self },
+            { parent: self, deleteBeforeReplace: true },
           );
 
           new ec2.RouteTableAssociation(

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1175,11 +1175,15 @@ export class Vpc extends Component implements Link.Linkable {
             ),
           );
 
-          new ec2.Route(`${name}PublicRoute${i + 1}`, {
-            routeTableId: routeTable.id,
-            destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: internetGateway.id,
-          });
+          new ec2.Route(
+            `${name}PublicRoute${i + 1}`,
+            {
+              routeTableId: routeTable.id,
+              destinationCidrBlock: "0.0.0.0/0",
+              gatewayId: internetGateway.id,
+            },
+            { parent: self },
+          );
 
           new ec2.RouteTableAssociation(
             `${name}PublicRouteTableAssociation${i + 1}`,
@@ -1230,19 +1234,28 @@ export class Vpc extends Component implements Link.Linkable {
           all([natGateways, natInstances]).apply(
             ([natGateways, natInstances]) => {
               if (natGateways[i]) {
-                new ec2.Route(`${name}PrivateNatGatewayRoute${i + 1}`, {
-                  routeTableId: routeTable.id,
-                  destinationCidrBlock: "0.0.0.0/0",
-                  natGatewayId: natGateways[i].id,
-                });
+                new ec2.Route(
+                  `${name}PrivateNatGatewayRoute${i + 1}`,
+                  {
+                    routeTableId: routeTable.id,
+                    destinationCidrBlock: "0.0.0.0/0",
+                    natGatewayId: natGateways[i].id,
+                  },
+                  { parent: self },
+                );
               }
 
               if (natInstances[i]) {
-                new ec2.Route(`${name}PrivateNetworkInterfaceRoute${i + 1}`, {
-                  routeTableId: routeTable.id,
-                  destinationCidrBlock: "0.0.0.0/0",
-                  networkInterfaceId: natInstances[i].primaryNetworkInterfaceId,
-                });
+                new ec2.Route(
+                  `${name}PrivateNetworkInterfaceRoute${i + 1}`,
+                  {
+                    routeTableId: routeTable.id,
+                    destinationCidrBlock: "0.0.0.0/0",
+                    networkInterfaceId:
+                      natInstances[i].primaryNetworkInterfaceId,
+                  },
+                  { parent: self },
+                );
               }
             },
           );

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1232,15 +1232,11 @@ export class Vpc extends Component implements Link.Linkable {
           all([natGateways, natInstances]).apply(
             ([natGateways, natInstances]) => {
               if (natGateways[i]) {
-                new ec2.Route(
-                  `${name}PrivateNatGatewayRoute${i + 1}`,
-                  {
-                    routeTableId: routeTable.id,
-                    destinationCidrBlock: "0.0.0.0/0",
-                    natGatewayId: natGateways[i].id,
-                  },
-                  { parent: self },
-                );
+                new ec2.Route(`${name}PrivateNatGatewayRoute${i + 1}`, {
+                  routeTableId: routeTable.id,
+                  destinationCidrBlock: "0.0.0.0/0",
+                  natGatewayId: natGateways[i].id,
+                });
               }
 
               if (natInstances[i]) {

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -15,6 +15,7 @@ import {
   route53,
   servicediscovery,
   ssm,
+  vpc as _vpc,
 } from "@pulumi/aws";
 import { Vpc as VpcV1 } from "./vpc-v1";
 import { Link } from "../link";
@@ -935,34 +936,35 @@ export class Vpc extends Component implements Link.Linkable {
     }
 
     function createSecurityGroup() {
-      return new ec2.DefaultSecurityGroup(
+      const defaultSecurityGroup = new ec2.DefaultSecurityGroup(
         ...transform(
           args.transform?.securityGroup,
           `${name}SecurityGroup`,
           {
             description: "Managed by SST",
             vpcId: vpc.id,
-            egress: [
-              {
-                fromPort: 0,
-                toPort: 0,
-                protocol: "-1",
-                cidrBlocks: ["0.0.0.0/0"],
-              },
-            ],
-            ingress: [
-              {
-                fromPort: 0,
-                toPort: 0,
-                protocol: "-1",
-                // Restricts inbound traffic to only within the VPC
-                cidrBlocks: [vpc.cidrBlock],
-              },
-            ],
+            egress: [],
+            ingress: [],
           },
           { parent: self },
         ),
       );
+
+      new _vpc.SecurityGroupEgressRule(`${name}SecurityGroupEgressRule`, {
+        securityGroupId: defaultSecurityGroup.id,
+        fromPort: 0,
+        toPort: 0,
+        ipProtocol: "-1",
+        cidrIpv4: "0.0.0.0/0",
+      });
+
+      new _vpc.SecurityGroupIngressRule(`${name}SecurityGroupIngressRule`, {
+        securityGroupId: defaultSecurityGroup.id,
+        ipProtocol: "-1",
+        cidrIpv4: vpc.cidrBlock,
+      });
+
+      return defaultSecurityGroup;
     }
 
     function createElasticIps() {

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -952,8 +952,6 @@ export class Vpc extends Component implements Link.Linkable {
 
       new _vpc.SecurityGroupEgressRule(`${name}SecurityGroupEgressRule`, {
         securityGroupId: defaultSecurityGroup.id,
-        fromPort: 0,
-        toPort: 0,
         ipProtocol: "-1",
         cidrIpv4: "0.0.0.0/0",
       });

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1170,7 +1170,6 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PublicRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
-                routes: [],
               },
               { parent: self },
             ),
@@ -1223,7 +1222,6 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PrivateRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
-                routes: [],
               },
               { parent: self },
             ),

--- a/platform/src/components/aws/vpc.ts
+++ b/platform/src/components/aws/vpc.ts
@@ -1170,16 +1170,16 @@ export class Vpc extends Component implements Link.Linkable {
               `${name}PublicRouteTable${i + 1}`,
               {
                 vpcId: vpc.id,
-                routes: [
-                  {
-                    cidrBlock: "0.0.0.0/0",
-                    gatewayId: internetGateway.id,
-                  },
-                ],
               },
               { parent: self },
             ),
           );
+
+          new ec2.Route(`${name}PublicRoute${i + 1}`, {
+            routeTableId: routeTable.id,
+            destinationCidrBlock: "0.0.0.0/0",
+            gatewayId: internetGateway.id,
+          });
 
           new ec2.RouteTableAssociation(
             `${name}PublicRouteTableAssociation${i + 1}`,


### PR DESCRIPTION
Resolves #6597 by creating routes using the `ec2.Route` construct rather than inline routes for the `VPC` component's public and private subnet creation.