### PR TITLE
Add `routes` option to `cloudflare.Worker`

### DIFF
--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -104,7 +104,7 @@ export interface WorkerArgs {
    * }
    * ```
    */
-  routes?: Input<Input<string>[]>;
+  routes?: Input<string>[];
   /**
    * Configure how your function is bundled.
    *

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -3,6 +3,7 @@ import path from "path";
 import crypto from "crypto";
 import {
   ComponentResourceOptions,
+  Output,
   output,
   all,
   jsonStringify,
@@ -66,6 +67,44 @@ export interface WorkerArgs {
    * ```
    */
   domain?: Input<string>;
+  /**
+   * Attach the Worker to one or more [route patterns](https://developers.cloudflare.com/workers/configuration/routing/routes/)
+   * instead of a dedicated custom domain.
+   *
+   * Unlike `domain`, which gives the Worker a full hostname, routes are
+   * pattern-based. This lets multiple Workers (or a Pages project) share a
+   * hostname and fall through to the origin for unmatched paths. Use routes
+   * when you want to put a Worker in front of only part of a site, e.g.
+   * `example.com/api/*`.
+   *
+   * Each pattern must start with a concrete hostname that belongs to a
+   * Cloudflare zone on the same account. Wildcard hostnames like `*.example.com`
+   * are not supported here.
+   *
+   * A proxied DNS record for the hostname must already exist in the zone —
+   * routes do not auto-manage DNS, unlike custom domains. You can create
+   * one in the Cloudflare dashboard or alongside the Worker with a
+   * `cloudflare.DnsRecord` resource.
+   *
+   * Cannot be used together with `domain`.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   routes: ["example.com/api/*"]
+   * }
+   * ```
+   *
+   * Multiple patterns on the same Worker:
+   *
+   * ```js
+   * {
+   *   routes: ["example.com/api/*", "api.example.com/*"]
+   * }
+   * ```
+   */
+  routes?: Input<Input<string>[]>;
   /**
    * Configure how your function is bundled.
    *
@@ -294,6 +333,7 @@ export class Worker extends Component implements Link.Linkable {
   private workerUrl: WorkerUrl;
   private workerPlacement?: WorkerPlacement;
   private workerDomain?: cf.WorkerDomain;
+  private workerRoutes?: Output<cf.WorkersRoute[]>;
 
   constructor(name: string, args: WorkerArgs, opts?: ComponentResourceOptions) {
     super(__pulumiType, name, args, opts);
@@ -324,11 +364,13 @@ export class Worker extends Component implements Link.Linkable {
     const workerUrl = createWorkersUrl();
     const workerPlacement = createWorkerPlacement();
     const workerDomain = createWorkersDomain();
+    const workerRoutes = createWorkersRoutes();
 
     this.script = script;
     this.workerUrl = workerUrl;
     this.workerPlacement = workerPlacement;
     this.workerDomain = workerDomain;
+    this.workerRoutes = workerRoutes;
 
     all([dev, buildInput, script.scriptName]).apply(
       async ([dev, buildInput, scriptName]) => {
@@ -619,6 +661,43 @@ export class Worker extends Component implements Link.Linkable {
         { parent },
       );
     }
+
+    function createWorkersRoutes() {
+      if (!args.routes) return;
+      if (args.domain)
+        throw new VisibleError(
+          `Cannot set both "domain" and "routes" on the "${name}" Worker. Use "domain" for a dedicated hostname, or "routes" for pattern-based routing.`,
+        );
+
+      return output(args.routes).apply((patterns) =>
+        patterns.map((pattern, i) => {
+          const hostname = pattern.split("/")[0];
+          if (!hostname || hostname.includes("*"))
+            throw new VisibleError(
+              `Route pattern "${pattern}" on the "${name}" Worker must start with a concrete hostname (e.g. "example.com/*"). Wildcard hostnames are not supported.`,
+            );
+
+          const zone = new ZoneLookup(
+            `${name}Route${i}ZoneLookup`,
+            {
+              accountId: DEFAULT_ACCOUNT_ID,
+              domain: hostname,
+            },
+            { parent },
+          );
+
+          return new cf.WorkersRoute(
+            `${name}Route${i}`,
+            {
+              zoneId: zone.id,
+              pattern,
+              script: script.scriptName,
+            },
+            { parent },
+          );
+        }),
+      );
+    }
   }
 
   /**
@@ -639,6 +718,10 @@ export class Worker extends Component implements Link.Linkable {
        * The Cloudflare Worker script.
        */
       worker: this.script,
+      /**
+       * The Cloudflare Worker routes, if `routes` was set.
+       */
+      routes: this.workerRoutes,
     };
   }
 

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -3,7 +3,6 @@ import path from "path";
 import crypto from "crypto";
 import {
   ComponentResourceOptions,
-  Output,
   output,
   all,
   jsonStringify,
@@ -333,7 +332,7 @@ export class Worker extends Component implements Link.Linkable {
   private workerUrl: WorkerUrl;
   private workerPlacement?: WorkerPlacement;
   private workerDomain?: cf.WorkerDomain;
-  private workerRoutes?: Output<cf.WorkersRoute[]>;
+  private workerRoutes?: cf.WorkersRoute[];
 
   constructor(name: string, args: WorkerArgs, opts?: ComponentResourceOptions) {
     super(__pulumiType, name, args, opts);
@@ -669,34 +668,35 @@ export class Worker extends Component implements Link.Linkable {
           `Cannot set both "domain" and "routes" on the "${name}" Worker. Use "domain" for a dedicated hostname, or "routes" for pattern-based routing.`,
         );
 
-      return output(args.routes).apply((patterns) =>
-        patterns.map((pattern, i) => {
-          const hostname = pattern.split("/")[0];
-          if (!hostname || hostname.includes("*"))
+      return args.routes.map((pattern, i) => {
+        const hostname = output(pattern).apply((p) => {
+          const h = p.split("/")[0];
+          if (!h || h.includes("*"))
             throw new VisibleError(
-              `Route pattern "${pattern}" on the "${name}" Worker must start with a concrete hostname (e.g. "example.com/*"). Wildcard hostnames are not supported.`,
+              `Route pattern "${p}" on the "${name}" Worker must start with a concrete hostname (e.g. "example.com/*"). Wildcard hostnames are not supported.`,
             );
+          return h;
+        });
 
-          const zone = new ZoneLookup(
-            `${name}Route${i}ZoneLookup`,
-            {
-              accountId: DEFAULT_ACCOUNT_ID,
-              domain: hostname,
-            },
-            { parent },
-          );
+        const zone = new ZoneLookup(
+          `${name}Route${i}ZoneLookup`,
+          {
+            accountId: DEFAULT_ACCOUNT_ID,
+            domain: hostname,
+          },
+          { parent },
+        );
 
-          return new cf.WorkersRoute(
-            `${name}Route${i}`,
-            {
-              zoneId: zone.id,
-              pattern,
-              script: script.scriptName,
-            },
-            { parent },
-          );
-        }),
-      );
+        return new cf.WorkersRoute(
+          `${name}Route${i}`,
+          {
+            zoneId: zone.id,
+            pattern,
+            script: script.scriptName,
+          },
+          { parent },
+        );
+      });
     }
   }
 

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -184,6 +184,7 @@ export class Component extends ComponentResource {
               "cloudflare:index/dnsRecord:DnsRecord",
               "cloudflare:index/workersCronTrigger:WorkersCronTrigger",
               "cloudflare:index/workersCustomDomain:WorkersCustomDomain",
+              "cloudflare:index/workersRoute:WorkersRoute",
               "cloudflare:index/queueConsumer:QueueConsumer",
               "docker-build:index:Image",
               "vercel:index/dnsRecord:DnsRecord",


### PR DESCRIPTION
## What this adds

A new `routes` field on `sst.cloudflare.Worker` that attaches the Worker to one or more Cloudflare [route patterns](https://developers.cloudflare.com/workers/configuration/routing/routes/) as an alternative to a full custom domain.

```ts
new sst.cloudflare.Worker("Api", {
  handler: "src/worker.ts",
  routes: ["example.com/api/*"],
});
```

Each pattern becomes a `cloudflare.WorkersRoute` resource, with the zone looked up from the pattern's hostname via the existing `ZoneLookup` provider — same machinery `domain:` already uses.

## Why

Today `cloudflare.Worker` only exposes `domain: "..."`, which maps to `WorkersCustomDomain` — i.e. the Worker owns the whole hostname. That's the right answer when a Worker is the only thing serving a subdomain, but it's not the only shape CF supports.

Routes are the other half of the CF dashboard's "Domains & Routes" panel. They're pattern-based, so multiple Workers (or a Pages project) can share a hostname and unmatched paths fall through to the origin. Concrete cases I keep hitting:

- One Worker fronting `example.com/api/*` while the rest of the site is served by Pages or an existing origin
- Migrating off an old origin incrementally, pattern by pattern
- Running several Workers on the same apex domain

Without a native option you end up reaching into `@pulumi/cloudflare` directly and hand-rolling `WorkersRoute` + `ZoneLookup` next to the SST component. That works but it's friction for something that's a one-liner in wrangler.