### PR TITLE
Support hyperdrive and worker version metadata bindings

### DIFF
--- a/pkg/types/typescript/typescript.go
+++ b/pkg/types/typescript/typescript.go
@@ -13,12 +13,14 @@ import (
 )
 
 var mapping = map[string]string{
-	"aiBindings":          "Ai",
-	"r2BucketBindings":    "R2Bucket",
-	"d1DatabaseBindings":  "D1Database",
-	"kvNamespaceBindings": "KVNamespace",
-	"queueBindings":       "Queue",
-	"serviceBindings":     "Service",
+	"aiBindings":               "Ai",
+	"r2BucketBindings":         "R2Bucket",
+	"d1DatabaseBindings":       "D1Database",
+	"kvNamespaceBindings":      "KVNamespace",
+	"queueBindings":            "Queue",
+	"serviceBindings":          "Service",
+	"hyperdriveBindings":       "Hyperdrive",
+	"versionMetadataBindings":  "WorkerVersionMetadata",
 }
 
 func Generate(root string, links common.Links) error {

--- a/platform/src/components/cloudflare/binding.ts
+++ b/platform/src/components/cloudflare/binding.ts
@@ -67,6 +67,18 @@ export interface D1DatabaseBinding {
   };
 }
 
+export interface HyperdriveBinding {
+  type: "hyperdriveBindings";
+  properties: {
+    id: Input<string>;
+  };
+}
+
+export interface VersionMetadataBinding {
+  type: "versionMetadataBindings";
+  properties: Record<string, never>;
+}
+
 export type Binding =
   | AiBinding
   | KvBinding
@@ -75,7 +87,9 @@ export type Binding =
   | PlainTextBinding
   | QueueBinding
   | R2BucketBinding
-  | D1DatabaseBinding;
+  | D1DatabaseBinding
+  | HyperdriveBinding
+  | VersionMetadataBinding;
 
 export function binding<T extends Binding["type"]>(input: Binding & {}) {
   return {

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -404,6 +404,8 @@ export class Worker extends Component implements Link.Linkable {
                     kvNamespaceBindings: "kv_namespace",
                     d1DatabaseBindings: "d1",
                     r2BucketBindings: "r2_bucket",
+                    hyperdriveBindings: "hyperdrive",
+                    versionMetadataBindings: "version_metadata",
                   }[b.binding],
                   name,
                   ...b.properties,


### PR DESCRIPTION
This PR adds hyperdrive and worker version metadata to the supported bindings mappings. (Closes #6690)

I tried to work around this with this wrapper component that I thought was clever:

```typescript
import type { WorkerVersionMetadata } from "@cloudflare/workers-types";

export class VersionMetadata extends $util.ComponentResource {
  #resourceName: string;

  constructor(name: string) {
    super(__pulumiType, name);
    this.#resourceName = name;
  }

  getSSTLink() {
    return {
      // Placeholders for type generation
      properties: {
        id: "",
        tag: "",
        timestamp: "",
      } satisfies WorkerVersionMetadata,
      include: [
        {
          type: "cloudflare.binding",
          binding: "versionMetadata",
          properties: {
            type: "version_metadata",
            name: this.#resourceName,
          },
        },
      ],
    };
  }
}

const __pulumiType = "sst:cloudflare:VersionMetadata";
// @ts-expect-error
VersionMetadata.__pulumiType = __pulumiType;
```

It worked as expected, binding the worker version metadata to the worker, but the type generation produced:

```typescript
// cloudflare 
import * as cloudflare from "@cloudflare/workers-types";
declare module "sst" {
  export interface Resource {
    "Api": cloudflare.Service
    "Hyperdrive": cloudflare.
    "MailJobDLQ": cloudflare.Queue
    "MailJobQueue": cloudflare.Queue
    "VersionMetadata": cloudflare.
  }
}
```

Where the two bindings not supported are generated incomplete as they're not in the mapping. Naming in the mapping can be changed if needed.