### PR TITLE
Fix Cloudflare worker import paths on Windows

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -69,6 +69,9 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	if err != nil {
 		return nil, err
 	}
+	// Windows paths must not be embedded raw in JS string literals: backslashes
+	// are escape sequences (\p, \f, etc.). Forward slashes work for imports.
+	importPath := filepath.ToSlash(abs)
 	target := filepath.Join(input.Out(), input.Handler)
 
 	slog.Info("loader info", "loader", build.Loader)
@@ -108,7 +111,7 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
       import { fromCloudflareEnv, wrapCloudflareHandler } from "sst/resource/cloudflare"
       export * from "%s"
       export default wrapCloudflareHandler(handler)
-      `, abs, abs),
+      `, importPath, importPath),
 			ResolveDir: filepath.Dir(abs),
 			Loader:     esbuild.LoaderTS,
 		},


### PR DESCRIPTION
## Summary

Cloudflare Worker builds on Windows broke because the absolute handler path was embedded in generated stdin JS using double-quoted string literals. Backslashes were interpreted as escapes, corrupting the path. Use `filepath.ToSlash` on that path before interpolating it into the import/export source in `pkg/runtime/worker/worker.go`.

## Related

Fixes https://github.com/anomalyco/sst/issues/6756

## Test plan

- [ ] `go test ./pkg/runtime/worker/...`
- [ ] On Windows: `sst dev` or deploy with `home: "cloudflare"` and a nested handler path; confirm bundling succeeds.
