### PR TITLE
Fix Cloudflare breaking with +50 zones

### DIFF
--- a/platform/src/components/cloudflare/providers/zone-lookup.ts
+++ b/platform/src/components/cloudflare/providers/zone-lookup.ts
@@ -43,6 +43,7 @@ class Provider implements dynamic.ResourceProvider {
     try {
       const qs = new URLSearchParams({
         per_page: "50",
+        page: String(page),
         "account.id": inputs.accountId,
       }).toString();
       const ret = await cfFetch<{ name: string; id: string }[]>(


### PR DESCRIPTION
## The bug

`Provider.lookup()` in [`platform/src/components/cloudflare/providers/zone-lookup.ts`](https://github.com/anomalyco/sst/blob/dev/platform/src/components/cloudflare/providers/zone-lookup.ts) builds the Cloudflare `/zones` API query string with `per_page` and `account.id` but **never includes the `page` parameter**. When the target zone isn't in the first 50 results, the method recurses with `page + 1`, but because `page` was never in the URL, every recursive call fetches the same first 50 zones forever.

The break condition on line 58 — `ret.result.length < ret.result_info!.per_page` — is only true on the actual last page, which the loop never reaches because it's stuck on page 1. The dynamic JS provider subprocess blocks indefinitely in libuv's `io_poll` and `sst deploy` hangs silently: no error, no log output. The Pulumi event log shows the preceding resource completing and then nothing.

```diff
 const qs = new URLSearchParams({
   per_page: "50",
+  page: String(page),
   "account.id": inputs.accountId,
 }).toString();
```

## Who's affected

Any SST user whose Cloudflare account has **more than 50 zones** AND whose target zone isn't in the first 50 results. The Cloudflare API default order is alphabetical by zone name, so the first zone affected is whatever zone sits at alphabetical position 51 in the account.

Accounts with fewer than 50 zones never see the bug, which is why it's gone unreported for a while — most SST + Cloudflare users have smaller accounts.

## Reproduction

Reproduced against a 97-zone Cloudflare account (2026-04-10):
- Zones alphabetically before position 51 (e.g. `adellion.com`, `endsights.com`, `homewealthmap.com`, `getvesper.io`) deployed fine
- The first zone alphabetically after position 50 (`simplified.media`) hung every deploy attempt for weeks

Traced by:
1. `sample <pulumi-resource-pulumi-nodejs PID> 3` on the hung subprocess — showed it spinning in `uv__io_poll` / `kevent`, confirming network I/O wait rather than CPU loop
2. Reading the Pulumi event log — last event was the preceding resource, then silence for 2+ hours
3. Manually calling `/zones?per_page=50&account.id=<id>` against Cloudflare's API — the target zone was not in the response, confirming it was on page 2
4. Reading `zone-lookup.ts` and finding the missing `page` parameter

## Not to be confused with

Issue #5005 (`Could not find hosted zone for domain _dmarc.er.dev.example.com`) is a different bug — that one throws the break-condition error from line 59-61 because the domain genuinely isn't found after a full scan. This PR's bug silently loops forever without reaching that line.

## Test plan

- Accounts with ≤50 zones: no behavior change (the `page` parameter defaults to 1 and the single fetch proceeds as before)
- Accounts with >50 zones where the target is on page 1: no behavior change
- Accounts with >50 zones where the target is on page ≥2: previously hung indefinitely, now resolves by fetching successive pages until the zone is found or the last page is reached (same semantics the code already intends, just actually working)

## Note on the error-handling pattern

Unrelated to this fix but worth flagging for a future cleanup: the `try { ... } catch (error) { console.log(error); throw error; }` pattern on line 64-67 swallows the error object to stdout then re-throws. That's fine functionally but makes the hang harder to debug because if the HTTP request errors (not the case here), the error only surfaces via `console.log` to the dynamic-provider subprocess's stdout, which Pulumi doesn't always forward. Happy to do that in a follow-up PR if wanted.