### PR TITLE
Reject `provider: true` config to prevent breaking major upgrades

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -206,8 +206,10 @@ console.log("~j" + JSON.stringify(await mod.app({
 			}
 
 			for name, args := range proj.app.Providers {
-				if argsBool, ok := args.(bool); ok && argsBool {
-					proj.app.Providers[name] = make(map[string]interface{})
+				if _, ok := args.(bool); ok {
+					return nil, util.NewReadableError(nil,
+						fmt.Sprintf(`Setting providers.%s to true is deprecated. Specify the version explicitly instead.`, name),
+					)
 				}
 
 				if argsString, ok := args.(string); ok {


### PR DESCRIPTION
using `true` was brittle. let's just reject it so we can release major updates for popular providers like planetscale #6625 