### PR TITLE
Expose route options in Function's `url.router` config

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2805,24 +2805,39 @@ export class Function extends Component implements Link.Linkable {
           {
             store: url.route.routerKvStoreArn,
             namespace: routeNamespace,
-            entries: all([fnUrl.functionUrl, isOac]).apply(
-              ([fnUrlValue, oac]) => ({
-                metadata: JSON.stringify({
-                  host: new URL(fnUrlValue).host,
-                  ...(oac
-                    ? {
-                        origin: {
-                          originAccessControlConfig: {
-                            enabled: true,
-                            signingBehavior: "always",
-                            signingProtocol: "sigv4",
-                            originType: "lambda",
-                          },
-                        },
-                      }
-                    : {}),
-                }),
-              }),
+            entries: all([fnUrl.functionUrl, isOac, url.route]).apply(
+              ([fnUrlValue, oac, route]) => {
+                const timeouts = [
+                  "connectionTimeout" as const,
+                  "readTimeout" as const,
+                  "keepAliveTimeout" as const,
+                ].flatMap((k) => {
+                  const value = route[k];
+                  return value ? [[k, toSeconds(value)]] : [];
+                });
+                return {
+                  metadata: JSON.stringify({
+                    host: new URL(fnUrlValue).host,
+                    rewrite: route.rewrite,
+                    origin: {
+                      ...(oac
+                        ? {
+                            originAccessControlConfig: {
+                              enabled: true,
+                              signingBehavior: "always",
+                              signingProtocol: "sigv4",
+                              originType: "lambda",
+                            },
+                          }
+                        : {}),
+                      connectionAttempts: route.connectionAttempts,
+                      ...(timeouts.length
+                        ? { timeouts: Object.fromEntries(timeouts) }
+                        : {}),
+                    },
+                  }),
+                };
+              },
             ),
             purge: false,
           },

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -3118,6 +3118,98 @@ export type RouterRouteArgs = {
    * ```
    */
   path?: Input<string>;
+  /**
+   * Rewrite the request path.
+   *
+   * @example
+   *
+   * If the route path is `/api/*` and a request comes in for `/api/users/profile`,
+   * the request path the destination sees is `/api/users/profile`.
+   *
+   * If you want to serve the route from the root, you can rewrite the request
+   * path to `/users/profile`.
+   *
+   * ```js
+   * router: {
+   *   instance: router,
+   *   path: "/api",
+   *   rewrite: {
+   *     regex: "^/api/(.*)$",
+   *     to: "/$1"
+   *   }
+   * }
+   * ```
+   */
+  rewrite?: Input<{
+    /**
+     * The regex to match the request path.
+     */
+    regex: Input<string>;
+    /**
+     * The replacement for the matched path.
+     */
+    to: Input<string>;
+  }>;
+  /**
+   * The number of seconds that CloudFront waits for a response after routing a
+   * request to the destination. Must be between 1 and 60 seconds.
+   *
+   * When compared to the `connectionTimeout`, this is the total time for the
+   * request.
+   *
+   * @default `"20 seconds"`
+   * @example
+   * ```js
+   * router: {
+   *   instance: router,
+   *   readTimeout: "60 seconds"
+   * }
+   * ```
+   */
+  readTimeout?: Input<DurationSeconds>;
+  /**
+   * The number of seconds that CloudFront should try to maintain the connection
+   * to the destination after receiving the last packet of the response. Must be
+   * between 1 and 60 seconds.
+   *
+   * @default `"5 seconds"`
+   * @example
+   * ```js
+   * router: {
+   *   instance: router,
+   *   keepAliveTimeout: "10 seconds"
+   * }
+   * ```
+   */
+  keepAliveTimeout?: Input<DurationSeconds>;
+  /**
+   * The number of seconds that CloudFront waits before timing out and closing the
+   * connection to the origin. Must be between 1 and 10 seconds.
+   *
+   * @default `"10 seconds"`
+   * @example
+   * ```js
+   * router: {
+   *   instance: router,
+   *   connectionTimeout: "3 seconds"
+   * }
+   * ```
+   */
+  connectionTimeout?: Input<DurationSeconds>;
+  /**
+   * The number of times that CloudFront attempts to connect to the origin. Must be
+   * between 1 and 3.
+   *
+   * @default `3`
+   * @example
+   * ```js
+   * router: {
+   *   instance: router,
+   *   connectionAttempts: 1
+   * }
+   * ```
+   */
+  connectionAttempts?: Input<number>;
 };
 
 export type RouterRouteArgsDeprecated = {
@@ -3162,6 +3254,11 @@ export function normalizeRouteArgs(
         routerKvStoreArn: v.instance._kvStoreArn!,
         routerProtection: v.instance._protection,
         routerDistributionArn: v.instance._distributionArn,
+        rewrite: v.rewrite,
+        readTimeout: v.readTimeout,
+        keepAliveTimeout: v.keepAliveTimeout,
+        connectionTimeout: v.connectionTimeout,
+        connectionAttempts: v.connectionAttempts,
       };
     });
   });


### PR DESCRIPTION
When using `url.router` on `sst.aws.Function`, the component writes CloudFront KV route metadata directly instead of calling `Router.route()`. This meant none of the CloudFront origin options (`readTimeout`, `keepAliveTimeout`, `connectionTimeout`, `connectionAttempts`, `rewrite`) were available through the inline `url.router` interface, forcing users to call `router.route()` separately, which in turn caused CORS settings on the Function URL to be ignored.

This adds these additional options to `RouterRouteArgs` s.t. they are then written into the KV metadata in the same structure that `RouterUrlRoute` produces.

Closes #5892.