### PR TITLE
Fix bridge task in dev mode when `entrypoint/command` is defined

### DIFF
--- a/platform/src/components/aws/task.ts
+++ b/platform/src/components/aws/task.ts
@@ -345,6 +345,8 @@ export class Task extends Component implements Link.Linkable {
             return [
               {
                 ...v[0],
+                entrypoint: undefined,
+                command: undefined,
                 image: output("ghcr.io/anomalyco/sst/bridge-task:latest"),
                 environment: {
                   ...v[0].environment,


### PR DESCRIPTION
**Problem:** Currently, if you define a task with either `command` and / or `entrypoint` and run `sst dev`, the bridge task definition is created incorrectly with the custom command. This prevents the bridge `main` from being executed and the task does not work. 

<img width="1088" height="699" alt="Screenshot 2026-04-10 at 12 39 11 AM" src="https://github.com/user-attachments/assets/6bfd6053-0d46-474e-b854-c91b630fcbd6" />

**Expected Behavior:** When a bridge task is created in `dev`, we should always get `/app/main` as the command in the task definition so that the tunneling / forwarding functionality works.

**Fix:** The cause was the spread operator in `v[0]` in `/aws/task.ts`. Added code to ensure `command` and `entrypoint` are not passed on in dev mode.