### PR TITLE
Add Stripe official to providers list

### DIFF
--- a/www/src/content/docs/docs/all-providers.mdx
+++ b/www/src/content/docs/docs/all-providers.mdx
@@ -240,6 +240,7 @@ If you want SST to support a Terraform provider or update a version, you can **s
 | [Statuscake](https://www.pulumi.com/registry/packages/statuscake) | `@pulumiverse/statuscake` |
 | [Strata Cloud Manager](https://www.pulumi.com/registry/packages/scm) | `scm` |
 | [Stripe](https://github.com/georgegebbett/pulumi-stripe) | `stripe` |
+| [Stripe Official](https://github.com/stripe/terraform-provider-stripe) | `stripe-official` |
 | [StrongDM](https://www.pulumi.com/registry/packages/sdm/) | `@pierskarsenbarg/sdm` |
 | [Sumo Logic](https://www.pulumi.com/registry/packages/sumologic) | `sumologic` |
 | [Supabase](https://github.com/sst/pulumi-supabase) | `supabase` |


### PR DESCRIPTION
## Summary

- Add the official Stripe Terraform provider (`stripe-official`) to the supported providers list
