### PR TITLE
Fix dangling promises in `sst diff` with `Service` component

### DIFF
--- a/platform/src/components/aws/helpers/container-builder.ts
+++ b/platform/src/components/aws/helpers/container-builder.ts
@@ -1,4 +1,4 @@
-import { all, output, ComponentResourceOptions } from "@pulumi/pulumi";
+import { output, ComponentResourceOptions } from "@pulumi/pulumi";
 import { Semaphore } from "../../../util/semaphore";
 import { Image, ImageArgs } from "@pulumi/docker-build";
 
@@ -11,9 +11,10 @@ export function imageBuilder(
   args: ImageArgs,
   opts?: ComponentResourceOptions,
 ) {
-  const ready = output(limiter.acquire(name));
-  // Wait for the all args values to be resolved before acquiring the semaphore
-  return all([args, ready]).apply(([args]) => {
+  // Wait for all arg values to be resolved before acquiring the semaphore.
+  return output(args).apply(async (args) => {
+    await limiter.acquire(name);
+
     const image = new Image(
       name,
       {


### PR DESCRIPTION
This PR fixes #6605 by updating the `container-builder.ts` code to wait for its outputs to resolve before acquiring the semaphore and building the container image.

This issue was causing `sst diff` to fail resulting in a confusing Pulumi dangling promises message.