### PR TITLE
Validate handler paths during sst dev deployment

### DIFF
--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -134,13 +134,13 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
 	if input.Handler != "" {
 		if info, err := os.Stat(input.Handler); err != nil || !info.IsDir() {
-			return fmt.Errorf("Handler not found: %v", input.Handler)
+			return fmt.Errorf("handler not found: %v", input.Handler)
 		}
 	}
 
 	_, err := fs.FindUp(input.Handler, "go.mod")
 	if err != nil {
-		return fmt.Errorf("Handler not found: could not find go.mod for handler %v", input.Handler)
+		return fmt.Errorf("handler not found: could not find go.mod for handler %v", input.Handler)
 	}
 	return nil
 }

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -3,6 +3,7 @@ package golang
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -128,6 +129,20 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 		stderr,
 		cmd,
 	}, nil
+}
+
+func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
+	if input.Handler != "" {
+		if info, err := os.Stat(input.Handler); err != nil || !info.IsDir() {
+			return fmt.Errorf("Handler not found: %v", input.Handler)
+		}
+	}
+
+	_, err := fs.FindUp(input.Handler, "go.mod")
+	if err != nil {
+		return fmt.Errorf("Handler not found: could not find go.mod for handler %v", input.Handler)
+	}
+	return nil
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {

--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -41,7 +41,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 
 	file, ok := r.getFile(input)
 	if !ok {
-		return nil, fmt.Errorf("Handler not found: %v", input.Handler)
+		return nil, fmt.Errorf("handler not found: %v", input.Handler)
 	}
 
 	isESM := true

--- a/pkg/runtime/node/node.go
+++ b/pkg/runtime/node/node.go
@@ -267,7 +267,7 @@ func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
 	}
 	_, ok := findHandlerFile(rootDir, input.Handler)
 	if !ok {
-		return fmt.Errorf("Handler not found: %v", input.Handler)
+		return fmt.Errorf("handler not found: %v", input.Handler)
 	}
 	return nil
 }

--- a/pkg/runtime/node/node.go
+++ b/pkg/runtime/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -242,20 +243,33 @@ func (r *Runtime) Match(runtime string) bool {
 	return strings.HasPrefix(runtime, "node")
 }
 
-func (r *Runtime) getFile(input *runtime.BuildInput) (string, bool) {
-	dir := filepath.Dir(input.Handler)
-	fileSplit := strings.Split(filepath.Base(input.Handler), ".")
+func findHandlerFile(rootDir string, handler string) (string, bool) {
+	dir := filepath.Dir(handler)
+	fileSplit := strings.Split(filepath.Base(handler), ".")
 	base := strings.Join(fileSplit[:len(fileSplit)-1], ".")
 	for _, ext := range NODE_EXTENSIONS {
-		file := filepath.Join(dir, base+ext)
-		if !filepath.IsAbs(file) {
-			file = filepath.Join(path.ResolveRootDir(input.CfgPath), file)
-		}
+		file := filepath.Join(rootDir, dir, base+ext)
 		if _, err := os.Stat(file); err == nil {
 			return file, true
 		}
 	}
 	return "", false
+}
+
+func (r *Runtime) getFile(input *runtime.BuildInput) (string, bool) {
+	return findHandlerFile(path.ResolveRootDir(input.CfgPath), input.Handler)
+}
+
+func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
+	rootDir := path.ResolveRootDir(input.CfgPath)
+	if input.Bundle != "" {
+		rootDir = input.Bundle
+	}
+	_, ok := findHandlerFile(rootDir, input.Handler)
+	if !ok {
+		return fmt.Errorf("Handler not found: %v", input.Handler)
+	}
+	return nil
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -182,7 +182,7 @@ func (r *PythonRuntime) ValidateHandler(input *runtime.BuildInput) error {
 	}
 	_, err := findHandlerFile(rootDir, input.Handler)
 	if err != nil {
-		return fmt.Errorf("Handler not found: %v", input.Handler)
+		return fmt.Errorf("handler not found: %v", input.Handler)
 	}
 	return nil
 }

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -175,6 +175,18 @@ func (r *PythonRuntime) Run(ctx context.Context, input *runtime.RunInput) (runti
 
 }
 
+func (r *PythonRuntime) ValidateHandler(input *runtime.BuildInput) error {
+	rootDir := path.ResolveRootDir(input.CfgPath)
+	if input.Bundle != "" {
+		rootDir = input.Bundle
+	}
+	_, err := findHandlerFile(rootDir, input.Handler)
+	if err != nil {
+		return fmt.Errorf("Handler not found: %v", input.Handler)
+	}
+	return nil
+}
+
 func (r *PythonRuntime) ShouldRebuild(functionID string, file string) bool {
 	// Assume that the build is always stale. We could do a better job here but bc of how the build
 	// process actually works its not a slowdown as the real slow part is starting the python interpreter
@@ -382,23 +394,23 @@ func (r *PythonRuntime) CreateBuildAsset(ctx context.Context, input *runtime.Bui
 	}
 }
 
-func (r *PythonRuntime) getFile(input *runtime.BuildInput) (string, error) {
-	slog.Info("looking for python handler file", "handler", input.Handler)
+func findHandlerFile(rootDir string, handler string) (string, error) {
+	dir := filepath.Dir(handler)
+	base := strings.TrimSuffix(filepath.Base(handler), filepath.Ext(handler))
 
-	dir := filepath.Dir(input.Handler)
-	base := strings.TrimSuffix(filepath.Base(input.Handler), filepath.Ext(input.Handler))
-	rootDir := path.ResolveRootDir(input.CfgPath)
-
-	// Look for .py file
 	pythonFile := filepath.Join(rootDir, dir, base+".py")
 	if _, err := os.Stat(pythonFile); err == nil {
 		return pythonFile, nil
 	}
 
-	// No Python file found for the handler
 	return "", fmt.Errorf("could not find Python file '%s.py' in directory '%s'",
 		base,
 		filepath.Join(rootDir, dir))
+}
+
+func (r *PythonRuntime) getFile(input *runtime.BuildInput) (string, error) {
+	slog.Info("looking for python handler file", "handler", input.Handler)
+	return findHandlerFile(path.ResolveRootDir(input.CfgPath), input.Handler)
 }
 
 func copyFile(src, dst string) error {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -103,7 +103,7 @@ func (c *Collection) Build(ctx context.Context, input *BuildInput) (*BuildOutput
 		out = input.Bundle
 		runtime, ok := c.Runtime(input.Runtime)
 		if !ok {
-			return nil, fmt.Errorf("Runtime not found: %v", input.Runtime)
+			return nil, fmt.Errorf("runtime not found: %v", input.Runtime)
 		}
 		if err := runtime.ValidateHandler(input); err != nil {
 			return nil, err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -20,6 +20,7 @@ type Runtime interface {
 	Build(ctx context.Context, input *BuildInput) (*BuildOutput, error)
 	Run(ctx context.Context, input *RunInput) (Worker, error)
 	ShouldRebuild(functionID string, path string) bool
+	ValidateHandler(input *BuildInput) error
 }
 
 type Worker interface {
@@ -100,6 +101,13 @@ func (c *Collection) Build(ctx context.Context, input *BuildInput) (*BuildOutput
 
 	if input.Bundle != "" {
 		out = input.Bundle
+		runtime, ok := c.Runtime(input.Runtime)
+		if !ok {
+			return nil, fmt.Errorf("Runtime not found: %v", input.Runtime)
+		}
+		if err := runtime.ValidateHandler(input); err != nil {
+			return nil, err
+		}
 		result = &BuildOutput{
 			Handler: input.Handler,
 			Errors:  []string{},

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -26,6 +26,9 @@ func (m *mockRuntime) Run(ctx context.Context, input *runtime.RunInput) (runtime
 func (m *mockRuntime) ShouldRebuild(functionID string, path string) bool {
 	return false
 }
+func (m *mockRuntime) ValidateHandler(input *runtime.BuildInput) error {
+	return nil
+}
 
 func TestBuildInputOut(t *testing.T) {
 	cfgPath := filepath.Join("/project", "sst.config.ts")

--- a/pkg/runtime/rust/rust.go
+++ b/pkg/runtime/rust/rust.go
@@ -81,6 +81,10 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	var properties Properties
 	json.Unmarshal(input.Properties, &properties)
 
+	if err := r.ValidateHandler(input); err != nil {
+		return nil, err
+	}
+
 	// split handler into path and function name
 	parts := strings.Split(input.Handler, ".")
 	handler := strings.Join(parts[:len(parts)-1], ".")

--- a/pkg/runtime/rust/rust.go
+++ b/pkg/runtime/rust/rust.go
@@ -204,7 +204,7 @@ func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
 
 	if handler != "" {
 		if info, err := os.Stat(handler); err != nil || !info.IsDir() {
-			return fmt.Errorf("Handler not found: %v", input.Handler)
+			return fmt.Errorf("handler not found: %v", input.Handler)
 		}
 	}
 
@@ -212,7 +212,7 @@ func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
 	if err != nil {
 		_, err = fs.FindUp(handler, "Cargo.toml")
 		if err != nil {
-			return fmt.Errorf("Handler not found: could not find Cargo.toml for handler %v", input.Handler)
+			return fmt.Errorf("handler not found: could not find Cargo.toml for handler %v", input.Handler)
 		}
 	}
 	return nil

--- a/pkg/runtime/rust/rust.go
+++ b/pkg/runtime/rust/rust.go
@@ -194,6 +194,26 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	}, nil
 }
 
+func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
+	parts := strings.Split(input.Handler, ".")
+	handler := strings.Join(parts[:len(parts)-1], ".")
+
+	if handler != "" {
+		if info, err := os.Stat(handler); err != nil || !info.IsDir() {
+			return fmt.Errorf("Handler not found: %v", input.Handler)
+		}
+	}
+
+	_, err := fs.FindUp(handler, "cargo.toml")
+	if err != nil {
+		_, err = fs.FindUp(handler, "Cargo.toml")
+		if err != nil {
+			return fmt.Errorf("Handler not found: could not find Cargo.toml for handler %v", input.Handler)
+		}
+	}
+	return nil
+}
+
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
 	// copied from go
 	if !strings.HasSuffix(file, ".rs") {

--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -179,16 +179,32 @@ func (w *Runtime) Match(runtime string) bool {
 	return runtime == "worker"
 }
 
-func (w *Runtime) getFile(input *runtime.BuildInput) (string, bool) {
-	dir := filepath.Dir(input.Handler)
-	base := strings.Split(filepath.Base(input.Handler), ".")[0]
+func findHandlerFile(rootDir string, handler string) (string, bool) {
+	dir := filepath.Dir(handler)
+	base := strings.Split(filepath.Base(handler), ".")[0]
 	for _, ext := range node.NODE_EXTENSIONS {
-		file := filepath.Join(path.ResolveRootDir(input.CfgPath), dir, base+ext)
+		file := filepath.Join(rootDir, dir, base+ext)
 		if _, err := os.Stat(file); err == nil {
 			return file, true
 		}
 	}
 	return "", false
+}
+
+func (w *Runtime) getFile(input *runtime.BuildInput) (string, bool) {
+	return findHandlerFile(path.ResolveRootDir(input.CfgPath), input.Handler)
+}
+
+func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
+	rootDir := path.ResolveRootDir(input.CfgPath)
+	if input.Bundle != "" {
+		rootDir = input.Bundle
+	}
+	_, ok := findHandlerFile(rootDir, input.Handler)
+	if !ok {
+		return fmt.Errorf("Handler not found: %v", input.Handler)
+	}
+	return nil
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {

--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -202,7 +202,7 @@ func (r *Runtime) ValidateHandler(input *runtime.BuildInput) error {
 	}
 	_, ok := findHandlerFile(rootDir, input.Handler)
 	if !ok {
-		return fmt.Errorf("Handler not found: %v", input.Handler)
+		return fmt.Errorf("handler not found: %v", input.Handler)
 	}
 	return nil
 }

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"net/rpc"
 
 	"github.com/sst/sst/v3/pkg/bus"
@@ -24,6 +25,14 @@ func (r *Runtime) Build(input *runtime.BuildInput, output *runtime.BuildOutput) 
 }
 
 func (r *Runtime) AddTarget(input *runtime.BuildInput, output *bool) error {
+	input.CfgPath = r.project.PathConfig()
+	rt, ok := r.project.Runtime.Runtime(input.Runtime)
+	if !ok {
+		return fmt.Errorf("Runtime not found: %v", input.Runtime)
+	}
+	if err := rt.ValidateHandler(input); err != nil {
+		return err
+	}
 	bus.Publish(input)
 	*output = true
 	return nil

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -28,7 +28,7 @@ func (r *Runtime) AddTarget(input *runtime.BuildInput, output *bool) error {
 	input.CfgPath = r.project.PathConfig()
 	rt, ok := r.project.Runtime.Runtime(input.Runtime)
 	if !ok {
-		return fmt.Errorf("Runtime not found: %v", input.Runtime)
+		return fmt.Errorf("runtime not found: %v", input.Runtime)
 	}
 	if err := rt.ValidateHandler(input); err != nil {
 		return err


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6680

## Summary

- Added `ValidateHandler` method to the `Runtime` interface, implemented across all runtimes (Node, Python, Go, Rust, Worker)
- `Runtime.AddTarget` RPC now validates handler paths before registering targets, so `sst dev` catches invalid handlers during deployment instead of at invocation time
- Added handler validation for the `bundle` case in `Collection.Build`, which previously skipped all checks
- Workers already performed a build step during `sst dev` so this was not an issue previously, but added `ValidateHandler` for consistency with the other runtimes

## Before/After

Videos below demonstrate the developer experience for each runtime when an invalid handler path is provided. Previously, when you ran `sst dev`, no error appeared during deployment if you specified an invalid handler path (e.g., a non-existent file). The error only became apparent when you invoked the function. Now, the error is displayed immediately during deployment.

<details><summary>Lambda Node.JS</summary>
<p>
Before:

https://github.com/user-attachments/assets/79688870-46fa-4370-8671-3e2dbd131d93

After:

https://github.com/user-attachments/assets/3ef4e317-e045-40b7-875c-03a478510d74

</p>
</details> 

<details><summary>Lambda Golang</summary>
<p>
Before:


https://github.com/user-attachments/assets/3ab63525-e38e-4fed-9a5d-c69e6ca35518

After:

https://github.com/user-attachments/assets/12cc0cf1-b598-4f3e-866c-9e37c68efc55



</p>
</details> 

<details><summary>Lambda Python</summary>
<p>

Before:

https://github.com/user-attachments/assets/f73175d1-9707-40e8-be66-3621f7c2e8f4

After:

https://github.com/user-attachments/assets/9be39f87-50a6-4f92-b367-2a4f82e31e9b




</p>
</details> 

<details><summary>Lambda Rust</summary>
<p>

Before:

https://github.com/user-attachments/assets/8d0b3f73-46d7-4851-8739-1e3b0af88641

After:

https://github.com/user-attachments/assets/572c4250-7a1a-4c95-acb1-6ac2c2424602




</p>
</details> 

<details><summary>Cloudflare Workers</summary>
<p>

Workers already performed a build step during sst dev so this was not an issue previously, but added ValidateHandler for consistency with the other runtimes.

https://github.com/user-attachments/assets/0479feec-4815-4280-9436-d94074941cab

</p>
</details> 

## Test plan

- [x] `sst dev` with invalid handler path — verify error surfaces during deployment (Node, Python, Go, Rust, Workers)
- [x] `sst dev` with valid handler path — verify no regression (Node, Python, Go, Rust, Workers)
- [x] `sst deploy` with invalid handler — verify existing behavior unchanged (Node, Python, Go, Rust, Workers)
  - Note that previously with Rust only, you could provide an invalid handler (e.g., `non/existent.aws-rust-lambda`), but SST deploy did not throw any errors. SST essentially treated it as if you had provided the following handler: `.aws-rust-lambda`. Now, `sst deploy` will throw an error in the same way that `sst dev` currently does for invalid handlers.
- [x] `sst deploy` with valid handler path — verify no regression (Node, Python, Go, Rust, Workers)