### PR TITLE
Make version type optional for core providers

### DIFF
--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -159,7 +159,11 @@ func (p *Project) writeTypes() error {
 	file.WriteString(`  interface Providers {` + "\n")
 	file.WriteString(`    providers?: {` + "\n")
 	for _, entry := range p.lock {
-		file.WriteString(`      "` + entry.Name + `"?:  (_` + entry.Alias + `.ProviderArgs & { package?: string, version: string }) | string;` + "\n")
+		versionField := "version: string"
+		if entry.Name == "aws" || entry.Name == "cloudflare" {
+			versionField = "version?: string"
+		}
+		file.WriteString(`      "` + entry.Name + `"?:  (_` + entry.Alias + `.ProviderArgs & { package?: string, ` + versionField + ` }) | string;` + "\n")
 	}
 	file.WriteString(`    }` + "\n")
 	file.WriteString(`  }` + "\n")


### PR DESCRIPTION
fixes #6666 - Generated provider types have version mandatory for core providers (aws and cloudflare) 

Commit 55c78cc of pull request Reject custom providers without an explicit version (#6643) introduced a bug where the type generated enforces provider version as mandatory, whereas the runtime implementation and intent (i think) is that for "aws" and "cloudflare" this should be optional