### PR TITLE
Add configurable S3 lifecycle rules for state bucket

### DIFF
--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -128,9 +129,12 @@ func (a *AwsProvider) Init(app string, stage string, args map[string]interface{}
 	if args["region"] == nil {
 		args["region"] = cfg.Region
 	}
-	_, err = a.Bootstrap(cfg.Region)
+	bootstrap, err := a.Bootstrap(cfg.Region)
 	if err != nil {
 		return err
+	}
+	if err := a.applyLifecycleRules(ctx, cfg, bootstrap); err != nil {
+		slog.Warn("failed to apply lifecycle rules", "error", err)
 	}
 	return nil
 }
@@ -198,6 +202,71 @@ func (p *AwsProvider) Bootstrap(region string) (*AwsBootstrapData, error) {
 	}
 	p.bootstrapCache[region] = bootstrapData
 	return bootstrapData, nil
+}
+
+func (a *AwsProvider) applyLifecycleRules(ctx context.Context, cfg aws.Config, data *AwsBootstrapData) error {
+	if os.Getenv("SST_LIFECYCLE") != "true" {
+		return nil
+	}
+
+	type prefixConfig struct {
+		name   string
+		prefix string
+		id     string
+	}
+
+	configs := []prefixConfig{
+		{"APP", "app/", "sst-app-cleanup"},
+		{"LOCK", "lock/", "sst-lock-cleanup"},
+		{"EVENTLOG", "eventlog/", "sst-eventlog-cleanup"},
+		{"SNAPSHOT", "snapshot/", "sst-snapshot-cleanup"},
+		{"UPDATE", "update/", "sst-update-cleanup"},
+	}
+
+	var rules []s3types.LifecycleRule
+	for _, c := range configs {
+		daysStr := os.Getenv("SST_LIFECYCLE_" + c.name + "_DAYS")
+		if daysStr == "" {
+			continue
+		}
+		days, err := strconv.Atoi(daysStr)
+		if err != nil || days <= 0 {
+			continue
+		}
+
+		rule := s3types.LifecycleRule{
+			ID:     aws.String(c.id),
+			Filter: &s3types.LifecycleRuleFilterMemberPrefix{Value: c.prefix},
+			Status: s3types.ExpirationStatusEnabled,
+			Expiration: &s3types.LifecycleExpiration{
+				Days: aws.Int32(int32(days)),
+			},
+			NoncurrentVersionExpiration: &s3types.NoncurrentVersionExpiration{
+				NoncurrentDays: aws.Int32(1),
+			},
+		}
+
+		versionsStr := os.Getenv("SST_LIFECYCLE_" + c.name + "_VERSIONS")
+		if versionsStr != "" {
+			if versions, err := strconv.Atoi(versionsStr); err == nil && versions > 0 {
+				rule.NoncurrentVersionExpiration.NewerNoncurrentVersions = aws.Int32(int32(versions))
+			}
+		}
+
+		rules = append(rules, rule)
+	}
+
+	if len(rules) == 0 {
+		return nil
+	}
+
+	slog.Info("applying lifecycle rules to state bucket", "bucket", data.State, "ruleCount", len(rules))
+	s3Client := s3.NewFromConfig(cfg)
+	_, err := s3Client.PutBucketLifecycleConfiguration(ctx, &s3.PutBucketLifecycleConfigurationInput{
+		Bucket:                 aws.String(data.State),
+		LifecycleConfiguration: &s3types.BucketLifecycleConfiguration{Rules: rules},
+	})
+	return err
 }
 
 func (app *AwsProvider) ResolveAppSync(ctx context.Context) (string, string, error) {

--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -205,7 +205,7 @@ func (p *AwsProvider) Bootstrap(region string) (*AwsBootstrapData, error) {
 }
 
 func (a *AwsProvider) applyLifecycleRules(ctx context.Context, cfg aws.Config, data *AwsBootstrapData) error {
-	if os.Getenv("SST_LIFECYCLE") != "true" {
+	if os.Getenv("SST_S3_LIFECYCLE") != "true" {
 		return nil
 	}
 
@@ -223,15 +223,33 @@ func (a *AwsProvider) applyLifecycleRules(ctx context.Context, cfg aws.Config, d
 		{"UPDATE", "update/", "sst-update-cleanup"},
 	}
 
+	// Default lifecycle values
+	defaults := map[string]struct{ days, versions int }{
+		"APP":       {days: 7, versions: 10},
+		"LOCK":      {days: 7, versions: 0},
+		"EVENTLOG":  {days: 7, versions: 0},
+		"SNAPSHOT":  {days: 30, versions: 0},
+		"UPDATE":    {days: 30, versions: 0},
+	}
+
 	var rules []s3types.LifecycleRule
 	for _, c := range configs {
-		daysStr := os.Getenv("SST_LIFECYCLE_" + c.name + "_DAYS")
+		daysStr := os.Getenv("SST_S3_LIFECYCLE_" + c.name + "_DAYS")
+		var days int
+		var err error
+
 		if daysStr == "" {
-			continue
-		}
-		days, err := strconv.Atoi(daysStr)
-		if err != nil || days <= 0 {
-			continue
+			// Use default value
+			if defaultConfig, ok := defaults[c.name]; ok {
+				days = defaultConfig.days
+			} else {
+				continue
+			}
+		} else {
+			days, err = strconv.Atoi(daysStr)
+			if err != nil || days <= 0 {
+				continue
+			}
 		}
 
 		rule := s3types.LifecycleRule{
@@ -246,11 +264,19 @@ func (a *AwsProvider) applyLifecycleRules(ctx context.Context, cfg aws.Config, d
 			},
 		}
 
-		versionsStr := os.Getenv("SST_LIFECYCLE_" + c.name + "_VERSIONS")
+		versionsStr := os.Getenv("SST_S3_LIFECYCLE_" + c.name + "_VERSIONS")
+		var versions int
 		if versionsStr != "" {
-			if versions, err := strconv.Atoi(versionsStr); err == nil && versions > 0 {
-				rule.NoncurrentVersionExpiration.NewerNoncurrentVersions = aws.Int32(int32(versions))
+			if v, err := strconv.Atoi(versionsStr); err == nil && v > 0 {
+				versions = v
 			}
+		} else if defaultConfig, ok := defaults[c.name]; ok && defaultConfig.versions > 0 {
+			// Use default version count
+			versions = defaultConfig.versions
+		}
+
+		if versions > 0 {
+			rule.NoncurrentVersionExpiration.NewerNoncurrentVersions = aws.Int32(int32(versions))
 		}
 
 		rules = append(rules, rule)


### PR DESCRIPTION
Problem: Over time the s3 storage usage exceeds multiple terabytes which causes increased costs and unnecessary storage usage. There should be an option to set sensible lifecycle rules for the sst state bucket.

## Summary
- Adds env-var-driven S3 lifecycle rules for the SST state bucket
- Master toggle `SST_S3_LIFECYCLE=true` (disabled by default)
- Per-prefix config for expiration days (`SST_S3_LIFECYCLE_{PREFIX}_DAYS`) and noncurrent version retention (`SST_S3_LIFECYCLE_{PREFIX}_VERSIONS`)
- Supports `app/`, `lock/`, `eventlog/`, `snapshot/`, `update/` prefixes
- Runs on every init (not a versioned bootstrap step), so config changes take effect immediately
- Non-fatal: failure logs a warning but doesn't block deploys

## Usage
```bash
export SST_S3_LIFECYCLE=true
export SST_S3_LIFECYCLE_APP_DAYS=7
export SST_S3_LIFECYCLE_APP_VERSIONS=10
export SST_S3_LIFECYCLE_LOCK_DAYS=7
export SST_S3_LIFECYCLE_EVENTLOG_DAYS=7
export SST_S3_LIFECYCLE_SNAPSHOT_DAYS=30
export SST_S3_LIFECYCLE_UPDATE_DAYS=30
```

## Issues

Closes https://github.com/anomalyco/sst/issues/6074
Closes https://github.com/anomalyco/sst/issues/4521