### PR TITLE
ApiGateway: allow naming routes via `name` arg

### DIFF
--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -343,13 +343,12 @@ export interface ApiGatewayWebSocketRouteArgs {
     }
   >;
   /**
-   * The name of the route. By default, SST generates a unique suffix from a hash of the
-   * route name (except for the special `$connect`, `$disconnect`, and `$default` routes,
-   * which always use their literal name). Setting `name` replaces the hashed suffix so
-   * the function becomes `<name>Handler`, giving you a stable, meaningful identifier in
-   * Pulumi state, the CloudWatch log group, and the `sst dev` TUI.
+   * The name of the route.
    *
-   * Must be unique across all routes on the same API.
+   * By default, SST generates a unique suffix from the route path. Setting `name` gives
+   * you a stable, human-readable name like `MyApiRouteSendMessageHandler`.
+   *
+   * Must be unique across all routes.
    *
    * @example
    * ```js

--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -343,6 +343,23 @@ export interface ApiGatewayWebSocketRouteArgs {
     }
   >;
   /**
+   * The name of the route. By default, SST generates a unique suffix from a hash of the
+   * route name (except for the special `$connect`, `$disconnect`, and `$default` routes,
+   * which always use their literal name). Setting `name` replaces the hashed suffix so
+   * the function becomes `<name>Handler`, giving you a stable, meaningful identifier in
+   * Pulumi state, the CloudWatch log group, and the `sst dev` TUI.
+   *
+   * Must be unique across all routes on the same API.
+   *
+   * @example
+   * ```js
+   * {
+   *   name: "SendMessage"
+   * }
+   * ```
+   */
+  name?: string;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
@@ -756,9 +773,11 @@ export class ApiGatewayWebSocket extends Component implements Link.Linkable {
   ) {
     const prefix = this.constructorName;
     const suffix = logicalName(
-      ["$connect", "$disconnect", "$default"].includes(route)
-        ? route
-        : hashStringToPrettyString(`${outputId}${route}`, 6),
+      args.name
+        ? args.name
+        : ["$connect", "$disconnect", "$default"].includes(route)
+          ? route
+          : hashStringToPrettyString(`${outputId}${route}`, 6),
     );
 
     const transformed = transform(

--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -624,13 +624,12 @@ export interface ApiGatewayV1RouteArgs {
    */
   streaming?: Input<boolean>;
   /**
-   * The name of the route. By default, SST generates a unique suffix from a hash of the
-   * method and path, producing opaque resource names like `MyApiRouteAbc123Handler`.
-   * Setting `name` replaces the hashed suffix so the function becomes `<name>Handler`,
-   * giving you a stable, meaningful identifier in Pulumi state, the CloudWatch log
-   * group, and the `sst dev` TUI.
+   * The name of the route.
    *
-   * Must be unique across all routes on the same API.
+   * By default, SST generates a unique suffix from the route path. Setting `name` gives
+   * you a stable, human-readable name like `MyApiRouteGetUserHandler`.
+   *
+   * Must be unique across all routes.
    *
    * @example
    * ```js

--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -624,6 +624,23 @@ export interface ApiGatewayV1RouteArgs {
    */
   streaming?: Input<boolean>;
   /**
+   * The name of the route. By default, SST generates a unique suffix from a hash of the
+   * method and path, producing opaque resource names like `MyApiRouteAbc123Handler`.
+   * Setting `name` replaces the hashed suffix so the function becomes `<name>Handler`,
+   * giving you a stable, meaningful identifier in Pulumi state, the CloudWatch log
+   * group, and the `sst dev` TUI.
+   *
+   * Must be unique across all routes on the same API.
+   *
+   * @example
+   * ```js
+   * {
+   *   name: "GetUser"
+   * }
+   * ```
+   */
+  name?: string;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
@@ -974,7 +991,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
 
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
-      this.buildRouteId(method, path),
+      this.buildRouteId(method, path, args.name),
       args,
       { provider: this.constructorOpts.provider },
     );
@@ -1039,7 +1056,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
 
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
-      this.buildRouteId(method, path),
+      this.buildRouteId(method, path, args.name),
       args,
       { provider: this.constructorOpts.provider },
     );
@@ -1097,10 +1114,12 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
     return { method, path };
   }
 
-  private buildRouteId(method: string, path: string) {
-    const suffix = logicalName(
-      hashStringToPrettyString([outputId, method, path].join(""), 6),
-    );
+  private buildRouteId(method: string, path: string, name?: string) {
+    const suffix = name
+      ? logicalName(name)
+      : logicalName(
+          hashStringToPrettyString([outputId, method, path].join(""), 6),
+        );
     return `${this.constructorName}Route${suffix}`;
   }
 

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -579,6 +579,23 @@ export interface ApiGatewayV2RouteArgs {
     }
   >;
   /**
+   * The name of the route. By default, SST generates a unique suffix from a hash of the
+   * route path, producing opaque resource names like `MyApiRouteAbc123Handler`. Setting
+   * `name` replaces the hashed suffix so the function becomes `<name>Handler`, giving
+   * you a stable, meaningful identifier in Pulumi state, the CloudWatch log group, and
+   * the `sst dev` TUI.
+   *
+   * Must be unique across all routes on the same API.
+   *
+   * @example
+   * ```js
+   * {
+   *   name: "GetUser"
+   * }
+   * ```
+   */
+  name?: string;
+  /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
    */
@@ -1117,7 +1134,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     const route = this.parseRoute(rawRoute);
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
-      this.buildRouteId(route),
+      this.buildRouteId(route, args.name),
       args,
       { provider: this.constructorOpts.provider },
     );
@@ -1171,7 +1188,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     const route = this.parseRoute(rawRoute);
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
-      this.buildRouteId(route),
+      this.buildRouteId(route, args.name),
       args,
       { provider: this.constructorOpts.provider },
     );
@@ -1265,7 +1282,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     const route = this.parseRoute(rawRoute);
     const transformed = transform(
       this.constructorArgs.transform?.route?.args,
-      this.buildRouteId(route),
+      this.buildRouteId(route, args.name),
       args,
       { provider: this.constructorOpts.provider },
     );
@@ -1321,10 +1338,10 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     return `${method} ${path}`;
   }
 
-  private buildRouteId(route: string) {
-    const suffix = logicalName(
-      hashStringToPrettyString([outputId, route].join(""), 6),
-    );
+  private buildRouteId(route: string, name?: string) {
+    const suffix = name
+      ? logicalName(name)
+      : logicalName(hashStringToPrettyString([outputId, route].join(""), 6));
     return `${this.constructorName}Route${suffix}`;
   }
 

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -579,13 +579,12 @@ export interface ApiGatewayV2RouteArgs {
     }
   >;
   /**
-   * The name of the route. By default, SST generates a unique suffix from a hash of the
-   * route path, producing opaque resource names like `MyApiRouteAbc123Handler`. Setting
-   * `name` replaces the hashed suffix so the function becomes `<name>Handler`, giving
-   * you a stable, meaningful identifier in Pulumi state, the CloudWatch log group, and
-   * the `sst dev` TUI.
+   * The name of the route.
    *
-   * Must be unique across all routes on the same API.
+   * By default, SST generates a unique suffix from the route path. Setting `name` gives
+   * you a stable, human-readable name like `MyApiRouteGetUserHandler`.
+   *
+   * Must be unique across all routes.
    *
    * @example
    * ```js


### PR DESCRIPTION
Closes #6736

## Motivation

Today, routes added via `api.route()` get auto-generated names like
`MyApiRouteAbc123Handler` (a 6-char hash of the route path). That suffix
is opaque when reading CloudWatch logs, scanning `pulumi state`, or
watching the `sst dev` TUI — you can't tell which route a function
belongs to without looking it up.

The only existing escape is to define a separate `sst.aws.Function` and
pass its ARN to `api.route()`, which loses the inline ergonomics
(`handlerLink`, `handlerTransform`, the auto `description` interpolation).
`transform.function.name` only renames the physical AWS Lambda — the
Pulumi URN, log group, and TUI ID still show the hash.

## Change

Add an optional `name` field to the route args of all three API Gateway
components (HTTP, REST, WebSocket). When set, it replaces the hashed
suffix used for the route's Pulumi component name:

```ts
api.route("GET /users/{id}", "src/users.get", { name: "GetUser" });
// → MyApiRouteGetUserHandler
```

Mirrors the existing `args.name` pattern used by
`ApiGatewayV1.addAuthorizer()` (apigatewayv1.ts:1181). Backward
compatible — routes without `name` keep the existing hash-based naming.

## Files

- `platform/src/components/aws/apigatewayv2.ts`
- `platform/src/components/aws/apigatewayv1.ts`
- `platform/src/components/aws/apigateway-websocket.ts`

## Notes

- `name` is a logical (Pulumi) name — the physical AWS Lambda name still
  goes through `physicalName()` and gets the standard `<app>-<stage>-`
  prefix, so the same `name` is safe across stages.
- Two routes on the same API in the same stage with the same `name`
  collide with a Pulumi duplicate-URN error, like any other resource.

## Test plan

- [x] `bun run typecheck` clean
- [ ] Maintainer to verify deploy of an example app with `name` set