### PR TITLE
Improve Musl detection for Bun install

### DIFF
--- a/pkg/global/bun.go
+++ b/pkg/global/bun.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"debug/elf"
 	"fmt"
 	"io"
 	"log/slog"
@@ -54,16 +55,9 @@ func InstallBun(ctx context.Context) error {
 	goos := runtime.GOOS
 	arch := runtime.GOARCH
 
-	// Check for MUSL on Linux
 	isMusl := false
 	if goos == "linux" {
-		if _, err := os.Stat("/lib/ld-musl-x86_64.so.1"); err == nil {
-			isMusl = true
-		} else {
-			cmd := exec.Command("ldd", "--version")
-			output, _ := cmd.CombinedOutput()
-			isMusl = strings.Contains(strings.ToLower(string(output)), "musl")
-		}
+		isMusl = linuxUsesMusl()
 	}
 
 	var filename string
@@ -162,4 +156,65 @@ func InstallBun(ctx context.Context) error {
 		return nil, nil
 	})
 	return err
+}
+
+func linuxUsesMusl() bool {
+	isMusl, ok := muslFromLdd()
+	if ok {
+		return isMusl
+	}
+
+	for _, path := range []string{"/bin/sh", "/usr/bin/env", "/bin/busybox"} {
+		isMusl, ok := muslFromELF(path)
+		if ok {
+			return isMusl
+		}
+	}
+
+	return false
+}
+
+func muslFromLdd() (bool, bool) {
+	lddPath, err := exec.LookPath("ldd")
+	if err != nil {
+		return false, false
+	}
+
+	output, err := exec.Command(lddPath, "--version").CombinedOutput()
+	if err != nil && len(output) == 0 {
+		return false, false
+	}
+
+	return strings.Contains(strings.ToLower(string(output)), "musl"), true
+}
+
+func muslFromELF(path string) (bool, bool) {
+	interpreter, err := elfInterpreter(path)
+	if err != nil || interpreter == "" {
+		return false, false
+	}
+
+	return strings.Contains(strings.ToLower(interpreter), "musl"), true
+}
+
+func elfInterpreter(path string) (string, error) {
+	file, err := elf.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	for _, prog := range file.Progs {
+		if prog.Type != elf.PT_INTERP {
+			continue
+		}
+
+		interpreter, err := io.ReadAll(prog.Open())
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimRight(string(interpreter), "\x00"), nil
+	}
+
+	return "", fmt.Errorf("no ELF interpreter found for %s", path)
 }

--- a/pkg/global/bun.go
+++ b/pkg/global/bun.go
@@ -171,6 +171,16 @@ func linuxUsesMusl() bool {
 		}
 	}
 
+	isMusl, ok = muslFromAlpineRelease()
+	if ok {
+		return isMusl
+	}
+
+	isMusl, ok = muslFromLoaderPath()
+	if ok {
+		return isMusl
+	}
+
 	return false
 }
 
@@ -195,6 +205,34 @@ func muslFromELF(path string) (bool, bool) {
 	}
 
 	return strings.Contains(strings.ToLower(interpreter), "musl"), true
+}
+
+func muslFromAlpineRelease() (bool, bool) {
+	_, err := os.Stat("/etc/alpine-release")
+	if err == nil {
+		return true, true
+	}
+
+	return false, false
+}
+
+func muslFromLoaderPath() (bool, bool) {
+	var path string
+	switch runtime.GOARCH {
+	case "amd64":
+		path = "/lib/ld-musl-x86_64.so.1"
+	case "arm64":
+		path = "/lib/ld-musl-aarch64.so.1"
+	default:
+		return false, false
+	}
+
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, true
+	}
+
+	return false, false
 }
 
 func elfInterpreter(path string) (string, error) {


### PR DESCRIPTION
Fixes #6663

Remove MUSL detection based on the presence of `/lib/ld-musl-x86_64.so.1`. The previous approach produced false positives on systems where musl is installed alongside glibc (for example Arch Linux), as the file may exist without the system being musl-based or capable of running musl-linked binaries correctly (installing `musl` package on arch will add the `/lib/ld-musl-x86_64.so.1`  file to the system)

This change replaces file existence checks with runtime-based detection. First it attempt detection via `ldd`, then it fallback to inspecting known system binaries (`sh`, `env`, `busybox`)

For each fallback binary, we parse the ELF headers and inspect the `PT_INTERP` segment to determine the dynamic loader in use (e.g. `ld-musl-*` vs `ld-linux-*`). 