### PR TITLE
feat: Default Bucket Encryption

### DIFF
--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -506,7 +506,7 @@ export interface BucketArgs {
    * @example
    * ```js
    * {
-   *   defaultServerSideEncryption: true
+   *   encryption: true
    * }
    * ```
    */
@@ -900,7 +900,7 @@ export class Bucket extends Component implements Link.Linkable {
 
     const bucket = createBucket();
     createVersioning();
-    createDefaultServerSideEncryption();
+    createEncryption();
     const publicAccessBlock = createPublicAccess();
     const policy = createBucketPolicy();
     createCorsRule();
@@ -976,7 +976,7 @@ export class Bucket extends Component implements Link.Linkable {
       });
     }
 
-    function createDefaultServerSideEncryption() {
+    function createEncryption() {
       if (!args.encryption) return;
 
       return new s3.BucketServerSideEncryptionConfiguration(

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -510,7 +510,7 @@ export interface BucketArgs {
    * }
    * ```
    */
-  encryption?: Input<boolean>;
+  encryption?: boolean;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -498,6 +498,20 @@ export interface BucketArgs {
    */
   versioning?: Input<boolean>;
   /**
+   * Enable default server-side encryption for objects uploaded to the bucket.
+   *
+   * This uses S3-managed keys (`AES256`).
+   *
+   * @default `false`
+   * @example
+   * ```js
+   * {
+   *   defaultServerSideEncryption: true
+   * }
+   * ```
+   */
+  defaultServerSideEncryption?: Input<boolean>;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
@@ -518,6 +532,10 @@ export interface BucketArgs {
      * Transform the S3 Bucket versioning resource.
      */
     versioning?: Transform<s3.BucketVersioningArgs>;
+    /**
+     * Transform the S3 Bucket server-side encryption configuration resource.
+     */
+    encryption?: Transform<s3.BucketServerSideEncryptionConfigurationArgs>;
     /**
      * Transform the S3 Bucket lifecycle resource.
      * */
@@ -882,6 +900,7 @@ export class Bucket extends Component implements Link.Linkable {
 
     const bucket = createBucket();
     createVersioning();
+    createDefaultServerSideEncryption();
     const publicAccessBlock = createPublicAccess();
     const policy = createBucketPolicy();
     createCorsRule();
@@ -950,6 +969,30 @@ export class Bucket extends Component implements Link.Linkable {
               versioningConfiguration: {
                 status: "Enabled",
               },
+            },
+            { parent },
+          ),
+        );
+      });
+    }
+
+    function createDefaultServerSideEncryption() {
+      return output(args.defaultServerSideEncryption).apply((enabled) => {
+        if (!enabled) return;
+
+        return new s3.BucketServerSideEncryptionConfiguration(
+          ...transform(
+            args.transform?.encryption,
+            `${name}Encryption`,
+            {
+              bucket: bucket.bucket,
+              rules: [
+                {
+                  applyServerSideEncryptionByDefault: {
+                    sseAlgorithm: "AES256",
+                  },
+                },
+              ],
             },
             { parent },
           ),

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -510,7 +510,7 @@ export interface BucketArgs {
    * }
    * ```
    */
-  defaultServerSideEncryption?: Input<boolean>;
+  encryption?: Input<boolean>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
@@ -977,27 +977,25 @@ export class Bucket extends Component implements Link.Linkable {
     }
 
     function createDefaultServerSideEncryption() {
-      return output(args.defaultServerSideEncryption).apply((enabled) => {
-        if (!enabled) return;
+      if (!args.encryption) return;
 
-        return new s3.BucketServerSideEncryptionConfiguration(
-          ...transform(
-            args.transform?.encryption,
-            `${name}Encryption`,
-            {
-              bucket: bucket.bucket,
-              rules: [
-                {
-                  applyServerSideEncryptionByDefault: {
-                    sseAlgorithm: "AES256",
-                  },
+      return new s3.BucketServerSideEncryptionConfiguration(
+        ...transform(
+          args.transform?.encryption,
+          `${name}Encryption`,
+          {
+            bucket: bucket.bucket,
+            rules: [
+              {
+                applyServerSideEncryptionByDefault: {
+                  sseAlgorithm: "AES256",
                 },
-              ],
-            },
-            { parent },
-          ),
-        );
-      });
+              },
+            ],
+          },
+          { parent },
+        ),
+      );
     }
 
     function createLifecycle() {

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -166,6 +166,7 @@ export class Component extends ComponentResource {
               "aws:s3/bucketObjectv2:BucketObjectv2",
               "aws:s3/bucketPolicy:BucketPolicy",
               "aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock",
+              "aws:s3/bucketServerSideEncryptionConfiguration:BucketServerSideEncryptionConfiguration",
               "aws:s3/bucketVersioningV2:BucketVersioningV2",
               "aws:s3/bucketLifecycleConfigurationV2:BucketLifecycleConfigurationV2",
               "aws:s3/bucketLifecycleConfiguration:BucketLifecycleConfiguration",


### PR DESCRIPTION
Added a flag to enable the default server side encryption for the `Bucket` component.

usage: 
```ts
export const encBucket = new sst.aws.Bucket(`encryptionTest`, {
  defaultServerSideEncryption: true,
});
```

Tested working:
<img width="2838" height="852" alt="CleanShot 2026-03-20 at 10 44 33@2x" src="https://github.com/user-attachments/assets/a54e8fce-dddb-4908-8d14-4ddef2308448" />

