### PR TITLE
Replace deprecated module syntax with namespace

### DIFF
--- a/examples/aws-auth-react/packages/core/src/example/index.ts
+++ b/examples/aws-auth-react/packages/core/src/example/index.ts
@@ -1,4 +1,4 @@
-export module Example {
+export namespace Example {
   export function hello() {
     return "Hello, world!";
   }

--- a/examples/aws-monorepo/packages/core/src/example/index.ts
+++ b/examples/aws-monorepo/packages/core/src/example/index.ts
@@ -1,4 +1,4 @@
-export module Example {
+export namespace Example {
   export function hello() {
     return "Hello, world!";
   }

--- a/platform/src/components/hint.ts
+++ b/platform/src/components/hint.ts
@@ -1,6 +1,6 @@
 import { Input, all } from "@pulumi/pulumi";
 
-export module Hint {
+export namespace Hint {
   let hints = {} as Record<string, Input<string>>;
   export function reset() {
     hints = {};

--- a/platform/src/components/link.ts
+++ b/platform/src/components/link.ts
@@ -9,7 +9,7 @@ import {
 import { VisibleError } from "./error.js";
 import { Linkable } from "./linkable.js";
 
-export module Link {
+export namespace Link {
   export interface Definition<
     Properties extends Record<string, any> = Record<string, any>,
   > {

--- a/platform/src/components/rpc/rpc.ts
+++ b/platform/src/components/rpc/rpc.ts
@@ -1,7 +1,7 @@
 import { dynamic } from "@pulumi/pulumi";
 import http from "http";
 
-export module rpc {
+export namespace rpc {
   export class MethodNotFoundError extends Error {
     constructor(public method: string) {
       super(`Method "${method}" not found`);

--- a/sdk/js/src/auth/index.ts
+++ b/sdk/js/src/auth/index.ts
@@ -5,7 +5,7 @@ export { Issuer } from "openid-client";
 import { AuthHandler } from "./handler.js";
 import { createSessionBuilder } from "./session.js";
 
-export module auth {
+export namespace auth {
   export type Issuer = import("openid-client").Issuer;
   export const authorizer = AuthHandler;
   export const sessions = createSessionBuilder;

--- a/sdk/js/src/aws/auth.ts
+++ b/sdk/js/src/aws/auth.ts
@@ -4,7 +4,7 @@ import { AuthHandler } from "../auth/handler.js";
 import { SessionBuilder, createSessionBuilder } from "../auth/session.js";
 import { handle, streamHandle } from "hono/aws-lambda";
 
-export module auth {
+export namespace auth {
   export type Issuer = import("openid-client").Issuer;
   export function authorizer<
     Providers extends Record<string, Adapter<any>>,
@@ -12,7 +12,7 @@ export module auth {
   >(...args: Parameters<typeof AuthHandler<Providers, Sessions>>) {
     const hono = AuthHandler(...args);
     return (
-      args[0].stream ? streamHandle(hono) : handle(hono) 
+      args[0].stream ? streamHandle(hono) : handle(hono)
     ) as Handler<any, any>;
   }
   export const sessions = createSessionBuilder;

--- a/sdk/js/src/aws/bus.ts
+++ b/sdk/js/src/aws/bus.ts
@@ -3,7 +3,7 @@ import { Resource } from "../resource.js";
 import { event } from "../event/index.js";
 import { EventBridgeEvent, EventBridgeHandler, Context } from "aws-lambda";
 
-export module bus {
+export namespace bus {
   export type Name = Extract<typeof Resource, { type: "sst.aws.Bus" }>["name"];
 
   function url(region?: string, options?: AwsOptions) {

--- a/sdk/js/src/aws/realtime.ts
+++ b/sdk/js/src/aws/realtime.ts
@@ -8,7 +8,7 @@ import { IoTCustomAuthorizerHandler, PolicyDocument } from "aws-lambda";
  * import { realtime } from "sst/aws/realtime";
  * ```
  */
-export module realtime {
+export namespace realtime {
   export interface AuthResult {
     /**
      * The principal ID of the authorized client. This could be a user ID, username, or

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -11,7 +11,7 @@ import { AwsOptions, client } from "./client.js";
  * [`RunTask`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html) to
  * run a task.
  */
-export module task {
+export namespace task {
   function url(region?: string, options?: AwsOptions) {
     if (options?.region) region = options.region;
     return `https://ecs.${region}.amazonaws.com/`;

--- a/sdk/js/src/event/index.ts
+++ b/sdk/js/src/event/index.ts
@@ -1,6 +1,6 @@
 import { Prettify } from "../auth/handler.js";
 
-export module event {
+export namespace event {
   export type Definition = {
     type: string;
     $input: any;

--- a/www/src/content/docs/docs/set-up-a-monorepo.mdx
+++ b/www/src/content/docs/docs/set-up-a-monorepo.mdx
@@ -76,7 +76,7 @@ The `packages/` directory  includes the following:
   defined as modules. For example, we have an `Example` module.
 
   ```ts title="packages/core/src/example/index.ts"
-  export module Example {
+  export namespace Example {
     export function hello() {
       return "Hello, world!";
     }


### PR DESCRIPTION
[Deprecated: legacy module Syntax for namespaces](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#deprecated:-legacy-module-syntax-for-namespaces)