### PR TITLE
fix: use alias for versioned lambda functions

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1513,6 +1513,11 @@ export interface FunctionArgs {
      */
     function?: Transform<lambda.FunctionArgs>;
     /**
+     * Transform the Lambda Alias resource. This is only created when versioning
+     * is enabled (via `versioning: true` or `durable: true`).
+     */
+    alias?: Transform<lambda.AliasArgs>;
+    /**
      * Transform the IAM Role resource.
      */
     role?: Transform<iam.RoleArgs>;
@@ -2726,12 +2731,15 @@ export class Function extends Component implements Link.Linkable {
         if (!isVersioningEnabled) return;
 
         return new lambda.Alias(
-          `${name}LatestAlias`,
-          {
-            functionName: fn.name,
-            functionVersion: fn.version,
-          },
-          { parent },
+          ...transform(
+            args.transform?.alias,
+            `${name}LatestAlias`,
+            {
+              functionName: fn.name,
+              functionVersion: fn.version,
+            },
+            { parent },
+          ),
         );
       });
     }

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1726,8 +1726,8 @@ export class Function extends Component implements Link.Linkable {
   private eventInvokeConfig?: lambda.FunctionEventInvokeConfig;
   private alias: Output<lambda.Alias | undefined>;
   private isVersioningEnabled: Output<boolean>;
-  public targetArn: Output<string>;
-  public qualifier: Output<string | undefined>;
+  #targetArn: Output<string>;
+  #qualifier: Output<string | undefined>;
 
   private static readonly encryptionKey = lazy(
     () =>
@@ -1815,8 +1815,8 @@ export class Function extends Component implements Link.Linkable {
     this.urlEndpoint = urlEndpoint;
     this.eventInvokeConfig = eventInvokeConfig;
     this.alias = alias;
-    this.targetArn = targetArn;
-    this.qualifier = qualifier;
+    this.#targetArn = targetArn;
+    this.#qualifier = qualifier;
     this.isVersioningEnabled = isVersioningEnabled;
 
     const buildInput = output({
@@ -3040,6 +3040,25 @@ export class Function extends Component implements Link.Linkable {
    */
   public get arn() {
     return this.function.arn;
+  }
+
+  /**
+   * The ARN to use when wiring this function to an event source.
+   *
+   * When versioning is enabled, this points to the Lambda alias that routes
+   * to the currently published version. Otherwise it falls back to the
+   * function ARN.
+   *
+   * Prefer this over `arn` when passing the function to an event source, so
+   * invocations go through the alias instead of `$LATEST`.
+   */
+  public get targetArn() {
+    return this.#targetArn;
+  }
+
+  /** @internal */
+  public get qualifier() {
+    return this.#qualifier;
   }
 
   /** @internal */

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1779,7 +1779,7 @@ export class Function extends Component implements Link.Linkable {
     const streaming = normalizeStreaming();
     const logging = normalizeLogging();
     const volume = normalizeVolume();
-    const url = normalizeUrl(args.url);
+    const url = normalizeUrl();
     const copyFiles = normalizeCopyFiles();
     const durable = normalizeDurable();
     const policies = output(args.policies ?? []);
@@ -1988,8 +1988,8 @@ export class Function extends Component implements Link.Linkable {
       }));
     }
 
-    function normalizeUrl(url: FunctionArgs["url"]) {
-      return output(url).apply((url) => {
+    function normalizeUrl() {
+      return output(args.url).apply((url) => {
         if (url === false || url === undefined) return;
         if (url === true) {
           url = {};
@@ -2023,7 +2023,6 @@ export class Function extends Component implements Link.Linkable {
         };
       });
     }
-    type NormalizedUrl = ReturnType<typeof normalizeUrl>;
 
     function normalizeCopyFiles() {
       return output(args.copyFiles ?? []).apply((copyFiles) =>

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2652,7 +2652,7 @@ export class Function extends Component implements Link.Linkable {
               layers: args.layers,
               tags: args.tags,
               publish: output(args.versioning).apply(
-                (v) => v || Boolean(args.durable),
+                (v) => v ?? Boolean(args.durable),
               ),
               reservedConcurrentExecutions: concurrency?.reserved,
               durableConfig: durable && {

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1309,6 +1309,12 @@ export interface FunctionArgs {
   /**
    * Enable versioning for the function.
    *
+   * :::caution
+   * If you're wiring this function to an event source by passing its ARN,
+   * use `fn.targetArn` rather than `fn.arn`. Using `fn.arn` invokes
+   * `$LATEST` and bypasses the alias that routes to the published version.
+   * :::
+   *
    * :::note
    * Durable functions enable this by default.
    * :::
@@ -1475,6 +1481,12 @@ export interface FunctionArgs {
    * :::caution
    * This property is meant to be used internally by [Workflow](/docs/component/aws/workflow).
    * Prefer the component if you want to use the [SDK](/docs/component/aws/workflow#sdk) or if you are not very familiar with durable functions limitations.
+   * :::
+   *
+   * :::caution
+   * If you're wiring this function to an event source by passing its ARN,
+   * use `fn.targetArn` rather than `fn.arn`. Using `fn.arn` invokes
+   * `$LATEST` and bypasses the alias that routes to the published version.
    * :::
    */
   durable?:
@@ -1712,6 +1724,10 @@ export class Function extends Component implements Link.Linkable {
   private logGroup: Output<cloudwatch.LogGroup | undefined>;
   private urlEndpoint: Output<string | undefined>;
   private eventInvokeConfig?: lambda.FunctionEventInvokeConfig;
+  private alias: Output<lambda.Alias | undefined>;
+  private isVersioningEnabled: Output<boolean>;
+  public targetArn: Output<string>;
+  public qualifier: Output<string | undefined>;
 
   private static readonly encryptionKey = lazy(
     () =>
@@ -1765,7 +1781,7 @@ export class Function extends Component implements Link.Linkable {
     const streaming = normalizeStreaming();
     const logging = normalizeLogging();
     const volume = normalizeVolume();
-    const url = normalizeUrl();
+    const url = normalizeUrl(args.url);
     const copyFiles = normalizeCopyFiles();
     const durable = normalizeDurable();
     const policies = output(args.policies ?? []);
@@ -1781,7 +1797,13 @@ export class Function extends Component implements Link.Linkable {
     const logGroup = createLogGroup();
     const zipAsset = createZipAsset();
     const fn = createFunction();
-    const urlEndpoint = createUrl();
+    const isVersioningEnabled = fn.publish.apply((publish) => Boolean(publish));
+    const alias = createLatestAlias();
+    const targetArn = createTargetArn(alias);
+    const qualifier = output(targetArn).apply(
+      (arn) => splitQualifiedFunctionArn(arn).qualifier,
+    );
+    const urlEndpoint = createLatestUrl();
     createProvisioned();
     const eventInvokeConfig = createEventInvokeConfig();
 
@@ -1792,6 +1814,10 @@ export class Function extends Component implements Link.Linkable {
     this.logGroup = logGroup;
     this.urlEndpoint = urlEndpoint;
     this.eventInvokeConfig = eventInvokeConfig;
+    this.alias = alias;
+    this.targetArn = targetArn;
+    this.qualifier = qualifier;
+    this.isVersioningEnabled = isVersioningEnabled;
 
     const buildInput = output({
       functionID: name,
@@ -1967,8 +1993,8 @@ export class Function extends Component implements Link.Linkable {
       }));
     }
 
-    function normalizeUrl() {
-      return output(args.url).apply((url) => {
+    function normalizeUrl(url: FunctionArgs["url"]) {
+      return output(url).apply((url) => {
         if (url === false || url === undefined) return;
         if (url === true) {
           url = {};
@@ -2002,6 +2028,7 @@ export class Function extends Component implements Link.Linkable {
         };
       });
     }
+    type NormalizedUrl = ReturnType<typeof normalizeUrl>;
 
     function normalizeCopyFiles() {
       return output(args.copyFiles ?? []).apply((copyFiles) =>
@@ -2630,7 +2657,7 @@ export class Function extends Component implements Link.Linkable {
               layers: args.layers,
               tags: args.tags,
               publish: output(args.versioning).apply(
-                (v) => v ?? Boolean(args.durable),
+                (v) => v || Boolean(args.durable),
               ),
               reservedConcurrentExecutions: concurrency?.reserved,
               durableConfig: durable && {
@@ -2700,7 +2727,33 @@ export class Function extends Component implements Link.Linkable {
       );
     }
 
-    function createUrl() {
+    function createLatestAlias() {
+      return isVersioningEnabled.apply((isVersioningEnabled) => {
+        if (!isVersioningEnabled) return;
+
+        return new lambda.Alias(
+          `${name}LatestAlias`,
+          {
+            functionName: fn.name,
+            functionVersion: fn.version,
+          },
+          { parent },
+        );
+      });
+    }
+
+    function createTargetArn(alias: Input<lambda.Alias | undefined>) {
+      return output(alias).apply((alias) => {
+        if (alias) return alias.arn;
+        return fn.arn;
+      });
+    }
+
+    type CreateUrlOpts = {
+      qualifier: string | undefined;
+      url: NormalizedUrl;
+    };
+    function createUrl({ url, qualifier }: CreateUrlOpts) {
       return url.apply((url) => {
         if (url === undefined) return output(undefined);
 
@@ -2712,23 +2765,10 @@ export class Function extends Component implements Link.Linkable {
           ([oac, authorization]) => oac || authorization === "iam",
         );
 
-        /**
-         * Lambda Function URLs only accept alias names in the explicit `qualifier`
-         * field. Durable functions with URLs therefore need an alias target here,
-         * even when the underlying function is still on `$LATEST`.
-         * See https://github.com/hashicorp/terraform-provider-aws/issues/31459
-         */
-        const qualifier = durable
-          ? new lambda.Alias(`${name}Durable`, {
-              functionName: fn.arn,
-              functionVersion: fn.version,
-            }).name
-          : undefined;
-
         const fnUrl = new lambda.FunctionUrl(
           `${name}Url`,
           {
-            functionName: durable ? fn.arn : fn.name,
+            functionName: fn.name,
             qualifier,
             authorizationType: isIam.apply((isIam) =>
               isIam ? "AWS_IAM" : "NONE",
@@ -2738,7 +2778,7 @@ export class Function extends Component implements Link.Linkable {
             ),
             cors: url.cors,
           },
-          { parent },
+          { parent, deleteBeforeReplace: false },
         );
 
         if (!url.route) {
@@ -2750,6 +2790,7 @@ export class Function extends Component implements Link.Linkable {
               {
                 action: "lambda:InvokeFunctionUrl",
                 function: fn.name,
+                qualifier,
                 principal: "*",
                 functionUrlAuthType: "NONE",
               },
@@ -2760,6 +2801,7 @@ export class Function extends Component implements Link.Linkable {
               {
                 action: "lambda:InvokeFunction",
                 function: fn.name,
+                qualifier,
                 principal: "*",
                 invokedViaFunctionUrl: true,
               },
@@ -2778,6 +2820,7 @@ export class Function extends Component implements Link.Linkable {
                 {
                   action: "lambda:InvokeFunctionUrl",
                   function: fn.name,
+                  qualifier,
                   principal: "cloudfront.amazonaws.com",
                   sourceArn: distributionArn,
                 },
@@ -2788,6 +2831,7 @@ export class Function extends Component implements Link.Linkable {
                 {
                   action: "lambda:InvokeFunction",
                   function: fn.name,
+                  qualifier,
                   principal: "cloudfront.amazonaws.com",
                   sourceArn: distributionArn,
                   invokedViaFunctionUrl: true,
@@ -2800,6 +2844,7 @@ export class Function extends Component implements Link.Linkable {
                 {
                   action: "lambda:InvokeFunctionUrl",
                   function: fn.name,
+                  qualifier,
                   principal: "*",
                   functionUrlAuthType: "NONE",
                 },
@@ -2810,6 +2855,7 @@ export class Function extends Component implements Link.Linkable {
                 {
                   action: "lambda:InvokeFunction",
                   function: fn.name,
+                  qualifier,
                   principal: "*",
                   invokedViaFunctionUrl: true,
                 },
@@ -2886,6 +2932,15 @@ export class Function extends Component implements Link.Linkable {
       });
     }
 
+    function createLatestUrl() {
+      return qualifier.apply((qualifier) =>
+        createUrl({
+          url,
+          qualifier,
+        }),
+      );
+    }
+
     function createProvisioned() {
       return all([args.concurrency, fn.publish]).apply(
         ([concurrency, publish]) => {
@@ -2952,6 +3007,10 @@ export class Function extends Component implements Link.Linkable {
        * The Function Event Invoke Config resource if retries are configured.
        */
       eventInvokeConfig: this.eventInvokeConfig,
+      /**
+       * The Lambda Alias. Available when `versioning` or `durable` is enabled.
+       */
+      alias: this.alias,
     };
   }
 
@@ -2984,45 +3043,22 @@ export class Function extends Component implements Link.Linkable {
   }
 
   /** @internal */
-  private get useQualifiedTarget() {
-    return this.function.publish.apply(
-      (publish) => (publish ?? false) || this.durable,
-    );
-  }
-
-  /** @internal */
-  public get targetArn() {
-    return this.useQualifiedTarget.apply((useQualifiedTarget) =>
-      useQualifiedTarget ? this.function.qualifiedArn : this.arn,
-    );
-  }
-
-  /** @internal */
-  public get qualifier() {
-    return this.targetArn.apply(
-      (arn) => splitQualifiedFunctionArn(arn).qualifier,
-    );
-  }
-
-  /** @internal */
   public get targetInvokeArn() {
-    return this.useQualifiedTarget.apply((useQualifiedTarget) =>
-      useQualifiedTarget
-        ? this.function.qualifiedInvokeArn
-        : this.function.invokeArn,
+    return this.alias.apply((alias) =>
+      alias ? alias.invokeArn : this.function.invokeArn,
     );
   }
 
   /** @internal */
   public get targetResponseStreamingInvokeArn() {
-    return this.useQualifiedTarget.apply((useQualifiedTarget) =>
-      useQualifiedTarget
+    return this.alias.apply((alias) =>
+      alias
         ? all([
             this.arn,
-            this.function.qualifiedArn,
+            alias.arn,
             this.function.responseStreamingInvokeArn,
-          ]).apply(([arn, qualifiedArn, responseStreamingInvokeArn]) =>
-            responseStreamingInvokeArn.replace(arn, qualifiedArn),
+          ]).apply(([arn, aliasArn, responseStreamingInvokeArn]) =>
+            responseStreamingInvokeArn.replace(arn, aliasArn),
           )
         : this.function.responseStreamingInvokeArn,
     );
@@ -3110,11 +3146,7 @@ export class Function extends Component implements Link.Linkable {
       properties: {
         name: this.name,
         url: this.urlEndpoint,
-        ...(this.durable
-          ? {
-              qualifier: this.qualifier,
-            }
-          : {}),
+        qualifier: this.qualifier,
       },
       include: [
         permission({
@@ -3132,7 +3164,13 @@ export class Function extends Component implements Link.Linkable {
                 ]
               : []),
           ],
-          resources: [this.durable ? interpolate`${this.arn}:*` : this.arn],
+          resources: this.isVersioningEnabled.apply((isVersioningEnabled) =>
+            this.durable
+              ? [interpolate`${this.arn}:*`]
+              : isVersioningEnabled
+                ? [this.arn, interpolate`${this.arn}:*`]
+                : [this.arn],
+          ),
         }),
       ],
     };

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1726,8 +1726,6 @@ export class Function extends Component implements Link.Linkable {
   private eventInvokeConfig?: lambda.FunctionEventInvokeConfig;
   private alias: Output<lambda.Alias | undefined>;
   private isVersioningEnabled: Output<boolean>;
-  #targetArn: Output<string>;
-  #qualifier: Output<string | undefined>;
 
   private static readonly encryptionKey = lazy(
     () =>
@@ -1799,11 +1797,6 @@ export class Function extends Component implements Link.Linkable {
     const fn = createFunction();
     const isVersioningEnabled = fn.publish.apply((publish) => Boolean(publish));
     const alias = createLatestAlias();
-    const targetArn = createTargetArn(alias);
-    const qualifier = output(targetArn).apply(
-      (arn) => splitQualifiedFunctionArn(arn).qualifier,
-    );
-    const urlEndpoint = createLatestUrl();
     createProvisioned();
     const eventInvokeConfig = createEventInvokeConfig();
 
@@ -1812,12 +1805,14 @@ export class Function extends Component implements Link.Linkable {
     this.function = fn;
     this.role = role;
     this.logGroup = logGroup;
-    this.urlEndpoint = urlEndpoint;
     this.eventInvokeConfig = eventInvokeConfig;
     this.alias = alias;
-    this.#targetArn = targetArn;
-    this.#qualifier = qualifier;
     this.isVersioningEnabled = isVersioningEnabled;
+
+    const urlEndpoint = this.qualifier.apply((qualifier) =>
+      createUrl(qualifier),
+    );
+    this.urlEndpoint = urlEndpoint;
 
     const buildInput = output({
       functionID: name,
@@ -2742,18 +2737,7 @@ export class Function extends Component implements Link.Linkable {
       });
     }
 
-    function createTargetArn(alias: Input<lambda.Alias | undefined>) {
-      return output(alias).apply((alias) => {
-        if (alias) return alias.arn;
-        return fn.arn;
-      });
-    }
-
-    type CreateUrlOpts = {
-      qualifier: string | undefined;
-      url: NormalizedUrl;
-    };
-    function createUrl({ url, qualifier }: CreateUrlOpts) {
+    function createUrl(qualifier: string | undefined) {
       return url.apply((url) => {
         if (url === undefined) return output(undefined);
 
@@ -2932,15 +2916,6 @@ export class Function extends Component implements Link.Linkable {
       });
     }
 
-    function createLatestUrl() {
-      return qualifier.apply((qualifier) =>
-        createUrl({
-          url,
-          qualifier,
-        }),
-      );
-    }
-
     function createProvisioned() {
       return all([args.concurrency, fn.publish]).apply(
         ([concurrency, publish]) => {
@@ -3053,12 +3028,17 @@ export class Function extends Component implements Link.Linkable {
    * invocations go through the alias instead of `$LATEST`.
    */
   public get targetArn() {
-    return this.#targetArn;
+    return this.alias.apply((alias) => {
+      if (alias) return alias.arn;
+      return this.function.arn;
+    });
   }
 
   /** @internal */
   public get qualifier() {
-    return this.#qualifier;
+    return this.targetArn.apply(
+      (arn) => splitQualifiedFunctionArn(arn).qualifier,
+    );
   }
 
   /** @internal */

--- a/platform/src/components/aws/workflow.ts
+++ b/platform/src/components/aws/workflow.ts
@@ -272,7 +272,12 @@ export interface WorkflowArgs
  * ID generation inside durable operations like `ctx.step()`.
  *
  * :::caution
- * Workflow handlers have versioning enabled. Deploying an update won't update existing running workflows.
+ * The workflow SDK invokes the handler through an alias. Each execution is pinned
+ * to the version the alias points to when it starts, and stays pinned across resumes
+ * and retries — so deploying an update won't affect already-running workflows.
+ *
+ * To resume on the latest code, invoke the function directly via the Lambda SDK
+ * with the `$LATEST` qualifier. Not recommended for production.
  * :::
  *
  * Before using workflows in production, review the

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -147,6 +147,7 @@ export class Component extends ComponentResource {
               "aws:cognito/identityPoolRoleAttachment:IdentityPoolRoleAttachment",
               "aws:cognito/identityProvider:IdentityProvider",
               "aws:cognito/userPoolClient:UserPoolClient",
+              "aws:lambda/alias:Alias",
               "aws:lambda/eventSourceMapping:EventSourceMapping",
               "aws:lambda/functionEventInvokeConfig:FunctionEventInvokeConfig",
               "aws:lambda/functionUrl:FunctionUrl",


### PR DESCRIPTION
closes https://github.com/anomalyco/sst/issues/6722 https://github.com/anomalyco/sst/issues/6720

### Summary

Reworks function versioning to always create a persistent `LatestAlias` when `versioning` (or `durable`) is enabled. `targetArn`, `qualifier`, Function URLs, URL permissions, and invoke ARNs now all route through this alias instead of a pinned numeric version.

Previously:
- `targetArn` pointed at `fn.qualifiedArn` (a specific published version number that churns each deploy).
- Durable functions created a one-off `${name}Durable` alias inline, but only for the Function URL — other consumers still got the pinned version ARN.

Now:
- A single `${name}LatestAlias` is created whenever the function is published, and every downstream integration (URL, event sources, API GW, cron, workflow, SDK link, etc.) targets it.
- `fn.qualifier` resolves to the alias name when versioning is on, and `undefined` when it isn't.
- The URL is bound to the alias (no longer to `$LATEST`) as soon as versioning is enabled.

This is groundwork for upcoming rollout support — we need a stable indirection in front of versioned functions before we can implement traffic shifting.

### What I tested

- Workflow **without a URL** — correctly routes through the alias.
- Workflow **with a URL** — URL is served off the alias.
- Function with URL, **no versioning** — no regression, URL still targets the unqualified function.
- Function with URL **and versioning** — alias created, URL targets the alias, permissions scoped to the alias.
- `Resource.<Fn>.qualifier` via the SDK — resolves to the alias name when versioning is enabled, and has no value when it isn't.
- Lambda behind **API Gateway**:
  - without versioning: integration and permissions target the function directly, as before.
  - with versioning: integration points at the alias and the `lambda:InvokeFunction` permission is scoped to the alias.
- **Response streaming** path — `targetResponseStreamingInvokeArn` now rewrites against the alias ARN, and streamed invocations work.
- AWS Router with protection (OAC) + Lambda **no versioning** — no regression, URL still targets the unqualified function.
- AWS Router with protection (OAC) + Lambda **with versioning** — alias created, Router targets the alias, permissions scoped to the alias.
- AWS SQS + Lambda **no versioning** — no regression, queue invoked the unqualified function.
- AWS SQS + Lambda **with versioning** — alias created, SQS triggers the alias.


### Upgrade notes

For any stack that previously enabled `versioning: true` or `durable: true` **with a URL**, the Function URL will be replaced:

- **`versioning: true`**: the existing URL currently points at `$LATEST`. After upgrade it will point at the alias — a new URL will be issued.
- **`durable: true`**: the alias changes from the old inline `${name}Durable` to `${name}LatestAlias`, which also causes a new URL to be issued.

Event sources that consume `fn.targetArn` (buckets, topics, crons, API Gateway integrations, etc.) will see a one-time update on upgrade as the ARN moves from a pinned version to the alias. This isn't new churn — previously, every deploy that changed function code published a new version, which forced those same event sources and permissions to update their target. With the alias, this happens once and then stops: subsequent deploys keep pointing at the same alias ARN, so downstream resources no longer need to be touched on every deploy.