### PR TITLE
ensure apigatewayv2 cors configuration is not set when input is 'false'

### DIFF
--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -675,7 +675,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
   private constructorName: string;
   private constructorArgs: ApiGatewayV2Args;
   private constructorOpts: ComponentResourceOptions;
-  private api: apigatewayv2.Api;
+  private api: Output<apigatewayv2.Api>;
   private apigDomain?: Output<apigatewayv2.DomainName>;
   private apiMapping?: Output<apigatewayv2.ApiMapping>;
   private logGroup: cloudwatch.LogGroup;
@@ -692,7 +692,6 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
 
     const accessLog = normalizeAccessLog();
     const domain = normalizeDomain();
-    const cors = normalizeCors();
     const vpc = normalizeVpc();
 
     const vpcLink = createVpcLink();
@@ -757,25 +756,6 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
       });
     }
 
-    function normalizeCors() {
-      return output(args.cors).apply((cors) => {
-        if (cors === false) return {};
-
-        const defaultCors: types.input.apigatewayv2.ApiCorsConfiguration = {
-          allowHeaders: ["*"],
-          allowMethods: ["*"],
-          allowOrigins: ["*"],
-        };
-        return cors === true || cors === undefined
-          ? defaultCors
-          : {
-            ...defaultCors,
-            ...cors,
-            maxAge: cors.maxAge && toSeconds(cors.maxAge),
-          };
-      });
-    }
-
     function normalizeVpc() {
       // "vpc" is undefined
       if (!args.vpc) return;
@@ -809,17 +789,63 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
     }
 
     function createApi() {
-      return new apigatewayv2.Api(
-        ...transform(
-          args.transform?.api,
-          `${name}Api`,
-          {
-            protocolType: "HTTP",
-            corsConfiguration: cors,
-          },
-          { parent },
-        ),
-      );
+      return output(args.cors).apply((cors) => {
+        const defaultCors: types.input.apigatewayv2.ApiCorsConfiguration = {
+          allowHeaders: ["*"],
+          allowMethods: ["*"],
+          allowOrigins: ["*"],
+        };
+
+        if (cors === false) {
+          return output(undefined).apply(
+            () =>
+              new apigatewayv2.Api(
+                ...transform(
+                  args.transform?.api,
+                  `${name}Api`,
+                  { protocolType: "HTTP" },
+                  { parent },
+                ),
+              ),
+          );
+        }
+
+        if (cors === true || cors === undefined) {
+          return output(undefined).apply(
+            () =>
+              new apigatewayv2.Api(
+                ...transform(
+                  args.transform?.api,
+                  `${name}Api`,
+                  {
+                    protocolType: "HTTP",
+                    corsConfiguration: defaultCors,
+                  },
+                  { parent },
+                ),
+              ),
+          );
+        }
+
+        const { maxAge: maxAgeInput, ...corsRest } = cors;
+        return output(maxAgeInput).apply((maxAge) =>
+          new apigatewayv2.Api(
+            ...transform(
+              args.transform?.api,
+              `${name}Api`,
+              {
+                protocolType: "HTTP",
+                corsConfiguration: {
+                  ...defaultCors,
+                  ...corsRest,
+                  maxAge: maxAge && toSeconds(maxAge),
+                },
+              },
+              { parent },
+            ),
+          ),
+        );
+      });
     }
 
     function createLogGroup() {


### PR DESCRIPTION
Fixes #6748 

### Background
Specifying `cors: false` on the ApiGatewayv2 construct results in the cors configuration being set to `{}` which actually sets a barebones default configuration instead of completely clearing it. The barebones default config results in all requests to the Api failing cors because the allowed origins and headers list is empty.

### Notes
Because the corsConfiguration parameter on the pulumi api construct is `Output<ApiArgs> | undefined`, I had to wrap the whole creation of the apigateway inside a `.apply()`. 

I tested this code change by deploying it and verifying the cors config value using `aws apigatewayv2 get-api --api-id <my id> --query "CorsConfiguration" --region us-east-2`