### PR TITLE
Add backups support for DSQL 

### DIFF
--- a/examples/aws-dsql-multiregion/sst.config.ts
+++ b/examples/aws-dsql-multiregion/sst.config.ts
@@ -56,6 +56,7 @@ export default $config({
   },
   async run() {
     const cluster = new sst.aws.Dsql("MultiRegion", {
+      backup: true,
       regions: {
         witness: "us-west-2",
         peer: "us-east-2",
@@ -69,8 +70,11 @@ export default $config({
     });
 
     return {
+      url: fn.url,
+      arn: cluster.arn,
       endpoint: cluster.endpoint,
       region: cluster.region,
+      peerArn: cluster.peer.arn,
       peerEndpoint: cluster.peer.endpoint,
       peerRegion: cluster.peer.region,
     };

--- a/examples/aws-dsql-multiregion/sst.config.ts
+++ b/examples/aws-dsql-multiregion/sst.config.ts
@@ -46,33 +46,37 @@
 export default $config({
   app(input) {
     return {
-      name: "aws-dsql-multiregion",
-      removal: input?.stage === "production" ? "retain" : "remove",
-      home: "aws",
+      name: 'aws-dsql-multiregion',
+      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      home: 'aws',
       providers: {
-        aws: { region: "us-east-1" },
+        aws: { region: 'us-east-1' },
       },
     };
   },
   async run() {
-    const cluster = new sst.aws.Dsql("MultiRegion", {
+    const cluster = new sst.aws.Dsql('MultiRegion', {
       regions: {
-        witness: "us-west-2",
-        peer: "us-east-2",
+        witness: 'us-west-2',
+        peer: { region: 'us-east-2' },
+      },
+      backup: {
+        retention: 45,
+        timezone: 'Australia/Melbourne',
       },
     });
 
-    const fn = new sst.aws.Function("MyFunction", {
-      handler: "lambda.handler",
+    const fn = new sst.aws.Function('MyFunction', {
+      handler: 'lambda.handler',
       link: [cluster],
       url: true,
     });
 
     return {
-      endpoint: cluster.endpoint,
+      endpoint: cluster.publicEndpoint,
       region: cluster.region,
-      peerEndpoint: cluster.peer.endpoint,
-      peerRegion: cluster.peer.region,
+      peerEndpoint: cluster.peerPublicEndpoint,
+      peerRegion: cluster.peerRegion,
     };
   },
 });

--- a/examples/aws-dsql-multiregion/sst.config.ts
+++ b/examples/aws-dsql-multiregion/sst.config.ts
@@ -46,33 +46,33 @@
 export default $config({
   app(input) {
     return {
-      name: 'aws-dsql-multiregion',
-      removal: input?.stage === 'production' ? 'retain' : 'remove',
-      home: 'aws',
+      name: "aws-dsql-multiregion",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
       providers: {
-        aws: { region: 'us-east-1' },
+        aws: { region: "us-east-1" },
       },
     };
   },
   async run() {
-    const cluster = new sst.aws.Dsql('MultiRegion', {
+    const cluster = new sst.aws.Dsql("MultiRegion", {
       regions: {
-        witness: 'us-west-2',
-        peer: 'us-east-2',
+        witness: "us-west-2",
+        peer: "us-east-2",
       },
     });
 
-    const fn = new sst.aws.Function('MyFunction', {
-      handler: 'lambda.handler',
+    const fn = new sst.aws.Function("MyFunction", {
+      handler: "lambda.handler",
       link: [cluster],
       url: true,
     });
 
     return {
-      endpoint: cluster.publicEndpoint,
+      endpoint: cluster.endpoint,
       region: cluster.region,
-      peerEndpoint: cluster.peerPublicEndpoint,
-      peerRegion: cluster.peerRegion,
+      peerEndpoint: cluster.peer.endpoint,
+      peerRegion: cluster.peer.region,
     };
   },
 });

--- a/examples/aws-dsql-multiregion/sst.config.ts
+++ b/examples/aws-dsql-multiregion/sst.config.ts
@@ -58,11 +58,7 @@ export default $config({
     const cluster = new sst.aws.Dsql('MultiRegion', {
       regions: {
         witness: 'us-west-2',
-        peer: { region: 'us-east-2' },
-      },
-      backup: {
-        retention: 45,
-        timezone: 'Australia/Melbourne',
+        peer: 'us-east-2',
       },
     });
 

--- a/examples/aws-dsql/sst.config.ts
+++ b/examples/aws-dsql/sst.config.ts
@@ -40,16 +40,16 @@
 export default $config({
   app(input) {
     return {
-      name: 'aws-dsql',
-      removal: input?.stage === 'production' ? 'retain' : 'remove',
-      home: 'aws',
+      name: "aws-dsql",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
     };
   },
   async run() {
-    const cluster = new sst.aws.Dsql('MyCluster', {});
+    const cluster = new sst.aws.Dsql("MyCluster", {});
 
-    const fn = new sst.aws.Function('MyFunction', {
-      handler: 'lambda.handler',
+    const fn = new sst.aws.Function("MyFunction", {
+      handler: "lambda.handler",
       link: [cluster],
       url: true,
     });

--- a/examples/aws-dsql/sst.config.ts
+++ b/examples/aws-dsql/sst.config.ts
@@ -40,16 +40,16 @@
 export default $config({
   app(input) {
     return {
-      name: "aws-dsql",
-      removal: input?.stage === "production" ? "retain" : "remove",
-      home: "aws",
+      name: 'aws-dsql',
+      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      home: 'aws',
     };
   },
   async run() {
-    const cluster = new sst.aws.Dsql("MyCluster", {});
+    const cluster = new sst.aws.Dsql('MyCluster', {});
 
-    const fn = new sst.aws.Function("MyFunction", {
-      handler: "lambda.handler",
+    const fn = new sst.aws.Function('MyFunction', {
+      handler: 'lambda.handler',
       link: [cluster],
       url: true,
     });

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -1,6 +1,7 @@
-import { ComponentResourceOptions, Output } from "@pulumi/pulumi";
+import { ComponentResourceOptions, Output, provider } from "@pulumi/pulumi";
 import { Component, transform, Transform } from "../component";
 import { Link } from "../link";
+import { VisibleError } from "../error";
 import { dsql } from "@pulumi/aws";
 import { permission } from "./permission";
 import { useProvider } from "./helpers/provider";
@@ -39,20 +40,64 @@ export interface DsqlArgs {
   };
 
   /**
-   * Enable automatic backups for the cluster using AWS Backup.
-   * Retains daily backups for 35 days. If multi-region is enabled, identical backup resources
-   * are created in both regions.
-   * * Set to `false` to explicitly disable backups.
+   * Configure automatic backups for the cluster using AWS Backup.
+   * If multi-region is enabled, identical backup resources are created in both regions.
    *
-   * @default true
+   * Omit to skip backup creation entirely.
+   *
    * @example
+   * Enable with defaults (daily at noon UTC, 30 day retention).
    * ```ts title="sst.config.ts"
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   * backup: false
+   *   backup: {}
+   * });
+   * ```
+   *
+   * Custom schedule, timezone, and retention.
+   * ```ts title="sst.config.ts"
+   * const cluster = new sst.aws.Dsql("MyCluster", {
+   *   backup: {
+   *     schedule: "cron(0 2 ? * * *)",
+   *     timezone: "Australia/Melbourne",
+   *     retention: 90
+   *   }
    * });
    * ```
    */
-  backup?: boolean;
+  backup?: {
+    /**
+     * The backup schedule as an AWS cron expression (6 fields).
+     * Evaluated in UTC by default, or in the timezone specified by `timezone`.
+     *
+     * See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
+     * @default `"cron(0 12 ? * * *)"`
+     * @example
+     * Every day at midnight.
+     * ```ts
+     * schedule: "cron(0 0 ? * * *)"
+     * ```
+     * Every Monday at 3am.
+     * ```ts
+     * schedule: "cron(0 3 ? * MON *)"
+     * ```
+     */
+    schedule?: Input<string>;
+    /**
+     * The IANA timezone for the backup schedule.
+     *
+     * @default `"UTC"`
+     * @example
+     * ```ts
+     * timezone: "Australia/Melbourne"
+     * ```
+     */
+    timezone?: Input<string>;
+    /**
+     * Number of days to retain backups.
+     * @default 30
+     */
+    retention?: Input<number>;
+  };
 
   /**
    * :::note
@@ -108,6 +153,9 @@ export interface DsqlArgs {
   transform?: {
     cluster?: Transform<dsql.ClusterArgs>;
     peerCluster?: Transform<dsql.ClusterArgs>;
+    backupVault?: Transform<aws.backup.VaultArgs>;
+    backupPlan?: Transform<aws.backup.PlanArgs>;
+    backupSelection?: Transform<aws.backup.SelectionArgs>;
   };
 }
 
@@ -115,6 +163,13 @@ interface DsqlRef {
   ref: boolean;
   cluster: dsql.Cluster;
   peerCluster?: dsql.Cluster;
+}
+
+interface BackupResources {
+  vault: aws.backup.Vault;
+  plan: aws.backup.Plan;
+  selection: aws.backup.Selection;
+  role: aws.iam.Role;
 }
 
 /**
@@ -152,6 +207,18 @@ interface DsqlRef {
  * });
  * ```
  *
+ * #### With backups
+ *
+ * ```ts title="sst.config.ts"
+ * const cluster = new sst.aws.Dsql("MyCluster", {
+ *   backup: {
+ *     schedule: "cron(0 2 ? * * *)",
+ *     timezone: "Australia/Melbourne",
+ *     retention: 90
+ *   }
+ * });
+ * ```
+ *
  * #### Link to a function
  *
  * ```ts title="sst.config.ts"
@@ -167,6 +234,8 @@ export class Dsql extends Component implements Link.Linkable {
   private cluster: dsql.Cluster;
   private peerCluster: dsql.Cluster | undefined;
   private connectionEndpoint: aws.ec2.VpcEndpoint | undefined;
+  private backup: BackupResources | undefined;
+  private peerBackup: BackupResources | undefined;
 
   constructor(
     name: string,
@@ -199,21 +268,44 @@ export class Dsql extends Component implements Link.Linkable {
       createPeerings(createdPeerCluster, peerProvider);
     }
 
-    const backupEnabled = args.backup !== false;
+    if (args.backup !== undefined) {
+      const schedule = args.backup.schedule ?? "cron(0 12 ? * * *)";
+      const timezone = args.backup.timezone ?? "UTC";
+      const retention = args.backup.retention ?? 30;
 
-    if (backupEnabled) {
-      createBackupSetup(primaryCluster, undefined, "");
+      if (typeof schedule === "string" && !schedule.startsWith("cron(")) {
+        throw new VisibleError(
+          `Invalid backup schedule "${schedule}". Must be an AWS cron expression with 6 fields, e.g. "cron(0 12 ? * * *)". See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html`,
+        );
+      }
+
+      this.backup = createBackupSetup(
+        primaryCluster,
+        schedule,
+        timezone,
+        retention,
+      );
 
       if (multiRegion && createdPeerCluster && peerProvider) {
-        createBackupSetup(createdPeerCluster, peerProvider, "Peer");
+        this.peerBackup = createBackupSetup(
+          createdPeerCluster,
+          schedule,
+          timezone,
+          retention,
+          peerProvider,
+          "Peer",
+        );
       }
     }
 
     function createBackupSetup(
       targetCluster: dsql.Cluster,
+      schedule: Input<string>,
+      timezone: Input<string>,
+      retention: Input<number>,
       provider?: aws.Provider,
       suffix: string = "",
-    ) {
+    ): BackupResources {
       const role = new aws.iam.Role(
         `${name}BackupRole${suffix}`,
         {
@@ -228,35 +320,47 @@ export class Dsql extends Component implements Link.Linkable {
       );
 
       const vault = new aws.backup.Vault(
-        `${name}BackupVault${suffix}`,
-        {},
-        { parent, provider },
+        ...transform(
+          args.transform?.backupVault,
+          `${name}BackupVault${suffix}`,
+          {},
+          { parent, provider },
+        ),
       );
 
       const plan = new aws.backup.Plan(
-        `${name}BackupPlan${suffix}`,
-        {
-          rules: [
-            {
-              ruleName: "Daily",
-              targetVaultName: vault.name,
-              schedule: "cron(0 12 * * ? *)",
-              lifecycle: { deleteAfter: 35 },
-            },
-          ],
-        },
-        { parent, provider },
+        ...transform(
+          args.transform?.backupPlan,
+          `${name}BackupPlan${suffix}`,
+          {
+            rules: [
+              {
+                ruleName: `${name}BackupPlan`,
+                targetVaultName: vault.name,
+                schedule,
+                scheduleExpressionTimezone: timezone,
+                lifecycle: { deleteAfter: retention },
+              },
+            ],
+          },
+          { parent, provider },
+        ),
       );
 
-      new aws.backup.Selection(
-        `${name}BackupSelection${suffix}`,
-        {
-          planId: plan.id,
-          iamRoleArn: role.arn,
-          resources: [targetCluster.arn],
-        },
-        { parent, provider },
+      const selection = new aws.backup.Selection(
+        ...transform(
+          args.transform?.backupSelection,
+          `${name}BackupSelection${suffix}`,
+          {
+            planId: plan.id,
+            iamRoleArn: role.arn,
+            resources: [targetCluster.arn],
+          },
+          { parent, provider },
+        ),
       );
+
+      return { vault, plan, selection, role };
     }
 
     function createPrimaryCluster() {
@@ -488,6 +592,22 @@ export class Dsql extends Component implements Link.Linkable {
     return {
       cluster: this.cluster,
       peerCluster: this.peerCluster,
+      backup: this.backup
+        ? {
+            vault: this.backup.vault,
+            plan: this.backup.plan,
+            selection: this.backup.selection,
+            role: this.backup.role,
+          }
+        : undefined,
+      peerBackup: this.peerBackup
+        ? {
+            vault: this.peerBackup.vault,
+            plan: this.peerBackup.plan,
+            selection: this.peerBackup.selection,
+            role: this.peerBackup.role,
+          }
+        : undefined,
     };
   }
 

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -41,16 +41,17 @@ export interface DsqlArgs {
   };
 
   /**
-   * Configure automatic backups for the cluster using AWS Backup.
+   * Configure automatic backups for the cluster using AWS Backup. Set to `true`
+   * to use the defaults, or pass an object to customize the schedule and retention.
    * If multi-region is enabled, identical backup resources are created in both regions.
    *
-   * Omit to skip backup creation entirely.
+   * Omit or set to `false` to skip backup creation entirely.
    *
    * @example
-   * Enable with defaults (daily at noon UTC, 30-day retention).
+   * Enable with defaults (daily at 5 AM UTC, 7-day retention).
    * ```ts title="sst.config.ts"
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   *   backup: {}
+   *   backup: true
    * });
    * ```
    *
@@ -64,30 +65,33 @@ export interface DsqlArgs {
    * });
    * ```
    */
-  backup?: {
-    /**
-     * The backup schedule as an AWS Backup cron expression.
-     * This uses the same 6-field `cron(...)` format as EventBridge and is always evaluated in UTC.
-     *
-     * See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
-     * @default `"cron(0 12 ? * * *)"`
-     * @example
-     * Every day at midnight UTC.
-     * ```ts
-     * schedule: "cron(0 0 ? * * *)"
-     * ```
-     * Every Monday at 3am UTC.
-     * ```ts
-     * schedule: "cron(0 3 ? * MON *)"
-     * ```
-     */
-    schedule?: Input<string>;
-    /**
-     * How long to retain backups. Use a day duration like `"30 days"`.
-     * @default `"30 days"`
-     */
-    retention?: Input<DurationDays>;
-  };
+  backup?:
+    | boolean
+    | {
+        /**
+         * The schedule for the backups as an [AWS Backup cron expression](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupRule.html).
+         *
+         * This uses the same 6-field `cron(...)` format as EventBridge and is evaluated in UTC.
+         *
+         * @default `"cron(0 5 ? * * *)"`
+         * @example
+         * Back up every day at midnight UTC.
+         * ```ts
+         * schedule: "cron(0 0 ? * * *)"
+         * ```
+         *
+         * Back up every Monday at 3 AM UTC.
+         * ```ts
+         * schedule: "cron(0 3 ? * MON *)"
+         * ```
+         */
+        schedule?: Input<string>;
+        /**
+         * How long to retain backups. Use a day duration like `"7 days"`.
+         * @default `"7 days"`
+         */
+        retention?: Input<DurationDays>;
+      };
 
   /**
    *
@@ -172,15 +176,15 @@ export interface DsqlArgs {
     /**
      * Transform the AWS Backup vault resource.
      */
-     backupVault?: Transform<backup.VaultArgs>;
+    backupVault?: Transform<backup.VaultArgs>;
     /**
      * Transform the AWS Backup plan resource.
      */
-     backupPlan?: Transform<backup.PlanArgs>;
+    backupPlan?: Transform<backup.PlanArgs>;
     /**
      * Transform the AWS Backup selection resource.
      */
-     backupSelection?: Transform<backup.SelectionArgs>;
+    backupSelection?: Transform<backup.SelectionArgs>;
   };
 }
 
@@ -249,10 +253,7 @@ interface DsqlRef {
  *
  * ```ts title="sst.config.ts"
  * const cluster = new sst.aws.Dsql("MyCluster", {
- *   backup: {
- *     schedule: "cron(0 2 ? * * *)",
- *     retention: "90 days"
- *   }
+ *   backup: true
  * });
  * ```
  *
@@ -316,33 +317,33 @@ export class Dsql extends Component implements Link.Linkable {
       );
 
     const vpc = normalizeVpc();
+    const backupConfig = normalizeBackup();
 
     const cluster = createCluster();
     const peerCluster = createPeerCluster();
     const endpoints = createVpcEndpoints();
 
-    this.cluster = cluster;
-    this.peerCluster = peerCluster;
-    this.connectionEndpoint = endpoints?.connection;
-
-    if (args.backup !== undefined) {
-      const schedule = args.backup.schedule ?? "cron(0 12 ? * * *)";
-      const retention = output(args.backup.retention).apply((retention) =>
-        toDays(retention ?? "30 days"),
+    if (backupConfig) {
+      createBackupSetup(
+        cluster,
+        backupConfig.schedule,
+        backupConfig.retention,
       );
-
-      createBackupSetup(cluster, schedule, retention);
 
       if (regions && peerCluster) {
         createBackupSetup(
           peerCluster,
-          schedule,
-          retention,
+          backupConfig.schedule,
+          backupConfig.retention,
           "Peer",
           useProvider(regions.peer as Region),
         );
       }
     }
+
+    this.cluster = cluster;
+    this.peerCluster = peerCluster;
+    this.connectionEndpoint = endpoints?.connection;
 
     function createCluster() {
       return new dsql.Cluster(
@@ -461,6 +462,16 @@ export class Dsql extends Component implements Link.Linkable {
           { parent, provider },
         ),
       );
+    }
+
+    function normalizeBackup() {
+      if (!args.backup) return;
+
+      const config = args.backup === true ? {} : args.backup;
+      return {
+        schedule: output(config.schedule).apply((v) => v ?? "cron(0 5 ? * * *)"),
+        retention: output(config.retention).apply((v) => toDays(v ?? "7 days")),
+      };
     }
 
     function normalizeVpc() {

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -1,7 +1,8 @@
-import { all, ComponentResourceOptions, Output } from "@pulumi/pulumi";
+import { all, ComponentResourceOptions, output } from "@pulumi/pulumi";
 import { Component, transform, Transform } from "../component";
+import { toDays, type DurationDays } from "../duration";
 import { Link } from "../link";
-import { dsql, ec2, Region } from "@pulumi/aws";
+import { backup, dsql, ec2, iam, Provider, Region } from "@pulumi/aws";
 import { permission } from "./permission";
 import { useProvider } from "./helpers/provider";
 import { Vpc } from "./vpc";
@@ -11,8 +12,6 @@ import {
 } from "./helpers/arn";
 import type { Input } from "../input";
 import { VisibleError } from "../error";
-
-import * as aws from "@pulumi/aws";
 
 export interface DsqlArgs {
   /**
@@ -48,57 +47,46 @@ export interface DsqlArgs {
    * Omit to skip backup creation entirely.
    *
    * @example
-   * Enable with defaults (daily at noon UTC, 30 day retention).
+   * Enable with defaults (daily at noon UTC, 30-day retention).
    * ```ts title="sst.config.ts"
    * const cluster = new sst.aws.Dsql("MyCluster", {
    *   backup: {}
    * });
    * ```
    *
-   * Custom schedule, timezone, and retention.
+   * Custom schedule and retention.
    * ```ts title="sst.config.ts"
    * const cluster = new sst.aws.Dsql("MyCluster", {
    *   backup: {
    *     schedule: "cron(0 2 ? * * *)",
-   *     timezone: "Australia/Melbourne",
-   *     retention: 90
+   *     retention: "90 days"
    *   }
    * });
    * ```
    */
   backup?: {
     /**
-     * The backup schedule as an AWS cron expression (6 fields).
-     * Evaluated in UTC by default, or in the timezone specified by `timezone`.
+     * The backup schedule as an AWS Backup cron expression.
+     * This uses the same 6-field `cron(...)` format as EventBridge and is always evaluated in UTC.
      *
      * See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
      * @default `"cron(0 12 ? * * *)"`
      * @example
-     * Every day at midnight.
+     * Every day at midnight UTC.
      * ```ts
      * schedule: "cron(0 0 ? * * *)"
      * ```
-     * Every Monday at 3am.
+     * Every Monday at 3am UTC.
      * ```ts
      * schedule: "cron(0 3 ? * MON *)"
      * ```
      */
     schedule?: Input<string>;
     /**
-     * The IANA timezone for the backup schedule.
-     *
-     * @default `"UTC"`
-     * @example
-     * ```ts
-     * timezone: "Australia/Melbourne"
-     * ```
+     * How long to retain backups. Use a day duration like `"30 days"`.
+     * @default `"30 days"`
      */
-    timezone?: Input<string>;
-    /**
-     * Number of days to retain backups.
-     * @default 30
-     */
-    retention?: Input<number>;
+    retention?: Input<DurationDays>;
   };
 
   /**
@@ -184,15 +172,15 @@ export interface DsqlArgs {
     /**
      * Transform the AWS Backup vault resource.
      */
-    backupVault?: Transform<aws.backup.VaultArgs>;
+     backupVault?: Transform<backup.VaultArgs>;
     /**
      * Transform the AWS Backup plan resource.
      */
-    backupPlan?: Transform<aws.backup.PlanArgs>;
+     backupPlan?: Transform<backup.PlanArgs>;
     /**
      * Transform the AWS Backup selection resource.
      */
-    backupSelection?: Transform<aws.backup.SelectionArgs>;
+     backupSelection?: Transform<backup.SelectionArgs>;
   };
 }
 
@@ -200,13 +188,6 @@ interface DsqlRef {
   ref: boolean;
   cluster: dsql.Cluster;
   peerCluster?: dsql.Cluster;
-}
-
-interface BackupResources {
-  vault: aws.backup.Vault;
-  plan: aws.backup.Plan;
-  selection: aws.backup.Selection;
-  role: aws.iam.Role;
 }
 
 /**
@@ -270,8 +251,7 @@ interface BackupResources {
  * const cluster = new sst.aws.Dsql("MyCluster", {
  *   backup: {
  *     schedule: "cron(0 2 ? * * *)",
- *     timezone: "Australia/Melbourne",
- *     retention: 90
+ *     retention: "90 days"
  *   }
  * });
  * ```
@@ -311,8 +291,6 @@ export class Dsql extends Component implements Link.Linkable {
   private peerCluster: dsql.Cluster | undefined;
   private connectionEndpoint: ec2.VpcEndpoint | undefined;
   private constructorName: string;
-  private backup: BackupResources | undefined;
-  private peerBackup: BackupResources | undefined;
 
   constructor(
     name: string,
@@ -349,22 +327,16 @@ export class Dsql extends Component implements Link.Linkable {
 
     if (args.backup !== undefined) {
       const schedule = args.backup.schedule ?? "cron(0 12 ? * * *)";
-      const timezone = args.backup.timezone ?? "UTC";
-      const retention = args.backup.retention ?? 30;
+      const retention = output(args.backup.retention).apply((retention) =>
+        toDays(retention ?? "30 days"),
+      );
 
-      if (typeof schedule === "string" && !schedule.startsWith("cron(")) {
-        throw new VisibleError(
-          `Invalid backup schedule "${schedule}". Must be an AWS cron expression with 6 fields, e.g. "cron(0 12 ? * * *)". See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html`,
-        );
-      }
-
-      this.backup = createBackupSetup(cluster, schedule, timezone, retention);
+      createBackupSetup(cluster, schedule, retention);
 
       if (regions && peerCluster) {
-        this.peerBackup = createBackupSetup(
+        createBackupSetup(
           peerCluster,
           schedule,
-          timezone,
           retention,
           "Peer",
           useProvider(regions.peer as Region),
@@ -432,15 +404,14 @@ export class Dsql extends Component implements Link.Linkable {
     function createBackupSetup(
       targetCluster: dsql.Cluster,
       schedule: Input<string>,
-      timezone: Input<string>,
       retention: Input<number>,
       suffix = "",
-      provider?: aws.Provider,
-    ): BackupResources {
-      const role = new aws.iam.Role(
+      provider?: Provider,
+    ) {
+      const role = new iam.Role(
         `${name}BackupRole${suffix}`,
         {
-          assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+          assumeRolePolicy: iam.assumeRolePolicyForPrincipal({
             Service: "backup.amazonaws.com",
           }),
           managedPolicyArns: [
@@ -450,7 +421,7 @@ export class Dsql extends Component implements Link.Linkable {
         { parent, provider },
       );
 
-      const vault = new aws.backup.Vault(
+      const vault = new backup.Vault(
         ...transform(
           args.transform?.backupVault,
           `${name}BackupVault${suffix}`,
@@ -459,7 +430,7 @@ export class Dsql extends Component implements Link.Linkable {
         ),
       );
 
-      const plan = new aws.backup.Plan(
+      const plan = new backup.Plan(
         ...transform(
           args.transform?.backupPlan,
           `${name}BackupPlan${suffix}`,
@@ -469,7 +440,7 @@ export class Dsql extends Component implements Link.Linkable {
                 ruleName: `${name}BackupRule${suffix}`,
                 targetVaultName: vault.name,
                 schedule,
-                scheduleExpressionTimezone: timezone,
+                scheduleExpressionTimezone: "UTC",
                 lifecycle: { deleteAfter: retention },
               },
             ],
@@ -478,7 +449,7 @@ export class Dsql extends Component implements Link.Linkable {
         ),
       );
 
-      const selection = new aws.backup.Selection(
+      new backup.Selection(
         ...transform(
           args.transform?.backupSelection,
           `${name}BackupSelection${suffix}`,
@@ -490,8 +461,6 @@ export class Dsql extends Component implements Link.Linkable {
           { parent, provider },
         ),
       );
-
-      return { vault, plan, selection, role };
     }
 
     function normalizeVpc() {
@@ -661,24 +630,6 @@ export class Dsql extends Component implements Link.Linkable {
       cluster: this.cluster,
       /** The peer DSQL cluster (multi-region only). */
       peerCluster: this.peerCluster,
-      /** The backup resources (when backup is configured). */
-      backup: this.backup
-        ? {
-            vault: this.backup.vault,
-            plan: this.backup.plan,
-            selection: this.backup.selection,
-            role: this.backup.role,
-          }
-        : undefined,
-      /** The peer backup resources (multi-region with backup only). */
-      peerBackup: this.peerBackup
-        ? {
-            vault: this.peerBackup.vault,
-            plan: this.peerBackup.plan,
-            selection: this.peerBackup.selection,
-            role: this.peerBackup.role,
-          }
-        : undefined,
     };
   }
 

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -1,76 +1,91 @@
-import { all, ComponentResourceOptions, Output } from "@pulumi/pulumi";
+import { ComponentResourceOptions, Output } from "@pulumi/pulumi";
 import { Component, transform, Transform } from "../component";
 import { Link } from "../link";
-import { dsql, ec2, Region } from "@pulumi/aws";
+import { dsql } from "@pulumi/aws";
 import { permission } from "./permission";
 import { useProvider } from "./helpers/provider";
 import { Vpc } from "./vpc";
-import {
-  parseDsqlPublicEndpoint,
-  parseDsqlPrivateEndpoint,
-} from "./helpers/arn";
+
 import type { Input } from "../input";
-import { VisibleError } from "../error";
+
+import * as aws from "@pulumi/aws";
 
 export interface DsqlArgs {
   /**
    * Configure multi-region cluster peering.
    *
-   * Creates a cluster in the current region and a peer cluster in another region,
+   * Creates a primary cluster in the current region and a peer cluster in another region,
    * linked via a witness region. The witness must differ from both cluster regions.
    *
-   * Learn more about [AWS DSQL regions](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html#region-availability).
+   * See https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html#region-availability
    *
    * @example
-   *
    * ```ts
- * const cluster = new sst.aws.Dsql("MyCluster", {
- *   regions: {
- *     witness: "us-west-2",
- *     peer: "us-east-2"
- *   }
- * });
- * ```
- */
+   * const cluster = new sst.aws.Dsql("MyCluster", {
+   * regions: {
+   * witness: "us-west-2",
+   * peer: { region: "us-east-2" }
+   * }
+   * });
+   * ```
+   */
   regions?: {
     /** The witness region. Must differ from both cluster regions. */
     witness: Input<string>;
-    /** The AWS region for the peer cluster. */
-    peer: Input<string>;
+    peer: {
+      /** The AWS region for the peer cluster. */
+      region: Input<string>;
+    };
   };
 
   /**
+   * Enable automatic backups for the cluster using AWS Backup.
+   * Retains daily backups for 35 days. If multi-region is enabled, identical backup resources
+   * are created in both regions.
+   * * Set to `false` to explicitly disable backups.
    *
-   * Create AWS PrivateLink interface endpoints in a VPC for private connectivity.
-   * This allows lambdas placed inside a VPC without NAT gateways to connect to the DSQL instance.
-   *
-   * :::note
-   * Currently only single region VPC is supported.
-   * :::
-   *
+   * @default true
    * @example
-   *
    * ```ts title="sst.config.ts"
-   * const myVpc = new sst.aws.Vpc("MyVpc");
-   *
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   *   vpc: myVpc
+   * backup: false
    * });
    * ```
+   */
+  backup?: boolean;
+
+  /**
+   * :::note
+   * Currently only single region VPC is supported. Multi region coming soon.
+   * :::
    *
-   * #### Customize VPC endpoints
+   * Create AWS PrivateLink interface endpoints in a VPC for private connectivity.
    *
+   * Two endpoint types are supported:
+   * - **Management** — control plane ops (create, get, update, delete clusters).
+   * Service: `com.amazonaws.{region}.dsql`
+   * - **Connection** — PostgreSQL client connections.
+   * Service name is cluster-specific and resolved automatically.
+   *
+   * :::note
+   * The VPC endpoint security group allows inbound on port 5432 from within the VPC CIDR.
+   * Your Lambda must be in the same VPC. The Lambda's default security group allows all
+   * outbound traffic, so it can reach the endpoint on port 5432 without any extra config.
+   * :::
+   *
+   *
+   * @example
    * ```ts title="sst.config.ts"
-   * const myVpc = new sst.aws.Vpc("MyVpc");
+   * const vpc = new sst.aws.Vpc("MyVpc");
    *
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   *   vpc: {
-   *     instance: vpc,
-   *     endpoints: {
-   *       management: true,
-   *       connection: true,
-   *     }
-   *   }
+   * vpc: {
+   * instance: vpc,
+   * endpoints: {
+   * management: true,
+   * connection: true,
+   * }
+   * }
    * });
    * ```
    */
@@ -79,18 +94,10 @@ export interface DsqlArgs {
     | {
         instance: Vpc;
         endpoints?: {
-          /**
-           * Endpoint for control plane ops (create, get, update, delete clusters).
-           *
-           * @default `false`
-           */
-          management?: boolean;
-          /**
-           * Endpoint for PostgreSQL client connections.
-           *
-           * @default `true`
-           */
-          connection?: boolean;
+          /** @default `false` */
+          management?: Input<boolean>;
+          /** @default `false` */
+          connection?: Input<boolean>;
         };
       };
 
@@ -99,26 +106,8 @@ export interface DsqlArgs {
    * resources.
    */
   transform?: {
-    /**
-     * Transform the DSQL cluster resource.
-     */
     cluster?: Transform<dsql.ClusterArgs>;
-    /**
-     * Transform the peer DSQL cluster resource.
-     */
     peerCluster?: Transform<dsql.ClusterArgs>;
-    /**
-     * Transform the EC2 security group resource for the DSQL VPC endpoints.
-     */
-    endpointSecurityGroup?: Transform<ec2.SecurityGroupArgs>;
-    /**
-     * Transform the EC2 VPC endpoint resource for DSQL management operations.
-     */
-    managementEndpoint?: Transform<ec2.VpcEndpointArgs>;
-    /**
-     * Transform the EC2 VPC endpoint resource for DSQL connections.
-     */
-    connectionEndpoint?: Transform<ec2.VpcEndpointArgs>;
   };
 }
 
@@ -139,34 +128,16 @@ interface DsqlRef {
  * const cluster = new sst.aws.Dsql("MyCluster");
  * ```
  *
- * Once linked, you can connect to it from your function code.
- *
- * ```ts title="src/lambda.ts"
- * import { Resource } from "sst";
- * import { AuroraDSQLClient } from "@aws/aurora-dsql-node-postgres-connector";
- *
- * const client = new AuroraDSQLClient({
- *   host: Resource.MyCluster.endpoint,
- *   user: "admin",
- * });
- *
- * await client.connect();
- * const result = await client.query("SELECT NOW() as now");
- * await client.end();
- * ```
- *
  * #### Multi-region cluster
  *
  * ```ts title="sst.config.ts"
  * const cluster = new sst.aws.Dsql("MyCluster", {
- *   regions: {
- *     witness: "us-west-2",
- *     peer: "us-east-2"
- *   }
+ * regions: {
+ * witness: "us-west-2",
+ * peer: { region: "us-east-2" }
+ * }
  * });
  * ```
- *
- * [Check out the full example](/docs/examples/#aws-dsql-multiregion).
  *
  * #### With private VPC endpoints
  *
@@ -174,50 +145,28 @@ interface DsqlRef {
  * const vpc = new sst.aws.Vpc("MyVpc");
  *
  * const cluster = new sst.aws.Dsql("MyCluster", {
- *   vpc: {
- *     instance: vpc,
- *     endpoints: { connection: true }
- *   }
+ * vpc: {
+ * instance: vpc,
+ * endpoints: { connection: true }
+ * }
  * });
  * ```
- *
- * [Check out the full example](/docs/examples/#aws-dsql-vpc).
  *
  * #### Link to a function
  *
  * ```ts title="sst.config.ts"
  * new sst.aws.Function("MyFunction", {
- *   handler: "src/lambda.handler",
- *   link: [cluster]
+ * handler: "src/lambda.handler",
+ * link: [cluster]
  * });
  * ```
- *
- * You can also use Drizzle ORM to query your DSQL cluster.
- * [Check out the Drizzle example](/docs/examples/#aws-dsql-drizzle).
- *
- * ---
- *
- * ### Cost
- *
- * Aurora DSQL is serverless and uses a pay-per-use pricing model. You are charged for
- * database activity measured in _Distributed Processing Units_ (DPUs) at $8 per million
- * DPUs, and storage at $0.33 per GB-month. When idle, usage scales to zero and you incur
- * no DPU charges.
- *
- * There is a free tier of 100,000 DPUs and 1 GB of storage per month.
- *
- * For example, a single-region cluster averaging 1.3M DPUs per month with 15 GB of storage
- * costs roughly 1.3 x $8 + 15 x $0.33 or **$15 per month**.
- *
- * Check out the [Aurora DSQL pricing](https://aws.amazon.com/rds/aurora/dsql/pricing/) for more details.
  *
  */
 
 export class Dsql extends Component implements Link.Linkable {
   private cluster: dsql.Cluster;
   private peerCluster: dsql.Cluster | undefined;
-  private connectionEndpoint: ec2.VpcEndpoint | undefined;
-  private constructorName: string;
+  private connectionEndpoint: aws.ec2.VpcEndpoint | undefined;
 
   constructor(
     name: string,
@@ -225,7 +174,6 @@ export class Dsql extends Component implements Link.Linkable {
     opts: ComponentResourceOptions = {},
   ) {
     super(__pulumiType, name, args, opts);
-    this.constructorName = name;
 
     if (args && "ref" in args) {
       const ref = args as unknown as DsqlRef;
@@ -235,32 +183,92 @@ export class Dsql extends Component implements Link.Linkable {
     }
 
     const parent = this;
-    const regions = args.regions;
+    const multiRegion = args.regions;
 
-    if (regions && args.vpc)
-      throw new VisibleError(
-        `Cannot use "vpc" with multi-region "regions". VPC endpoints are only supported for single-region clusters.`,
+    const peerProvider = multiRegion
+      ? useProvider(multiRegion.peer.region as aws.Region)
+      : undefined;
+
+    const primaryCluster = createPrimaryCluster();
+    this.cluster = primaryCluster;
+
+    const createdPeerCluster = multiRegion ? createPeerCluster() : undefined;
+    this.peerCluster = createdPeerCluster;
+
+    if (multiRegion && createdPeerCluster && peerProvider) {
+      createPeerings(createdPeerCluster, peerProvider);
+    }
+
+    const backupEnabled = args.backup !== false;
+
+    if (backupEnabled) {
+      createBackupSetup(primaryCluster, undefined, "");
+
+      if (multiRegion && createdPeerCluster && peerProvider) {
+        createBackupSetup(createdPeerCluster, peerProvider, "Peer");
+      }
+    }
+
+    function createBackupSetup(
+      targetCluster: dsql.Cluster,
+      provider?: aws.Provider,
+      suffix: string = "",
+    ) {
+      const role = new aws.iam.Role(
+        `${name}BackupRole${suffix}`,
+        {
+          assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "backup.amazonaws.com",
+          }),
+          managedPolicyArns: [
+            "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+          ],
+        },
+        { parent, provider },
       );
 
-    const vpc = normalizeVpc();
+      const vault = new aws.backup.Vault(
+        `${name}BackupVault${suffix}`,
+        {},
+        { parent, provider },
+      );
 
-    const cluster = createCluster();
-    const peerCluster = createPeerCluster();
-    const endpoints = createVpcEndpoints();
+      const plan = new aws.backup.Plan(
+        `${name}BackupPlan${suffix}`,
+        {
+          rules: [
+            {
+              ruleName: "Daily",
+              targetVaultName: vault.name,
+              schedule: "cron(0 12 * * ? *)",
+              lifecycle: { deleteAfter: 35 },
+            },
+          ],
+        },
+        { parent, provider },
+      );
 
-    this.cluster = cluster;
-    this.peerCluster = peerCluster;
-    this.connectionEndpoint = endpoints?.connection;
+      new aws.backup.Selection(
+        `${name}BackupSelection${suffix}`,
+        {
+          planId: plan.id,
+          iamRoleArn: role.arn,
+          resources: [targetCluster.arn],
+        },
+        { parent, provider },
+      );
+    }
 
-    function createCluster() {
+    function createPrimaryCluster() {
       return new dsql.Cluster(
         ...transform(
           args.transform?.cluster,
           `${name}Cluster`,
           {
-            multiRegionProperties: regions
-              ? { witnessRegion: regions.witness }
+            multiRegionProperties: multiRegion
+              ? { witnessRegion: multiRegion.witness }
               : undefined,
+            tags: { Name: name },
           },
           { parent },
         ),
@@ -268,46 +276,48 @@ export class Dsql extends Component implements Link.Linkable {
     }
 
     function createPeerCluster() {
-      if (!regions) return;
-
-      const peerProvider = useProvider(regions.peer as Region);
-
-      const peerCluster = new dsql.Cluster(
+      return new dsql.Cluster(
         ...transform(
           args.transform?.peerCluster,
           `${name}PeerCluster`,
           {
             multiRegionProperties: {
-              witnessRegion: regions.witness,
+              witnessRegion: multiRegion!.witness,
             },
+            tags: { Name: `${name}Peer` },
           },
           { parent, provider: peerProvider },
         ),
       );
+    }
 
-      // DSQL requires both clusters to declare each other — two-way handshake.
+    function createPeerings(peer: dsql.Cluster, peerProv: aws.Provider) {
       new dsql.ClusterPeering(
-        `${name}Peering1`,
+        `${name}PrimaryPeering`,
         {
-          identifier: cluster.identifier,
-          clusters: [peerCluster.arn],
-          witnessRegion: regions.witness,
+          identifier: primaryCluster.identifier,
+          clusters: [peer.arn],
+          witnessRegion: primaryCluster.multiRegionProperties.apply(
+            (p) => p?.witnessRegion!,
+          ),
         },
         { parent },
       );
 
       new dsql.ClusterPeering(
-        `${name}Peering2`,
+        `${name}PeerPeering`,
         {
-          identifier: peerCluster.identifier,
-          clusters: [cluster.arn],
-          witnessRegion: regions.witness,
+          identifier: peer.identifier,
+          clusters: [primaryCluster.arn],
+          witnessRegion: peer.multiRegionProperties.apply(
+            (p) => p?.witnessRegion!,
+          ),
         },
-        { parent, provider: peerProvider },
+        { parent, provider: peerProv },
       );
-
-      return peerCluster;
     }
+
+    const vpc = normalizeVpc();
 
     function normalizeVpc() {
       if (!args.vpc) return undefined;
@@ -316,8 +326,8 @@ export class Dsql extends Component implements Link.Linkable {
         return {
           instance: args.vpc,
           endpoints: {
-            management: false,
-            connection: true,
+            management: false as Input<boolean>,
+            connection: false as Input<boolean>,
           },
         };
       }
@@ -326,155 +336,157 @@ export class Dsql extends Component implements Link.Linkable {
         instance: args.vpc.instance,
         endpoints: {
           management: args.vpc.endpoints?.management ?? false,
-          connection: args.vpc.endpoints?.connection ?? true,
+          connection: args.vpc.endpoints?.connection ?? false,
         },
       };
     }
 
-    function createVpcEndpoints() {
-      if (!vpc) return;
+    if (vpc) {
+      const managementEnabled = vpc.endpoints?.management ?? false;
+      const connectionEnabled = vpc.endpoints?.connection ?? false;
 
-      const endpointSecurityGroup = new ec2.SecurityGroup(
-        ...transform(
-          args.transform?.endpointSecurityGroup,
-          `${name}DsqlEndpointSecurityGroup`,
-          {
-            vpcId: vpc.instance.id,
-            description: "Allow DSQL access to VPC endpoints",
-            ingress: [
-              ...(vpc.endpoints.management
-                ? [
-                    {
-                      protocol: "tcp",
-                      fromPort: 443,
-                      toPort: 443,
-                      cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
-                    },
-                  ]
-                : []),
-              ...(vpc.endpoints.connection
-                ? [
-                    {
-                      protocol: "tcp",
-                      fromPort: 5432,
-                      toPort: 5432,
-                      cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
-                    },
-                  ]
-                : []),
-            ],
-            egress: [
-              {
-                protocol: "-1",
-                fromPort: 0,
-                toPort: 0,
-                cidrBlocks: ["0.0.0.0/0"],
-              },
-            ],
-          },
-          { parent },
-        ),
+      const endpointSg = new aws.ec2.SecurityGroup(
+        `${name}EndpointSg`,
+        {
+          vpcId: vpc.instance.id,
+          description: "Allow PostgreSQL access to DSQL VPC endpoints",
+          ingress: [
+            {
+              protocol: "tcp",
+              fromPort: 5432,
+              toPort: 5432,
+              cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
+            },
+          ],
+          egress: [
+            {
+              protocol: "-1",
+              fromPort: 0,
+              toPort: 0,
+              cidrBlocks: ["0.0.0.0/0"],
+            },
+          ],
+          tags: { Name: `${name}Endpoint` },
+        },
+        { parent },
       );
 
-      let management, connection;
-
-      if (vpc.endpoints.management) {
-        management = new ec2.VpcEndpoint(
-          ...transform(
-            args.transform?.managementEndpoint,
-            `${name}ManagementEndpoint`,
-            {
-              vpcId: vpc.instance.id,
-              serviceName: cluster.arn.apply((arn) => {
-                const region = arn.split(":")[3];
-                return `com.amazonaws.${region}.dsql`;
-              }),
-              vpcEndpointType: "Interface",
-              subnetIds: vpc.instance.privateSubnets,
-              privateDnsEnabled: true,
-              securityGroupIds: [endpointSecurityGroup.id],
-            },
-            { parent },
-          ),
+      if (managementEnabled) {
+        new aws.ec2.VpcEndpoint(
+          `${name}ManagementEndpoint`,
+          {
+            vpcId: vpc.instance.id,
+            serviceName: primaryCluster.arn.apply((arn) => {
+              const region = arn.split(":")[3];
+              return `com.amazonaws.${region}.dsql`;
+            }),
+            vpcEndpointType: "Interface",
+            subnetIds: vpc.instance.privateSubnets,
+            privateDnsEnabled: true,
+            tags: { Name: `${name}Management` },
+            securityGroupIds: [endpointSg.id],
+          },
+          { parent },
         );
       }
 
-      if (vpc.endpoints.connection) {
-        connection = new ec2.VpcEndpoint(
-          ...transform(
-            args.transform?.connectionEndpoint,
-            `${name}ConnectionEndpoint`,
-            {
-              vpcId: vpc.instance.id,
-              serviceName: cluster.vpcEndpointServiceName,
-              vpcEndpointType: "Interface",
-              subnetIds: vpc.instance.privateSubnets,
-              privateDnsEnabled: true,
-              securityGroupIds: [endpointSecurityGroup.id],
-            },
-            { parent },
-          ),
+      if (connectionEnabled) {
+        this.connectionEndpoint = new aws.ec2.VpcEndpoint(
+          `${name}ConnectionEndpoint`,
+          {
+            vpcId: vpc.instance.id,
+            serviceName: primaryCluster.vpcEndpointServiceName,
+            vpcEndpointType: "Interface",
+            subnetIds: vpc.instance.privateSubnets,
+            privateDnsEnabled: true,
+            tags: { Name: `${name}Connection` },
+            securityGroupIds: [endpointSg.id],
+          },
+          { parent },
         );
       }
-
-      return { connection, management };
     }
   }
 
-  /** The region of the cluster. */
-  public get region() {
-    return this.cluster.region;
+  private static publicEndpointFromArn(clusterArn: Output<string>) {
+    return clusterArn.apply((arn) => {
+      const parts = arn.split(":");
+      const region = parts[3];
+      const clusterId = parts[5].split("/")[1];
+      return `${clusterId}.dsql.${region}.on.aws`;
+    });
   }
 
-  /** The endpoint of the cluster. */
-  public get endpoint() {
-    // Use the private VPC endpoint hostname when available so linked functions
-    // inside the VPC don't route through the public IP.
-    return all([this.cluster.arn, this.connectionEndpoint?.dnsEntries]).apply(
-      ([arn, dns]) => {
-        if (!dns) {
-          return parseDsqlPublicEndpoint(arn);
-        }
-        return parseDsqlPrivateEndpoint(arn, dns);
-      },
-    );
+  private static regionFromArn(clusterArn: Output<string>) {
+    return clusterArn.apply((arn) => arn.split(":")[3]);
+  }
+
+  private static privateEndpointFromVpcEndpoint(
+    cluster: dsql.Cluster,
+    vpcEndpoint: aws.ec2.VpcEndpoint,
+  ): Output<string> {
+    return cluster.arn.apply((arn) => {
+      const clusterId = arn.split(":")[5].split("/")[1];
+      return vpcEndpoint.dnsEntries.apply((dnsEntries) => {
+        const wildcardEntry = dnsEntries.find(
+          (e) => e.dnsName?.startsWith("*."),
+        );
+        const privateDnsName = wildcardEntry?.dnsName ?? dnsEntries[0]?.dnsName;
+        return privateDnsName!.replace("*", clusterId);
+      });
+    });
+  }
+
+  /** The ARN of the primary cluster. */
+  public get arn() {
+    return this.cluster.arn;
+  }
+
+  /** The ARN of the peer cluster (multi-region only). */
+  public get peerArn(): Output<string> | undefined {
+    return this.peerCluster?.arn;
+  }
+
+  /** The identifier of the primary cluster. */
+  public get identifier() {
+    return this.cluster.identifier;
+  }
+
+  /** The identifier of the peer cluster (multi-region only). */
+  public get peerIdentifier(): Output<string> | undefined {
+    return this.peerCluster?.identifier;
   }
 
   /**
-   * The peer cluster info. Only available for multi-region clusters.
-   *
-   * @example
-   * ```ts title="sst.config.ts"
-   * const cluster = new sst.aws.Dsql("MyCluster", {
-   *   regions: { peer: "us-east-2" },
-   * });
-   *
-   * return {
-   *   peerRegion: cluster.peer.region,
-   *   peerEndpoint: cluster.peer.endpoint,
-   * };
-   * ```
+   * The public endpoint of the primary cluster.
+   * Format: `{identifier}.dsql.{region}.on.aws`
    */
-  public get peer() {
-    if (!this.peerCluster)
-      throw new VisibleError(
-        `Cannot access "peer" on "${this.constructorName}" because it is a single-region cluster. Set "regions.peer" to enable multi-region.`,
-      );
-    const peerCluster = this.peerCluster;
-    return {
-      /** The region of the peer cluster. */
-      region: peerCluster.region,
-      /** The endpoint of the peer cluster. */
-      endpoint: peerCluster.arn.apply(parseDsqlPublicEndpoint),
-    };
+  public get publicEndpoint() {
+    return Dsql.publicEndpointFromArn(this.cluster.arn);
   }
 
-  /** The underlying [resources](/docs/components/#nodes) this component creates. */
+  /** The public endpoint of the peer cluster (multi-region only). */
+  public get peerPublicEndpoint(): Output<string> | undefined {
+    return this.peerCluster
+      ? Dsql.publicEndpointFromArn(this.peerCluster.arn)
+      : undefined;
+  }
+
+  /** The region of the primary cluster. */
+  public get region() {
+    return Dsql.regionFromArn(this.cluster.arn);
+  }
+
+  /** The region of the peer cluster (multi-region only). */
+  public get peerRegion(): Output<string> | undefined {
+    return this.peerCluster
+      ? Dsql.regionFromArn(this.peerCluster.arn)
+      : undefined;
+  }
+
   public get nodes() {
     return {
-      /** The DSQL cluster. */
       cluster: this.cluster,
-      /** The peer DSQL cluster (multi-region only). */
       peerCluster: this.peerCluster,
     };
   }
@@ -488,77 +500,73 @@ export class Dsql extends Component implements Link.Linkable {
    * :::
    *
    * @example
-   *
-   * #### Single-region cluster
-   *
    * ```ts title="sst.config.ts"
    * const cluster = $app.stage === "frank"
-   *   ? sst.aws.Dsql.get("MyCluster", { id: "kzttrvbdg4k2o5ze2m2rrwdj7u" })
-   *   : new sst.aws.Dsql("MyCluster");
-   * ```
-   * #### Multi-region cluster
-   *
-   * ```ts title="sst.config.ts"
-   * const cluster = sst.aws.Dsql.get("MyCluster", {
-   *   id: "app-dev-mycluster",
-   *   peer: {
-   *     id: "kzttrvbdg4k2o5ze2m2rrwdj7u",
-   *     region: "us-east-2",
-   *   }
-   * });
+   * ? sst.aws.Dsql.get("MyCluster", "app-dev-mycluster")
+   * : new sst.aws.Dsql("MyCluster");
    * ```
    */
   public static get(
     name: string,
     args: {
-      id: Input<string>;
-      peer?: {
-        id: string;
-        region: string;
-      };
+      identifier: Input<string>;
+      peerIdentifier?: Input<string>;
+      peerRegion: Input<string>;
     },
     opts?: ComponentResourceOptions,
   ) {
     const cluster = dsql.Cluster.get(
       `${name}Cluster`,
-      args.id,
+      args.identifier,
       undefined,
       opts,
     );
 
-    const peerCluster = args.peer
-      ? dsql.Cluster.get(`${name}PeerCluster`, args.peer.id, undefined, {
-          ...opts,
-          provider: useProvider(args.peer.region as Region),
-        })
-      : undefined;
+    let peerCluster: dsql.Cluster | undefined;
 
-    return new Dsql(
-      name,
-      { ref: true, cluster, peerCluster } satisfies DsqlRef as unknown as DsqlArgs,
-      opts,
-    );
+    if (args.peerIdentifier && args.peerRegion) {
+      const peerProvider = useProvider(args.peerRegion as aws.Region);
+      peerCluster = dsql.Cluster.get(
+        `${name}PeerCluster`,
+        args.peerIdentifier,
+        undefined,
+        { ...opts, provider: peerProvider },
+      );
+    }
+
+    return new Dsql(name, { ref: true, cluster, peerCluster } as DsqlArgs);
   }
 
   /** @internal */
   public getSSTLink() {
+    const primaryEndpoint = this.connectionEndpoint
+      ? Dsql.privateEndpointFromVpcEndpoint(
+          this.cluster,
+          this.connectionEndpoint,
+        )
+      : this.publicEndpoint;
+
+    const peerEndpoint = this.peerCluster
+      ? Dsql.publicEndpointFromArn(this.peerCluster.arn)
+      : undefined;
+
     return {
       properties: {
         region: this.region,
-        endpoint: this.endpoint,
-        peer: this.peerCluster
-          ? {
-              region: this.peerCluster.region,
-              endpoint: this.peerCluster.arn.apply(parseDsqlPublicEndpoint),
-            }
-          : undefined,
+        endpoint: primaryEndpoint,
+        peer: {
+          region: this.peerCluster
+            ? Dsql.regionFromArn(this.peerCluster.arn)
+            : undefined,
+          endpoint: peerEndpoint,
+        },
       },
       include: [
         permission({
           actions: ["dsql:DbConnect", "dsql:DbConnectAdmin", "dsql:GetCluster"],
           resources: this.peerCluster
-            ? [this.cluster.arn, this.peerCluster.arn]
-            : [this.cluster.arn],
+            ? [this.arn, this.peerCluster.arn]
+            : [this.arn],
         }),
       ],
     };

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -41,10 +41,14 @@ export interface DsqlArgs {
   };
 
   /**
-   * Configure automatic backups for the cluster using AWS Backup. Set to `true`
-   * to use the defaults, or pass an object to customize the schedule and retention.
+   * Configure automatic backups for the cluster using AWS Backup.
+   *
+   * Set to `true` to use the defaults, or pass an object to customize the schedule and retention.
+   *
+   * :::tip
    * If multi-region is enabled, backups are scheduled in the current region and
    * copied to the peer region.
+   * :::
    *
    * Omit or set to `false` to skip backup creation entirely.
    *

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -43,7 +43,8 @@ export interface DsqlArgs {
   /**
    * Configure automatic backups for the cluster using AWS Backup. Set to `true`
    * to use the defaults, or pass an object to customize the schedule and retention.
-   * If multi-region is enabled, identical backup resources are created in both regions.
+   * If multi-region is enabled, backups are scheduled in the current region and
+   * copied to the peer region.
    *
    * Omit or set to `false` to skip backup creation entirely.
    *
@@ -322,24 +323,7 @@ export class Dsql extends Component implements Link.Linkable {
     const cluster = createCluster();
     const peerCluster = createPeerCluster();
     const endpoints = createVpcEndpoints();
-
-    if (backupConfig) {
-      createBackupSetup(
-        cluster,
-        backupConfig.schedule,
-        backupConfig.retention,
-      );
-
-      if (regions && peerCluster) {
-        createBackupSetup(
-          peerCluster,
-          backupConfig.schedule,
-          backupConfig.retention,
-          "Peer",
-          useProvider(regions.peer as Region),
-        );
-      }
-    }
+    createBackup();
 
     this.cluster = cluster;
     this.peerCluster = peerCluster;
@@ -402,15 +386,11 @@ export class Dsql extends Component implements Link.Linkable {
       return peerCluster;
     }
 
-    function createBackupSetup(
-      targetCluster: dsql.Cluster,
-      schedule: Input<string>,
-      retention: Input<number>,
-      suffix = "",
-      provider?: Provider,
-    ) {
+    function createBackup() {
+      if (!backupConfig) return;
+
       const role = new iam.Role(
-        `${name}BackupRole${suffix}`,
+        `${name}BackupRole`,
         {
           assumeRolePolicy: iam.assumeRolePolicyForPrincipal({
             Service: "backup.amazonaws.com",
@@ -419,46 +399,61 @@ export class Dsql extends Component implements Link.Linkable {
             "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
           ],
         },
-        { parent, provider },
+        { parent },
       );
 
-      const vault = new backup.Vault(
-        ...transform(
-          args.transform?.backupVault,
-          `${name}BackupVault${suffix}`,
-          {},
-          { parent, provider },
-        ),
-      );
+      const vault = createBackupVault();
+      const peerVault = regions
+        ? createBackupVault("Peer", useProvider(regions.peer as Region))
+        : undefined;
 
       const plan = new backup.Plan(
         ...transform(
           args.transform?.backupPlan,
-          `${name}BackupPlan${suffix}`,
+          `${name}BackupPlan`,
           {
             rules: [
               {
-                ruleName: `${name}BackupRule${suffix}`,
+                ruleName: `${name}BackupRule`,
                 targetVaultName: vault.name,
-                schedule,
+                schedule: backupConfig.schedule,
                 scheduleExpressionTimezone: "UTC",
-                lifecycle: { deleteAfter: retention },
+                lifecycle: { deleteAfter: backupConfig.retention },
+                copyActions: peerVault
+                  ? [
+                      {
+                        destinationVaultArn: peerVault.arn,
+                        lifecycle: { deleteAfter: backupConfig.retention },
+                      },
+                    ]
+                  : undefined,
               },
             ],
           },
-          { parent, provider },
+          { parent },
         ),
       );
 
       new backup.Selection(
         ...transform(
           args.transform?.backupSelection,
-          `${name}BackupSelection${suffix}`,
+          `${name}BackupSelection`,
           {
             planId: plan.id,
             iamRoleArn: role.arn,
-            resources: [targetCluster.arn],
+            resources: [cluster.arn],
           },
+          { parent },
+        ),
+      );
+    }
+
+    function createBackupVault(suffix = "", provider?: Provider) {
+      return new backup.Vault(
+        ...transform(
+          args.transform?.backupVault,
+          `${name}BackupVault${suffix}`,
+          {},
           { parent, provider },
         ),
       );
@@ -468,8 +463,11 @@ export class Dsql extends Component implements Link.Linkable {
       if (!args.backup) return;
 
       const config = args.backup === true ? {} : args.backup;
+
       return {
-        schedule: output(config.schedule).apply((v) => v ?? "cron(0 5 ? * * *)"),
+        schedule: output(config.schedule).apply(
+          (v) => v ?? "cron(0 5 ? * * *)",
+        ),
         retention: output(config.retention).apply((v) => toDays(v ?? "7 days")),
       };
     }

--- a/platform/src/components/aws/dsql.ts
+++ b/platform/src/components/aws/dsql.ts
@@ -1,13 +1,16 @@
-import { ComponentResourceOptions, Output, provider } from "@pulumi/pulumi";
+import { all, ComponentResourceOptions, Output } from "@pulumi/pulumi";
 import { Component, transform, Transform } from "../component";
 import { Link } from "../link";
-import { VisibleError } from "../error";
-import { dsql } from "@pulumi/aws";
+import { dsql, ec2, Region } from "@pulumi/aws";
 import { permission } from "./permission";
 import { useProvider } from "./helpers/provider";
 import { Vpc } from "./vpc";
-
+import {
+  parseDsqlPublicEndpoint,
+  parseDsqlPrivateEndpoint,
+} from "./helpers/arn";
 import type { Input } from "../input";
+import { VisibleError } from "../error";
 
 import * as aws from "@pulumi/aws";
 
@@ -15,28 +18,27 @@ export interface DsqlArgs {
   /**
    * Configure multi-region cluster peering.
    *
-   * Creates a primary cluster in the current region and a peer cluster in another region,
+   * Creates a cluster in the current region and a peer cluster in another region,
    * linked via a witness region. The witness must differ from both cluster regions.
    *
-   * See https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html#region-availability
+   * Learn more about [AWS DSQL regions](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html#region-availability).
    *
    * @example
+   *
    * ```ts
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   * regions: {
-   * witness: "us-west-2",
-   * peer: { region: "us-east-2" }
-   * }
+   *   regions: {
+   *     witness: "us-west-2",
+   *     peer: "us-east-2"
+   *   }
    * });
    * ```
    */
   regions?: {
     /** The witness region. Must differ from both cluster regions. */
     witness: Input<string>;
-    peer: {
-      /** The AWS region for the peer cluster. */
-      region: Input<string>;
-    };
+    /** The AWS region for the peer cluster. */
+    peer: Input<string>;
   };
 
   /**
@@ -100,37 +102,37 @@ export interface DsqlArgs {
   };
 
   /**
-   * :::note
-   * Currently only single region VPC is supported. Multi region coming soon.
-   * :::
    *
    * Create AWS PrivateLink interface endpoints in a VPC for private connectivity.
-   *
-   * Two endpoint types are supported:
-   * - **Management** — control plane ops (create, get, update, delete clusters).
-   * Service: `com.amazonaws.{region}.dsql`
-   * - **Connection** — PostgreSQL client connections.
-   * Service name is cluster-specific and resolved automatically.
+   * This allows lambdas placed inside a VPC without NAT gateways to connect to the DSQL instance.
    *
    * :::note
-   * The VPC endpoint security group allows inbound on port 5432 from within the VPC CIDR.
-   * Your Lambda must be in the same VPC. The Lambda's default security group allows all
-   * outbound traffic, so it can reach the endpoint on port 5432 without any extra config.
+   * Currently only single region VPC is supported.
    * :::
    *
-   *
    * @example
+   *
    * ```ts title="sst.config.ts"
-   * const vpc = new sst.aws.Vpc("MyVpc");
+   * const myVpc = new sst.aws.Vpc("MyVpc");
    *
    * const cluster = new sst.aws.Dsql("MyCluster", {
-   * vpc: {
-   * instance: vpc,
-   * endpoints: {
-   * management: true,
-   * connection: true,
-   * }
-   * }
+   *   vpc: myVpc
+   * });
+   * ```
+   *
+   * #### Customize VPC endpoints
+   *
+   * ```ts title="sst.config.ts"
+   * const myVpc = new sst.aws.Vpc("MyVpc");
+   *
+   * const cluster = new sst.aws.Dsql("MyCluster", {
+   *   vpc: {
+   *     instance: vpc,
+   *     endpoints: {
+   *       management: true,
+   *       connection: true,
+   *     }
+   *   }
    * });
    * ```
    */
@@ -139,10 +141,18 @@ export interface DsqlArgs {
     | {
         instance: Vpc;
         endpoints?: {
-          /** @default `false` */
-          management?: Input<boolean>;
-          /** @default `false` */
-          connection?: Input<boolean>;
+          /**
+           * Endpoint for control plane ops (create, get, update, delete clusters).
+           *
+           * @default `false`
+           */
+          management?: boolean;
+          /**
+           * Endpoint for PostgreSQL client connections.
+           *
+           * @default `true`
+           */
+          connection?: boolean;
         };
       };
 
@@ -151,10 +161,37 @@ export interface DsqlArgs {
    * resources.
    */
   transform?: {
+    /**
+     * Transform the DSQL cluster resource.
+     */
     cluster?: Transform<dsql.ClusterArgs>;
+    /**
+     * Transform the peer DSQL cluster resource.
+     */
     peerCluster?: Transform<dsql.ClusterArgs>;
+    /**
+     * Transform the EC2 security group resource for the DSQL VPC endpoints.
+     */
+    endpointSecurityGroup?: Transform<ec2.SecurityGroupArgs>;
+    /**
+     * Transform the EC2 VPC endpoint resource for DSQL management operations.
+     */
+    managementEndpoint?: Transform<ec2.VpcEndpointArgs>;
+    /**
+     * Transform the EC2 VPC endpoint resource for DSQL connections.
+     */
+    connectionEndpoint?: Transform<ec2.VpcEndpointArgs>;
+    /**
+     * Transform the AWS Backup vault resource.
+     */
     backupVault?: Transform<aws.backup.VaultArgs>;
+    /**
+     * Transform the AWS Backup plan resource.
+     */
     backupPlan?: Transform<aws.backup.PlanArgs>;
+    /**
+     * Transform the AWS Backup selection resource.
+     */
     backupSelection?: Transform<aws.backup.SelectionArgs>;
   };
 }
@@ -183,16 +220,34 @@ interface BackupResources {
  * const cluster = new sst.aws.Dsql("MyCluster");
  * ```
  *
+ * Once linked, you can connect to it from your function code.
+ *
+ * ```ts title="src/lambda.ts"
+ * import { Resource } from "sst";
+ * import { AuroraDSQLClient } from "@aws/aurora-dsql-node-postgres-connector";
+ *
+ * const client = new AuroraDSQLClient({
+ *   host: Resource.MyCluster.endpoint,
+ *   user: "admin",
+ * });
+ *
+ * await client.connect();
+ * const result = await client.query("SELECT NOW() as now");
+ * await client.end();
+ * ```
+ *
  * #### Multi-region cluster
  *
  * ```ts title="sst.config.ts"
  * const cluster = new sst.aws.Dsql("MyCluster", {
- * regions: {
- * witness: "us-west-2",
- * peer: { region: "us-east-2" }
- * }
+ *   regions: {
+ *     witness: "us-west-2",
+ *     peer: "us-east-2"
+ *   }
  * });
  * ```
+ *
+ * [Check out the full example](/docs/examples/#aws-dsql-multiregion).
  *
  * #### With private VPC endpoints
  *
@@ -200,12 +255,14 @@ interface BackupResources {
  * const vpc = new sst.aws.Vpc("MyVpc");
  *
  * const cluster = new sst.aws.Dsql("MyCluster", {
- * vpc: {
- * instance: vpc,
- * endpoints: { connection: true }
- * }
+ *   vpc: {
+ *     instance: vpc,
+ *     endpoints: { connection: true }
+ *   }
  * });
  * ```
+ *
+ * [Check out the full example](/docs/examples/#aws-dsql-vpc).
  *
  * #### With backups
  *
@@ -223,17 +280,37 @@ interface BackupResources {
  *
  * ```ts title="sst.config.ts"
  * new sst.aws.Function("MyFunction", {
- * handler: "src/lambda.handler",
- * link: [cluster]
+ *   handler: "src/lambda.handler",
+ *   link: [cluster]
  * });
  * ```
+ *
+ * You can also use Drizzle ORM to query your DSQL cluster.
+ * [Check out the Drizzle example](/docs/examples/#aws-dsql-drizzle).
+ *
+ * ---
+ *
+ * ### Cost
+ *
+ * Aurora DSQL is serverless and uses a pay-per-use pricing model. You are charged for
+ * database activity measured in _Distributed Processing Units_ (DPUs) at $8 per million
+ * DPUs, and storage at $0.33 per GB-month. When idle, usage scales to zero and you incur
+ * no DPU charges.
+ *
+ * There is a free tier of 100,000 DPUs and 1 GB of storage per month.
+ *
+ * For example, a single-region cluster averaging 1.3M DPUs per month with 15 GB of storage
+ * costs roughly 1.3 x $8 + 15 x $0.33 or **$15 per month**.
+ *
+ * Check out the [Aurora DSQL pricing](https://aws.amazon.com/rds/aurora/dsql/pricing/) for more details.
  *
  */
 
 export class Dsql extends Component implements Link.Linkable {
   private cluster: dsql.Cluster;
   private peerCluster: dsql.Cluster | undefined;
-  private connectionEndpoint: aws.ec2.VpcEndpoint | undefined;
+  private connectionEndpoint: ec2.VpcEndpoint | undefined;
+  private constructorName: string;
   private backup: BackupResources | undefined;
   private peerBackup: BackupResources | undefined;
 
@@ -243,6 +320,7 @@ export class Dsql extends Component implements Link.Linkable {
     opts: ComponentResourceOptions = {},
   ) {
     super(__pulumiType, name, args, opts);
+    this.constructorName = name;
 
     if (args && "ref" in args) {
       const ref = args as unknown as DsqlRef;
@@ -252,21 +330,22 @@ export class Dsql extends Component implements Link.Linkable {
     }
 
     const parent = this;
-    const multiRegion = args.regions;
+    const regions = args.regions;
 
-    const peerProvider = multiRegion
-      ? useProvider(multiRegion.peer.region as aws.Region)
-      : undefined;
+    if (regions && args.vpc)
+      throw new VisibleError(
+        `Cannot use "vpc" with multi-region "regions". VPC endpoints are only supported for single-region clusters.`,
+      );
 
-    const primaryCluster = createPrimaryCluster();
-    this.cluster = primaryCluster;
+    const vpc = normalizeVpc();
 
-    const createdPeerCluster = multiRegion ? createPeerCluster() : undefined;
-    this.peerCluster = createdPeerCluster;
+    const cluster = createCluster();
+    const peerCluster = createPeerCluster();
+    const endpoints = createVpcEndpoints();
 
-    if (multiRegion && createdPeerCluster && peerProvider) {
-      createPeerings(createdPeerCluster, peerProvider);
-    }
+    this.cluster = cluster;
+    this.peerCluster = peerCluster;
+    this.connectionEndpoint = endpoints?.connection;
 
     if (args.backup !== undefined) {
       const schedule = args.backup.schedule ?? "cron(0 12 ? * * *)";
@@ -279,23 +358,75 @@ export class Dsql extends Component implements Link.Linkable {
         );
       }
 
-      this.backup = createBackupSetup(
-        primaryCluster,
-        schedule,
-        timezone,
-        retention,
-      );
+      this.backup = createBackupSetup(cluster, schedule, timezone, retention);
 
-      if (multiRegion && createdPeerCluster && peerProvider) {
+      if (regions && peerCluster) {
         this.peerBackup = createBackupSetup(
-          createdPeerCluster,
+          peerCluster,
           schedule,
           timezone,
           retention,
-          peerProvider,
           "Peer",
+          useProvider(regions.peer as Region),
         );
       }
+    }
+
+    function createCluster() {
+      return new dsql.Cluster(
+        ...transform(
+          args.transform?.cluster,
+          `${name}Cluster`,
+          {
+            multiRegionProperties: regions
+              ? { witnessRegion: regions.witness }
+              : undefined,
+          },
+          { parent },
+        ),
+      );
+    }
+
+    function createPeerCluster() {
+      if (!regions) return;
+
+      const peerProvider = useProvider(regions.peer as Region);
+
+      const peerCluster = new dsql.Cluster(
+        ...transform(
+          args.transform?.peerCluster,
+          `${name}PeerCluster`,
+          {
+            multiRegionProperties: {
+              witnessRegion: regions.witness,
+            },
+          },
+          { parent, provider: peerProvider },
+        ),
+      );
+
+      // DSQL requires both clusters to declare each other — two-way handshake.
+      new dsql.ClusterPeering(
+        `${name}Peering1`,
+        {
+          identifier: cluster.identifier,
+          clusters: [peerCluster.arn],
+          witnessRegion: regions.witness,
+        },
+        { parent },
+      );
+
+      new dsql.ClusterPeering(
+        `${name}Peering2`,
+        {
+          identifier: peerCluster.identifier,
+          clusters: [cluster.arn],
+          witnessRegion: regions.witness,
+        },
+        { parent, provider: peerProvider },
+      );
+
+      return peerCluster;
     }
 
     function createBackupSetup(
@@ -303,8 +434,8 @@ export class Dsql extends Component implements Link.Linkable {
       schedule: Input<string>,
       timezone: Input<string>,
       retention: Input<number>,
+      suffix = "",
       provider?: aws.Provider,
-      suffix: string = "",
     ): BackupResources {
       const role = new aws.iam.Role(
         `${name}BackupRole${suffix}`,
@@ -335,7 +466,7 @@ export class Dsql extends Component implements Link.Linkable {
           {
             rules: [
               {
-                ruleName: `${name}BackupPlan`,
+                ruleName: `${name}BackupRule${suffix}`,
                 targetVaultName: vault.name,
                 schedule,
                 scheduleExpressionTimezone: timezone,
@@ -363,66 +494,6 @@ export class Dsql extends Component implements Link.Linkable {
       return { vault, plan, selection, role };
     }
 
-    function createPrimaryCluster() {
-      return new dsql.Cluster(
-        ...transform(
-          args.transform?.cluster,
-          `${name}Cluster`,
-          {
-            multiRegionProperties: multiRegion
-              ? { witnessRegion: multiRegion.witness }
-              : undefined,
-            tags: { Name: name },
-          },
-          { parent },
-        ),
-      );
-    }
-
-    function createPeerCluster() {
-      return new dsql.Cluster(
-        ...transform(
-          args.transform?.peerCluster,
-          `${name}PeerCluster`,
-          {
-            multiRegionProperties: {
-              witnessRegion: multiRegion!.witness,
-            },
-            tags: { Name: `${name}Peer` },
-          },
-          { parent, provider: peerProvider },
-        ),
-      );
-    }
-
-    function createPeerings(peer: dsql.Cluster, peerProv: aws.Provider) {
-      new dsql.ClusterPeering(
-        `${name}PrimaryPeering`,
-        {
-          identifier: primaryCluster.identifier,
-          clusters: [peer.arn],
-          witnessRegion: primaryCluster.multiRegionProperties.apply(
-            (p) => p?.witnessRegion!,
-          ),
-        },
-        { parent },
-      );
-
-      new dsql.ClusterPeering(
-        `${name}PeerPeering`,
-        {
-          identifier: peer.identifier,
-          clusters: [primaryCluster.arn],
-          witnessRegion: peer.multiRegionProperties.apply(
-            (p) => p?.witnessRegion!,
-          ),
-        },
-        { parent, provider: peerProv },
-      );
-    }
-
-    const vpc = normalizeVpc();
-
     function normalizeVpc() {
       if (!args.vpc) return undefined;
 
@@ -430,8 +501,8 @@ export class Dsql extends Component implements Link.Linkable {
         return {
           instance: args.vpc,
           endpoints: {
-            management: false as Input<boolean>,
-            connection: false as Input<boolean>,
+            management: false,
+            connection: true,
           },
         };
       }
@@ -440,158 +511,157 @@ export class Dsql extends Component implements Link.Linkable {
         instance: args.vpc.instance,
         endpoints: {
           management: args.vpc.endpoints?.management ?? false,
-          connection: args.vpc.endpoints?.connection ?? false,
+          connection: args.vpc.endpoints?.connection ?? true,
         },
       };
     }
 
-    if (vpc) {
-      const managementEnabled = vpc.endpoints?.management ?? false;
-      const connectionEnabled = vpc.endpoints?.connection ?? false;
+    function createVpcEndpoints() {
+      if (!vpc) return;
 
-      const endpointSg = new aws.ec2.SecurityGroup(
-        `${name}EndpointSg`,
-        {
-          vpcId: vpc.instance.id,
-          description: "Allow PostgreSQL access to DSQL VPC endpoints",
-          ingress: [
-            {
-              protocol: "tcp",
-              fromPort: 5432,
-              toPort: 5432,
-              cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
-            },
-          ],
-          egress: [
-            {
-              protocol: "-1",
-              fromPort: 0,
-              toPort: 0,
-              cidrBlocks: ["0.0.0.0/0"],
-            },
-          ],
-          tags: { Name: `${name}Endpoint` },
-        },
-        { parent },
+      const endpointSecurityGroup = new ec2.SecurityGroup(
+        ...transform(
+          args.transform?.endpointSecurityGroup,
+          `${name}DsqlEndpointSecurityGroup`,
+          {
+            vpcId: vpc.instance.id,
+            description: "Allow DSQL access to VPC endpoints",
+            ingress: [
+              ...(vpc.endpoints.management
+                ? [
+                    {
+                      protocol: "tcp",
+                      fromPort: 443,
+                      toPort: 443,
+                      cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
+                    },
+                  ]
+                : []),
+              ...(vpc.endpoints.connection
+                ? [
+                    {
+                      protocol: "tcp",
+                      fromPort: 5432,
+                      toPort: 5432,
+                      cidrBlocks: [vpc.instance.nodes.vpc.cidrBlock],
+                    },
+                  ]
+                : []),
+            ],
+            egress: [
+              {
+                protocol: "-1",
+                fromPort: 0,
+                toPort: 0,
+                cidrBlocks: ["0.0.0.0/0"],
+              },
+            ],
+          },
+          { parent },
+        ),
       );
 
-      if (managementEnabled) {
-        new aws.ec2.VpcEndpoint(
-          `${name}ManagementEndpoint`,
-          {
-            vpcId: vpc.instance.id,
-            serviceName: primaryCluster.arn.apply((arn) => {
-              const region = arn.split(":")[3];
-              return `com.amazonaws.${region}.dsql`;
-            }),
-            vpcEndpointType: "Interface",
-            subnetIds: vpc.instance.privateSubnets,
-            privateDnsEnabled: true,
-            tags: { Name: `${name}Management` },
-            securityGroupIds: [endpointSg.id],
-          },
-          { parent },
+      let management, connection;
+
+      if (vpc.endpoints.management) {
+        management = new ec2.VpcEndpoint(
+          ...transform(
+            args.transform?.managementEndpoint,
+            `${name}ManagementEndpoint`,
+            {
+              vpcId: vpc.instance.id,
+              serviceName: cluster.arn.apply((arn) => {
+                const region = arn.split(":")[3];
+                return `com.amazonaws.${region}.dsql`;
+              }),
+              vpcEndpointType: "Interface",
+              subnetIds: vpc.instance.privateSubnets,
+              privateDnsEnabled: true,
+              securityGroupIds: [endpointSecurityGroup.id],
+            },
+            { parent },
+          ),
         );
       }
 
-      if (connectionEnabled) {
-        this.connectionEndpoint = new aws.ec2.VpcEndpoint(
-          `${name}ConnectionEndpoint`,
-          {
-            vpcId: vpc.instance.id,
-            serviceName: primaryCluster.vpcEndpointServiceName,
-            vpcEndpointType: "Interface",
-            subnetIds: vpc.instance.privateSubnets,
-            privateDnsEnabled: true,
-            tags: { Name: `${name}Connection` },
-            securityGroupIds: [endpointSg.id],
-          },
-          { parent },
+      if (vpc.endpoints.connection) {
+        connection = new ec2.VpcEndpoint(
+          ...transform(
+            args.transform?.connectionEndpoint,
+            `${name}ConnectionEndpoint`,
+            {
+              vpcId: vpc.instance.id,
+              serviceName: cluster.vpcEndpointServiceName,
+              vpcEndpointType: "Interface",
+              subnetIds: vpc.instance.privateSubnets,
+              privateDnsEnabled: true,
+              securityGroupIds: [endpointSecurityGroup.id],
+            },
+            { parent },
+          ),
         );
       }
+
+      return { connection, management };
     }
   }
 
-  private static publicEndpointFromArn(clusterArn: Output<string>) {
-    return clusterArn.apply((arn) => {
-      const parts = arn.split(":");
-      const region = parts[3];
-      const clusterId = parts[5].split("/")[1];
-      return `${clusterId}.dsql.${region}.on.aws`;
-    });
+  /** The region of the cluster. */
+  public get region() {
+    return this.cluster.region;
   }
 
-  private static regionFromArn(clusterArn: Output<string>) {
-    return clusterArn.apply((arn) => arn.split(":")[3]);
-  }
-
-  private static privateEndpointFromVpcEndpoint(
-    cluster: dsql.Cluster,
-    vpcEndpoint: aws.ec2.VpcEndpoint,
-  ): Output<string> {
-    return cluster.arn.apply((arn) => {
-      const clusterId = arn.split(":")[5].split("/")[1];
-      return vpcEndpoint.dnsEntries.apply((dnsEntries) => {
-        const wildcardEntry = dnsEntries.find(
-          (e) => e.dnsName?.startsWith("*."),
-        );
-        const privateDnsName = wildcardEntry?.dnsName ?? dnsEntries[0]?.dnsName;
-        return privateDnsName!.replace("*", clusterId);
-      });
-    });
-  }
-
-  /** The ARN of the primary cluster. */
-  public get arn() {
-    return this.cluster.arn;
-  }
-
-  /** The ARN of the peer cluster (multi-region only). */
-  public get peerArn(): Output<string> | undefined {
-    return this.peerCluster?.arn;
-  }
-
-  /** The identifier of the primary cluster. */
-  public get identifier() {
-    return this.cluster.identifier;
-  }
-
-  /** The identifier of the peer cluster (multi-region only). */
-  public get peerIdentifier(): Output<string> | undefined {
-    return this.peerCluster?.identifier;
+  /** The endpoint of the cluster. */
+  public get endpoint() {
+    // Use the private VPC endpoint hostname when available so linked functions
+    // inside the VPC don't route through the public IP.
+    return all([this.cluster.arn, this.connectionEndpoint?.dnsEntries]).apply(
+      ([arn, dns]) => {
+        if (!dns) {
+          return parseDsqlPublicEndpoint(arn);
+        }
+        return parseDsqlPrivateEndpoint(arn, dns);
+      },
+    );
   }
 
   /**
-   * The public endpoint of the primary cluster.
-   * Format: `{identifier}.dsql.{region}.on.aws`
+   * The peer cluster info. Only available for multi-region clusters.
+   *
+   * @example
+   * ```ts title="sst.config.ts"
+   * const cluster = new sst.aws.Dsql("MyCluster", {
+   *   regions: { peer: "us-east-2" },
+   * });
+   *
+   * return {
+   *   peerRegion: cluster.peer.region,
+   *   peerEndpoint: cluster.peer.endpoint,
+   * };
+   * ```
    */
-  public get publicEndpoint() {
-    return Dsql.publicEndpointFromArn(this.cluster.arn);
+  public get peer() {
+    if (!this.peerCluster)
+      throw new VisibleError(
+        `Cannot access "peer" on "${this.constructorName}" because it is a single-region cluster. Set "regions.peer" to enable multi-region.`,
+      );
+    const peerCluster = this.peerCluster;
+    return {
+      /** The region of the peer cluster. */
+      region: peerCluster.region,
+      /** The endpoint of the peer cluster. */
+      endpoint: peerCluster.arn.apply(parseDsqlPublicEndpoint),
+    };
   }
 
-  /** The public endpoint of the peer cluster (multi-region only). */
-  public get peerPublicEndpoint(): Output<string> | undefined {
-    return this.peerCluster
-      ? Dsql.publicEndpointFromArn(this.peerCluster.arn)
-      : undefined;
-  }
-
-  /** The region of the primary cluster. */
-  public get region() {
-    return Dsql.regionFromArn(this.cluster.arn);
-  }
-
-  /** The region of the peer cluster (multi-region only). */
-  public get peerRegion(): Output<string> | undefined {
-    return this.peerCluster
-      ? Dsql.regionFromArn(this.peerCluster.arn)
-      : undefined;
-  }
-
+  /** The underlying [resources](/docs/components/#nodes) this component creates. */
   public get nodes() {
     return {
+      /** The DSQL cluster. */
       cluster: this.cluster,
+      /** The peer DSQL cluster (multi-region only). */
       peerCluster: this.peerCluster,
+      /** The backup resources (when backup is configured). */
       backup: this.backup
         ? {
             vault: this.backup.vault,
@@ -600,6 +670,7 @@ export class Dsql extends Component implements Link.Linkable {
             role: this.backup.role,
           }
         : undefined,
+      /** The peer backup resources (multi-region with backup only). */
       peerBackup: this.peerBackup
         ? {
             vault: this.peerBackup.vault,
@@ -620,73 +691,81 @@ export class Dsql extends Component implements Link.Linkable {
    * :::
    *
    * @example
+   *
+   * #### Single-region cluster
+   *
    * ```ts title="sst.config.ts"
    * const cluster = $app.stage === "frank"
-   * ? sst.aws.Dsql.get("MyCluster", "app-dev-mycluster")
-   * : new sst.aws.Dsql("MyCluster");
+   *   ? sst.aws.Dsql.get("MyCluster", { id: "kzttrvbdg4k2o5ze2m2rrwdj7u" })
+   *   : new sst.aws.Dsql("MyCluster");
+   * ```
+   * #### Multi-region cluster
+   *
+   * ```ts title="sst.config.ts"
+   * const cluster = sst.aws.Dsql.get("MyCluster", {
+   *   id: "app-dev-mycluster",
+   *   peer: {
+   *     id: "kzttrvbdg4k2o5ze2m2rrwdj7u",
+   *     region: "us-east-2",
+   *   }
+   * });
    * ```
    */
   public static get(
     name: string,
     args: {
-      identifier: Input<string>;
-      peerIdentifier?: Input<string>;
-      peerRegion: Input<string>;
+      id: Input<string>;
+      peer?: {
+        id: string;
+        region: string;
+      };
     },
     opts?: ComponentResourceOptions,
   ) {
     const cluster = dsql.Cluster.get(
       `${name}Cluster`,
-      args.identifier,
+      args.id,
       undefined,
       opts,
     );
 
-    let peerCluster: dsql.Cluster | undefined;
+    const peerCluster = args.peer
+      ? dsql.Cluster.get(`${name}PeerCluster`, args.peer.id, undefined, {
+          ...opts,
+          provider: useProvider(args.peer.region as Region),
+        })
+      : undefined;
 
-    if (args.peerIdentifier && args.peerRegion) {
-      const peerProvider = useProvider(args.peerRegion as aws.Region);
-      peerCluster = dsql.Cluster.get(
-        `${name}PeerCluster`,
-        args.peerIdentifier,
-        undefined,
-        { ...opts, provider: peerProvider },
-      );
-    }
-
-    return new Dsql(name, { ref: true, cluster, peerCluster } as DsqlArgs);
+    return new Dsql(
+      name,
+      {
+        ref: true,
+        cluster,
+        peerCluster,
+      } satisfies DsqlRef as unknown as DsqlArgs,
+      opts,
+    );
   }
 
   /** @internal */
   public getSSTLink() {
-    const primaryEndpoint = this.connectionEndpoint
-      ? Dsql.privateEndpointFromVpcEndpoint(
-          this.cluster,
-          this.connectionEndpoint,
-        )
-      : this.publicEndpoint;
-
-    const peerEndpoint = this.peerCluster
-      ? Dsql.publicEndpointFromArn(this.peerCluster.arn)
-      : undefined;
-
     return {
       properties: {
         region: this.region,
-        endpoint: primaryEndpoint,
-        peer: {
-          region: this.peerCluster
-            ? Dsql.regionFromArn(this.peerCluster.arn)
-            : undefined,
-          endpoint: peerEndpoint,
-        },
+        endpoint: this.endpoint,
+        peer: this.peerCluster
+          ? {
+              region: this.peerCluster.region,
+              endpoint: this.peerCluster.arn.apply(parseDsqlPublicEndpoint),
+            }
+          : undefined,
       },
       include: [
         permission({
           actions: ["dsql:DbConnect", "dsql:DbConnectAdmin", "dsql:GetCluster"],
           resources: this.peerCluster
-            ? [this.arn, this.peerCluster.arn]
-            : [this.arn],
+            ? [this.cluster.arn, this.peerCluster.arn]
+            : [this.cluster.arn],
         }),
       ],
     };

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -327,6 +327,9 @@ export class Component extends ComponentResource {
               { lower: true },
             ],
             "cloudflare:index/r2Bucket:R2Bucket": ["name", 64, { lower: true }],
+            "aws:backup/vault:Vault": ["name", 50],
+            "aws:backup/plan:Plan": ["name", 50],
+            "aws:backup/selection:Selection": ["name", 50],
             "cloudflare:index/workersScript:WorkersScript": [
               "scriptName",
               64,


### PR DESCRIPTION
Adds optional backup configuration to `sst.aws.Dsql`. When enabled, creates an AWS Backup vault, plan, selection, and IAM role for the cluster. For multi-region clusters, backup resources are mirrored in the peer region.

```ts
new sst.aws.Dsql("MyCluster", {
  backup: true
});
```

```ts
new sst.aws.Dsql("MyCluster", {
  backup: {
    schedule: "cron(0 2 ? * * *)",
    retention: "90 days"
  }
});
```

Backups are explicitly opt-in. `backup: true` enables the default plan: daily at 5 AM UTC with 7 day retention. Or pass an object to customize the schedule and retention.

Backup resources support transforms via `backupVault`, `backupPlan`, and `backupSelection`.

Also adds `aws:backup/vault:Vault`, `aws:backup/plan:Plan`, and `aws:backup/selection:Selection` to `namingRules` in `component.ts` (50 char limit) so SST auto-naming handles these resource types.

Design reasons
Explicit opt-in made the most sense since AWS Backup is a separate service.

For multi-region clusters, mirroring the backup plan in each region is simpler than copying backups across regions and avoids cross-region transfer costs.

Using AWS Backup cron expressions keeps the API close to what the service natively accepts.

Related to issue #6645