### PR TITLE
Docs/Providers Directory: Update Neon Provider Link

### DIFF
--- a/www/src/content/docs/docs/all-providers.mdx
+++ b/www/src/content/docs/docs/all-providers.mdx
@@ -198,7 +198,7 @@ If you want SST to support a Terraform provider or update a version, you can **s
 | [MongoDB Atlas](https://www.pulumi.com/registry/packages/mongodbatlas) | `mongodbatlas` |
 | [MSSQL](https://www.pulumi.com/registry/packages/mssql) | `@pulumiverse/mssql` |
 | [MySQL](https://www.pulumi.com/registry/packages/mysql) | `mysql` |
-| [Neon](https://github.com/kislerdm/terraform-provider-neon) | `neon` |
+| [Neon](https://www.pulumi.com/registry/packages/neon) | `neon` |
 | [New Relic](https://www.pulumi.com/registry/packages/newrelic) | `newrelic` |
 | [NGINX Ingress Controller](https://www.pulumi.com/registry/packages/kubernetes-ingress-nginx/) | `kubernetes-ingress-nginx` |
 | [ngrok](https://www.pulumi.com/registry/packages/ngrok) | `@pierskarsenbarg/ngrok` |


### PR DESCRIPTION
- Update the Neon Provider link to be the Pulumi Neon Provider page.
- This should facilitate getting started with Neon quicker by linking right to the relevant resources users will use with sst (neon.Branch, noen.Database and so on), rather than the old link which goes to the Neon terraform provider github.

<img width="1512" height="982" alt="Screenshot 2026-04-07 at 5 12 13 PM" src="https://github.com/user-attachments/assets/a1e2d0a6-12e5-433d-85c6-a89e9addf3f5" />
