### PR TITLE
Fix TanStackStart Lambda bundle path by resolving server output to an absolute path

### DIFF
--- a/platform/src/components/aws/tan-stack-start.ts
+++ b/platform/src/components/aws/tan-stack-start.ts
@@ -218,7 +218,7 @@ export interface TanStackStartArgs extends SsrSiteArgs {
    *   }
    * }
    * ```
-   * 
+   *
    * Finally, to serve your TanStack Start app **from a combined pattern** like
    * `dev.example.com/docs`, you'll need to configure the domain in your `Router` to
    * match the subdomain, and set the `domain` and the `path`.
@@ -427,12 +427,12 @@ export class TanStackStart extends SsrSite {
         );
       }
 
-      const serverOutputPath = path.join(outputPath, ".output", "server");
+      const serverOutputPath = path.resolve(outputPath, ".output", "server");
 
       // If basepath is configured, nitro.mjs will have a line that looks like this:
       // return createRouter$2({ routeTree: Nr, defaultPreload: "intent", defaultErrorComponent: ce, defaultNotFoundComponent: () => jsx(de, {}), scrollRestoration: true, basepath: "/tan" });
       let basepath;
-      
+
       try {
         const serverNitroChunk = fs.readFileSync(
           path.join(serverOutputPath, "chunks", "_", "server.mjs"),


### PR DESCRIPTION
### Description

`TanStackStart` currently passes the Lambda server bundle path as a relative path. In some deploy flows, this causes downstream packaging/runtime steps to resolve generated files like `resource.enc` from the wrong working directory.

This change resolves the server bundle path to an absolute path before handing it to the function bundle configuration.

### Why this matters

- fixes deploy failures like `open web/.output/server/resource.enc: no such file or directory`
- makes `TanStackStart` more reliable when the app lives in a monorepo subdirectory
- avoids relying on process working directory during packaging

### Context

- app deployed with `sst.aws.TanStackStart`
- TanStack Start app located in a workspace subdirectory such as `web/`
- Nitro output was generated successfully
- failure occurred during SST packaging/deploy, not during the Nitro build
