### PR TITLE
fix(router): remove originAccessControlConfig for HTTP origins to prevent 502

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2965,7 +2965,8 @@ function setUrlOrigin(urlHost, override) {
   };
   override = override ?? {};
   if (override.protocol === "http") {
-    delete origin.customOriginConfig;
+    origin.customOriginConfig = { port: 80, protocol: "http", sslProtocols: ["TLSv1.2"] };
+    delete origin.originAccessControlConfig;
   }
   if (override.connectionAttempts) {
     origin.connectionAttempts = override.connectionAttempts;


### PR DESCRIPTION
## Problem

`router.route("/", "http://<alb-dns>")` returns **502 "Failed to contact the origin"** because CloudFront tries HTTPS:443 instead of HTTP:80.

## Root cause

In `setUrlOrigin`, when `override.protocol === "http"`, only `customOriginConfig` is deleted — the expectation being that `cf.updateRequestOrigin` inherits the placeholder origin's `http-only` config.

However:
1. The remaining `originAccessControlConfig: { enabled: false }` prevents this inheritance
2. Even deleting **both** properties still fails — `cf.updateRequestOrigin` does not reliably inherit `customOriginConfig` from the placeholder origin when the `domainName` changes dynamically

## Fix

Explicitly set `customOriginConfig` to HTTP port 80 for HTTP origins, and remove the unused `originAccessControlConfig`:

```diff
  if (override.protocol === "http") {
-   delete origin.customOriginConfig;
+   origin.customOriginConfig = { port: 80, protocol: "http", sslProtocols: ["TLSv1.2"] };
+   delete origin.originAccessControlConfig;
  }
```

The `override.originAccessControlConfig` check below still allows OAC-enabled origins (`protection: "oac"`) to re-add it explicitly, so existing behavior is preserved.

## Validation

Tested by deploying a CloudFront Function that calls `cf.updateRequestOrigin` with explicit HTTP `customOriginConfig` — confirmed 200 responses through CloudFront to an HTTP-only ALB. Verified the `cf` module is completely frozen in CloudFront Functions runtime (`writable: false, configurable: false`), so runtime workarounds via injection are not possible.

Fixes #6742