### PR TITLE
Disable VCS metadata in Go build

### DIFF
--- a/platform/scripts/build
+++ b/platform/scripts/build
@@ -9,7 +9,7 @@ bun build ./functions/cf-static-site-router-worker/index.ts --target=node --outd
 bun build ./functions/cf-ssr-site-router-worker/index.ts --target=node --outdir ./dist/cf-ssr-site-router-worker/
 bun build ./functions/nodejs-runtime/index.ts --target=node --outdir ./dist/nodejs-runtime/
 bun build ./functions/nodejs-runtime/loop.ts --target=node --outdir ./dist/nodejs-runtime/
-GOARCH=amd64 GOOS=linux go build -trimpath -mod=readonly -ldflags="-buildid=" -o ./dist/bridge/bootstrap ./functions/bridge 
+GOARCH=amd64 GOOS=linux go build -trimpath -buildvcs=false -mod=readonly -ldflags="-buildid=" -o ./dist/bridge/bootstrap ./functions/bridge
 node ./scripts/build.mjs
 
 mkdir -p ./dist/python-runtime/


### PR DESCRIPTION
Add -buildvcs=false to the go build invocation in platform/scripts/build for the bridge binary. This prevents embedding VCS metadata into the output,  improving reproducibility of the built artifact.

## Problem
This is another issue related to sst dev.
At the moment, the hash of the build bridge bootstrap binary changes with every commit. As a result, all Lambda functions are treated as changed after every SST release.
https://github.com/anomalyco/sst/pull/6465 already reduced this to a single upload, but the S3 key for every Lambda is still changing, which can still slow deployments down.

## Changes 
- remove vcs information from go build

## Validation
I tested this by switching between commits, with this change the hash stays stable, without it changed every time. 

@vimtor this is the other problem i mentioned in my #6465. 