### PR TITLE
Fix nodejs.install package.json lookup

### DIFF
--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -256,7 +256,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 
 		if len(installPackages) > 0 {
 			log.Info("installing", "packages", installPackages)
-			src, err := fs.FindUp(filepath.Dir(target), "package.json")
+			src, err := fs.FindUp(filepath.Dir(file), "package.json")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
- resolve the `nodejs.install` package manifest lookup from the source handler path instead of the build artifact path
- avoid reading stale `.sst/artifacts/.../package.json` files during rebuilds
- fixes #6661