### PR TITLE
Allow Cloudflare components to override `accountId`

### DIFF
--- a/platform/src/components/cloudflare/bucket.ts
+++ b/platform/src/components/cloudflare/bucket.ts
@@ -4,8 +4,15 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link.js";
 import { binding } from "./binding.js";
 import { DEFAULT_ACCOUNT_ID } from "./account-id";
+import type { Input } from "../input";
 
 export interface BucketArgs {
+  /**
+   * The Cloudflare account ID to use for this R2 Bucket.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
   /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
@@ -73,7 +80,7 @@ export class Bucket extends Component implements Link.Linkable {
           `${name}Bucket`,
           {
             name: "",
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: args?.accountId ?? DEFAULT_ACCOUNT_ID,
           },
           { parent },
         ),

--- a/platform/src/components/cloudflare/cron.ts
+++ b/platform/src/components/cloudflare/cron.ts
@@ -81,6 +81,12 @@ export interface CronArgs {
    */
   schedules: Input<string[]>;
   /**
+   * The Cloudflare account ID to use for this Cron and its worker.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
+  /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
    */
@@ -142,7 +148,6 @@ export class Cron extends Component {
     const workerArgs = normalizeWorker();
     const worker = createWorker();
     const trigger = createTrigger();
-
     this.worker = worker;
     this.trigger = trigger;
 
@@ -159,7 +164,7 @@ export class Cron extends Component {
         throw new VisibleError(
           `You must provide a "worker" for the "${name}" Cron component.`,
         );
-      return workerBuilder(`${name}Handler`, workerArgs);
+      return workerBuilder(`${name}Handler`, workerArgs, undefined, undefined, args.accountId);
     }
 
     function createTrigger() {
@@ -169,7 +174,7 @@ export class Cron extends Component {
             args.transform?.trigger,
             `${name}Trigger`,
             {
-              accountId: DEFAULT_ACCOUNT_ID,
+              accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
               scriptName: worker.script.scriptName,
               schedules: schedules.map((s) => ({ cron: s })),
             },

--- a/platform/src/components/cloudflare/d1.ts
+++ b/platform/src/components/cloudflare/d1.ts
@@ -4,8 +4,15 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link";
 import { binding } from "./binding";
 import { DEFAULT_ACCOUNT_ID } from ".";
+import type { Input } from "../input";
 
 export interface D1Args {
+  /**
+   * The Cloudflare account ID to use for this D1 database.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
   /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
@@ -70,7 +77,6 @@ export class D1 extends Component implements Link.Linkable {
     }
 
     const parent = this;
-
     const db = createDB();
 
     this.database = db;
@@ -82,7 +88,7 @@ export class D1 extends Component implements Link.Linkable {
           `${name}Database`,
           {
             name: "",
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: args?.accountId ?? DEFAULT_ACCOUNT_ID,
           },
           { parent },
         ),
@@ -153,7 +159,7 @@ export class D1 extends Component implements Link.Linkable {
    * :::
    *
    * @param name The name of the component.
-   * @param databaseId The database ID of the existing D1 Database.
+   * @param args The database ID and optional account ID of the existing D1 Database.
    *
    * @example
    * Imagine you create a D1 Database in the `dev` stage. And in your personal
@@ -162,7 +168,7 @@ export class D1 extends Component implements Link.Linkable {
    *
    * ```ts title="sst.config.ts"
    * const d1 = $app.stage === "giorgio"
-   *   ? sst.cloudflare.D1.get("MyD1", "my-database-id")
+   *   ? sst.cloudflare.D1.get("MyD1", { databaseId: "my-database-id" })
    *   : new sst.cloudflare.D1("MyD1");
    * ```
    *
@@ -177,12 +183,12 @@ export class D1 extends Component implements Link.Linkable {
    */
   public static get(
     name: string,
-    databaseId: string,
+    args: { databaseId: string; accountId?: string },
     opts?: ComponentResourceOptions,
   ) {
     const database = cloudflare.D1Database.get(
       `${name}Database`,
-      `${DEFAULT_ACCOUNT_ID}/${databaseId}`,
+      `${args.accountId ?? DEFAULT_ACCOUNT_ID}/${args.databaseId}`,
       undefined,
       opts,
     );

--- a/platform/src/components/cloudflare/d1.ts
+++ b/platform/src/components/cloudflare/d1.ts
@@ -185,10 +185,36 @@ export class D1 extends Component implements Link.Linkable {
     name: string,
     args: { databaseId: string; accountId?: string },
     opts?: ComponentResourceOptions,
+  ): D1;
+  /**
+   * @deprecated Use the object-based `args` signature instead: `get(name, { databaseId }, opts)`.
+   */
+  public static get(
+    name: string,
+    databaseId: string,
+    opts?: ComponentResourceOptions,
+  ): D1;
+
+  public static get(
+    name: string,
+    argsOrDatabaseId: { databaseId: string; accountId?: string } | string,
+    opts?: ComponentResourceOptions,
   ) {
+    if (typeof argsOrDatabaseId === "string") {
     const database = cloudflare.D1Database.get(
       `${name}Database`,
-      `${args.accountId ?? DEFAULT_ACCOUNT_ID}/${args.databaseId}`,
+      `${DEFAULT_ACCOUNT_ID}/${argsOrDatabaseId}`,
+      undefined,
+      opts,
+    );
+    return new D1(name, {
+      ref: true,
+      database,
+    } as D1Args);
+    }
+    const database = cloudflare.D1Database.get(
+      `${name}Database`,
+      `${argsOrDatabaseId.accountId ?? DEFAULT_ACCOUNT_ID}/${argsOrDatabaseId.databaseId}`,
       undefined,
       opts,
     );

--- a/platform/src/components/cloudflare/dns.ts
+++ b/platform/src/components/cloudflare/dns.ts
@@ -63,6 +63,12 @@ export interface DnsArgs {
    */
   zone?: Input<string>;
   /**
+   * The Cloudflare account ID to use for zone lookups.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
+  /**
    * Configure ALIAS DNS records as [proxy records](https://developers.cloudflare.com/learning-paths/get-started-free/onboarding/proxy-dns-records/).
    *
    * :::tip
@@ -118,7 +124,7 @@ export function dns(args: DnsArgs = {}) {
     const zone = new ZoneLookup(
       `${namePrefix}${recordType}${recordName}ZoneLookup`,
       {
-        accountId: DEFAULT_ACCOUNT_ID,
+        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
         domain: recordName.replace(/\.$/, ""),
       },
       opts,
@@ -169,6 +175,7 @@ export function dns(args: DnsArgs = {}) {
           zoneId: zone.id,
           type: "CAA",
           name: zone.name,
+          accountId: args.accountId,
           data: {
             flags: "0",
             tag: "issue",
@@ -183,6 +190,7 @@ export function dns(args: DnsArgs = {}) {
           zoneId: zone.id,
           type: "CAA",
           name: zone.name,
+          accountId: args.accountId,
           data: {
             flags: "0",
             tag: "issuewild",

--- a/platform/src/components/cloudflare/helpers/worker-builder.ts
+++ b/platform/src/components/cloudflare/helpers/worker-builder.ts
@@ -18,12 +18,13 @@ export function workerBuilder(
   definition: Input<string | WorkerArgs>,
   argsTransform?: Transform<WorkerArgs>,
   opts?: ComponentResourceOptions,
+  accountId?: Input<string>,
 ): WorkerBuilder {
   return output(definition).apply((definition) => {
     if (typeof definition === "string") {
       // Case 1: The definition is a handler
       const worker = new Worker(
-        ...transform(argsTransform, name, { handler: definition }, opts || {}),
+        ...transform(argsTransform, name, { accountId, handler: definition }, opts || {}),
       );
       return {
         getWorker: () => worker,
@@ -38,6 +39,7 @@ export function workerBuilder(
           argsTransform,
           name,
           {
+            accountId,
             ...definition,
           },
           opts || {},

--- a/platform/src/components/cloudflare/helpers/wrangler.ts
+++ b/platform/src/components/cloudflare/helpers/wrangler.ts
@@ -26,7 +26,7 @@ export function createWranglerConfig(input: {
   compatibility: WranglerCompatibility;
   environment?: Record<string, string>;
   links?: WranglerLink[];
-  accountID?: string;
+  accountId?: string;
 }) {
   const config: Record<string, any> = {
     ...(input.frameworkConfig ?? {}),
@@ -35,8 +35,8 @@ export function createWranglerConfig(input: {
     compatibility_flags: input.compatibility.flags,
   };
 
-  if (input.accountID) {
-    config.account_id = input.accountID;
+  if (input.accountId) {
+    config.account_id = input.accountId;
   }
 
   const vars: Record<string, string> = {

--- a/platform/src/components/cloudflare/hyperdrive.ts
+++ b/platform/src/components/cloudflare/hyperdrive.ts
@@ -11,6 +11,12 @@ export interface HyperdriveGetArgs {
    * The ID of the existing Hyperdrive config.
    */
   hyperdriveId: string;
+  /**
+   * The Cloudflare account ID the Hyperdrive config belongs to.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: string;
 }
 
 interface HyperdriveRef {
@@ -252,7 +258,7 @@ export class Hyperdrive extends Component implements Link.Linkable {
         args.transform?.hyperdrive,
         `${name}Hyperdrive`,
         {
-        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
+          accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
           caching,
           mtls: args.mtls,
           name: "",
@@ -376,7 +382,7 @@ export class Hyperdrive extends Component implements Link.Linkable {
   ) {
     const hyperdrive = cloudflare.HyperdriveConfig.get(
       `${name}Hyperdrive`,
-      `${DEFAULT_ACCOUNT_ID}/${args.hyperdriveId}`,
+      `${args.accountId ?? DEFAULT_ACCOUNT_ID}/${args.hyperdriveId}`,
       undefined,
       opts,
     );

--- a/platform/src/components/cloudflare/hyperdrive.ts
+++ b/platform/src/components/cloudflare/hyperdrive.ts
@@ -137,6 +137,13 @@ export interface HyperdriveArgs {
      */
     user: Input<string>;
   }>;
+
+  /**
+   * The Cloudflare account ID to use for this Hyperdrive.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
   /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
@@ -245,7 +252,7 @@ export class Hyperdrive extends Component implements Link.Linkable {
         args.transform?.hyperdrive,
         `${name}Hyperdrive`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
           caching,
           mtls: args.mtls,
           name: "",

--- a/platform/src/components/cloudflare/kv.ts
+++ b/platform/src/components/cloudflare/kv.ts
@@ -4,8 +4,15 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link";
 import { binding } from "./binding";
 import { DEFAULT_ACCOUNT_ID } from "./account-id";
+import type { Input } from "../input";
 
 export interface KvArgs {
+  /**
+   * The Cloudflare account ID to use for this KV namespace.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
   /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
@@ -23,6 +30,12 @@ export interface KvGetArgs {
    * The ID of the existing KV namespace.
    */
   namespaceId: string;
+  /**
+   * The Cloudflare account ID the namespace belongs to.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+  */
+  accountId?: string;
 }
 
 interface KvRef {
@@ -87,7 +100,7 @@ export class Kv extends Component implements Link.Linkable {
           `${name}Namespace`,
           {
             title: "",
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: args?.accountId ?? DEFAULT_ACCOUNT_ID,
           },
           { parent },
         ),
@@ -126,7 +139,7 @@ export class Kv extends Component implements Link.Linkable {
   ) {
     const namespace = cloudflare.WorkersKvNamespace.get(
       `${name}Namespace`,
-      `${DEFAULT_ACCOUNT_ID}/${args.namespaceId}`,
+      `${args.accountId ?? DEFAULT_ACCOUNT_ID}/${args.namespaceId}`,
       undefined,
       opts,
     );

--- a/platform/src/components/cloudflare/providers/dns-record.ts
+++ b/platform/src/components/cloudflare/providers/dns-record.ts
@@ -13,6 +13,7 @@ export interface DnsRecordInputs {
     value: Input<string>;
   }>;
   proxied?: Input<boolean>;
+  accountId?: Input<string>;
 }
 
 export interface DnsRecord {
@@ -31,7 +32,7 @@ export class DnsRecord extends dynamic.Resource {
       {
         ...args,
         recordId: undefined,
-        accountId: DEFAULT_ACCOUNT_ID,
+        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
         apiToken:
           $app.providers?.cloudflare?.apiToken ||
           process.env.CLOUDFLARE_API_TOKEN!,

--- a/platform/src/components/cloudflare/providers/worker-assets.ts
+++ b/platform/src/components/cloudflare/providers/worker-assets.ts
@@ -8,6 +8,7 @@ export interface WorkerAssetsInputs {
   manifest: Input<
     Record<string, { hash: string; size: number; contentType: string }>
   >;
+  accountId?: Input<string>;
 }
 
 export interface WorkerAssets {
@@ -27,7 +28,7 @@ export class WorkerAssets extends dynamic.Resource {
       {
         ...args,
         jwt: undefined,
-        accountId: DEFAULT_ACCOUNT_ID,
+        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
         apiToken:
           $app.providers?.cloudflare?.apiToken ||
           process.env.CLOUDFLARE_API_TOKEN!,

--- a/platform/src/components/cloudflare/providers/worker-script.ts
+++ b/platform/src/components/cloudflare/providers/worker-script.ts
@@ -33,7 +33,7 @@ export class WorkerScript extends dynamic.Resource {
       `${name}.sst.cloudflare.WorkerScript`,
       {
         ...args,
-        accountId: DEFAULT_ACCOUNT_ID,
+        accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
         apiToken:
           $app.providers?.cloudflare?.apiToken ||
           process.env.CLOUDFLARE_API_TOKEN!,

--- a/platform/src/components/cloudflare/queue-worker-subscriber.ts
+++ b/platform/src/components/cloudflare/queue-worker-subscriber.ts
@@ -25,6 +25,12 @@ export interface QueueWorkerSubscriberArgs {
    */
   subscriber: Input<string | WorkerArgs>;
   /**
+   * The Cloudflare account ID to use for this subscriber and its consumer.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+  */
+  accountId?: Input<string>;
+  /**
    * The dead letter queue to send messages that fail processing.
    *
    * When `dlq` is configured, `dlq.queue` is required.
@@ -116,6 +122,7 @@ export class QueueWorkerSubscriber extends Component {
 
     const self = this;
     const queue = output(args.queue);
+    const accountId = args.accountId ?? DEFAULT_ACCOUNT_ID;
     const worker = createWorker();
     const batchSize = output(args.batch?.size ?? 10);
     const window = output(args.batch?.window ?? "5 seconds");
@@ -131,6 +138,7 @@ export class QueueWorkerSubscriber extends Component {
         args.subscriber,
         args.transform?.worker,
         { parent: self },
+        accountId,
       );
     }
 
@@ -140,7 +148,7 @@ export class QueueWorkerSubscriber extends Component {
           args.transform?.consumer,
           `${name}Consumer`,
           {
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: accountId,
             deadLetterQueue: args.dlq?.queue,
             queueId: queue.id,
             scriptName: worker.script.scriptName,

--- a/platform/src/components/cloudflare/queue.ts
+++ b/platform/src/components/cloudflare/queue.ts
@@ -11,6 +11,12 @@ import { DurationMinutes, DurationSeconds } from "../duration";
 
 export interface QueueArgs {
   /**
+   * The Cloudflare account ID to use for this Queue.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
+  /**
    * The dead letter queue to send messages that fail processing.
    *
    * When `dlq` is configured, `dlq.queue` is required.
@@ -189,7 +195,7 @@ export class Queue extends Component implements Link.Linkable {
           `${name}Queue`,
           {
             queueName: "",
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: args?.accountId ?? DEFAULT_ACCOUNT_ID,
           },
           { parent },
         ),
@@ -255,6 +261,7 @@ export class Queue extends Component implements Link.Linkable {
       {
         queue: { id: this.queue.id },
         subscriber,
+        accountId: this.constructorArgs?.accountId,
         dlq: this.constructorArgs?.dlq,
         maxConcurrency: this.constructorArgs?.maxConcurrency,
         batch: args?.batch,

--- a/platform/src/components/cloudflare/ssr-site.ts
+++ b/platform/src/components/cloudflare/ssr-site.ts
@@ -139,6 +139,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
         {
           environment: args.environment,
           link: args.link,
+          accountId: args.accountId,
           url: true,
           dev: false,
           domain: args.domain,
@@ -175,7 +176,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
         resolveLinkBindings(),
         compatibility,
         frameworkConfig,
-        args.accountId
+        args.accountId,
       ]).apply(([environment, links, compatibility, frameworkConfig, accountId]) => {
         return createWranglerConfig({
           appName: $app.name,
@@ -239,6 +240,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
           {
             environment: args.environment,
             link: args.link,
+            accountId: args.accountId,
             url: true,
             dev: false,
             domain: args.domain,

--- a/platform/src/components/cloudflare/ssr-site.ts
+++ b/platform/src/components/cloudflare/ssr-site.ts
@@ -13,6 +13,7 @@ import {
 } from "./helpers/wrangler.js";
 import { Link } from "../link.js";
 import { URL_UNAVAILABLE } from "../aws/linkable.js";
+import { DEFAULT_ACCOUNT_ID } from "./account-id.js";
 
 export type Plan = {
   server: string;
@@ -21,6 +22,12 @@ export type Plan = {
 
 export interface SsrSiteArgs extends BaseSsrSiteArgs {
   domain?: WorkerArgs["domain"];
+  /**
+   * The Cloudflare account ID to use for this SsrSite.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
@@ -168,7 +175,8 @@ export abstract class SsrSite extends Component implements Link.Linkable {
         resolveLinkBindings(),
         compatibility,
         frameworkConfig,
-      ]).apply(([environment, links, compatibility, frameworkConfig]) => {
+        args.accountId
+      ]).apply(([environment, links, compatibility, frameworkConfig, accountId]) => {
         return createWranglerConfig({
           appName: $app.name,
           appStage: $app.stage,
@@ -177,7 +185,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
           compatibility,
           environment,
           links,
-          accountID: process.env.CLOUDFLARE_DEFAULT_ACCOUNT_ID,
+          accountId: accountId ?? DEFAULT_ACCOUNT_ID,
         });
       });
     }

--- a/platform/src/components/cloudflare/static-site-v2.ts
+++ b/platform/src/components/cloudflare/static-site-v2.ts
@@ -162,6 +162,12 @@ export interface StaticSiteV2Args extends Omit<BaseStaticSiteArgs, "vite"> {
      */
     server?: Transform<WorkerArgs>;
   };
+  /**
+   * The Cloudflare account ID to use for this StaticSiteV2 and its worker.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
 }
 
 /**
@@ -345,6 +351,7 @@ export class StaticSiteV2 extends Component implements Link.Linkable {
           args.transform?.server,
           `${name}Router`,
           {
+            accountId: args.accountId,
             handler: path.join(
               $cli.paths.platform,
               "functions",

--- a/platform/src/components/cloudflare/static-site.ts
+++ b/platform/src/components/cloudflare/static-site.ts
@@ -293,7 +293,9 @@ export class StaticSite extends Component implements Link.Linkable {
         ...transform(
           args.transform?.assets,
           `${name}Assets`,
-          {},
+          {
+            accountId: args.accountId,
+          },
           {
             parent,
             retainOnDelete: false,
@@ -385,6 +387,7 @@ export class StaticSite extends Component implements Link.Linkable {
       return new Worker(
         `${name}Router`,
         {
+          accountId: args.accountId,
           handler: path.join(
             $cli.paths.platform,
             "functions",

--- a/platform/src/components/cloudflare/static-site.ts
+++ b/platform/src/components/cloudflare/static-site.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { ComponentResourceOptions, all, output } from "@pulumi/pulumi";
+import { ComponentResourceOptions, all, output, type Input } from "@pulumi/pulumi";
 import { Kv, KvArgs } from "./kv.js";
 import { Component, Prettify, Transform, transform } from "../component.js";
 import { Link } from "../link.js";
@@ -133,6 +133,12 @@ export interface StaticSiteArgs extends BaseStaticSiteArgs {
      */
     assets?: Transform<KvArgs>;
   };
+  /**
+   * The Cloudflare account ID to use for this StaticSite and its resources.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
 }
 
 /**
@@ -359,7 +365,7 @@ export class StaticSite extends Component implements Link.Linkable {
       return new KvData(
         `${name}AssetFiles`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+          accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
           namespaceId: storage.id,
           entries: assetManifest.apply((manifest) =>
             manifest.map((m) => ({

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -773,7 +773,7 @@ export class Worker extends Component implements Link.Linkable {
         const zone = new ZoneLookup(
           `${name}Alias${i}ZoneLookup`,
           {
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId,
             domain: hostname,
           },
           { parent },
@@ -782,7 +782,7 @@ export class Worker extends Component implements Link.Linkable {
         new cf.WorkersCustomDomain(
           `${name}Alias${i}Domain`,
           {
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId,
             service: script.scriptName,
             hostname,
             zoneId: zone.id,
@@ -801,7 +801,7 @@ export class Worker extends Component implements Link.Linkable {
         const zone = new ZoneLookup(
           `${resourceName}ZoneLookup`,
           {
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId,
             domain: hostname,
           },
           { parent },

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -310,6 +310,12 @@ export interface WorkerArgs {
     worker?: Transform<cf.WorkersScriptArgs>;
   };
   /**
+   * The Cloudflare account ID to use for this Worker and all its sub-resources.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
+  /**
    * @internal
    * Placehodler for future feature.
    */
@@ -387,6 +393,7 @@ export class Worker extends Component implements Link.Linkable {
 
     const parent = this;
 
+    const accountId = args.accountId ?? DEFAULT_ACCOUNT_ID;
     const dev = normalizeDev();
     const urlEnabled = normalizeUrl();
     const compatibility = normalizeCompatibility(args);
@@ -402,7 +409,7 @@ export class Worker extends Component implements Link.Linkable {
           handler,
           runtime: "worker",
           properties: {
-            accountID: DEFAULT_ACCOUNT_ID,
+            accountID: accountId,
             build,
             compatibility,
           },
@@ -450,7 +457,7 @@ export class Worker extends Component implements Link.Linkable {
             handler,
             runtime: "worker",
             properties: {
-              accountID: DEFAULT_ACCOUNT_ID,
+              accountID: accountId,
               scriptName: script.scriptName,
               build,
               compatibility,
@@ -621,7 +628,7 @@ export class Worker extends Component implements Link.Linkable {
             // workers.dev URLs fail above 54 chars when previews are enabled
             scriptName: prefixName(54, `${name}Script`).toLowerCase(),
             mainModule: "placeholder",
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: accountId,
             contentFile: contentFilePath,
             contentSha256: contentFilePath.apply(async (p) =>
               crypto
@@ -707,7 +714,7 @@ export class Worker extends Component implements Link.Linkable {
       return new WorkerUrl(
         `${name}Url`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+          accountId: accountId,
           scriptName: script.scriptName,
           enabled: urlEnabled,
         },
@@ -723,7 +730,7 @@ export class Worker extends Component implements Link.Linkable {
       return new WorkerPlacement(
         `${name}Placement`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+          accountId: accountId,
           scriptName: script.scriptName,
           // Reapply placement after each script update. Asset-backed SSR workers
           // can rewrite script settings and reset placement back to the default.
@@ -740,7 +747,7 @@ export class Worker extends Component implements Link.Linkable {
       const zone = new ZoneLookup(
         `${name}ZoneLookup`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+          accountId: accountId,
           domain: domain.name,
         },
         { parent },
@@ -749,7 +756,7 @@ export class Worker extends Component implements Link.Linkable {
       return new cf.WorkersCustomDomain(
         `${name}Domain`,
         {
-          accountId: DEFAULT_ACCOUNT_ID,
+          accountId: accountId,
           service: script.scriptName,
           hostname: domain.name,
           zoneId: zone.id,

--- a/platform/src/components/cloudflare/workflow.ts
+++ b/platform/src/components/cloudflare/workflow.ts
@@ -90,6 +90,12 @@ export interface WorkflowArgs {
    */
   environment?: Input<Record<string, Input<string>>>;
   /**
+   * The Cloudflare account ID to use for this Workflow.
+   * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
+   * @internal
+   */
+  accountId?: Input<string>;
+  /**
    * [Transform](/docs/components/#transform) how this component creates its underlying
    * resources.
    */
@@ -224,7 +230,7 @@ export class Workflow extends Component implements Link.Linkable {
           args.transform?.workflow,
           `${name}Workflow`,
           {
-            accountId: DEFAULT_ACCOUNT_ID,
+            accountId: args.accountId ?? DEFAULT_ACCOUNT_ID,
             workflowName: "",
             className: args.className,
             scriptName: worker.nodes.worker.scriptName,

--- a/www/src/content/docs/docs/cloudflare.mdx
+++ b/www/src/content/docs/docs/cloudflare.mdx
@@ -55,6 +55,28 @@ export CLOUDFLARE_DEFAULT_ACCOUNT_ID=aaaaaaaa_aaaaaaaaaaaa_aaaaaaaa
 
 ---
 
+### Deploying into Multiple Cloudflare Accounts
+
+You can deploy cloudflare components into multiple Cloudflare accounts by specifying the accountId argument and providing a different Cloudflare Provider.
+
+```ts
+// define a provider with another api token for a different account
+const provider = new cloudflare.Provider("AnotherProvider", { apiToken: "bbbbbbbb_bbbbbbbbbbbb_bbbbbbbb" });
+
+// specify resource in another account
+const sstWorker = new sst.cloudflare.Worker(
+  "MyWorker",
+  { handler: "index.ts", accountId: "bbbbbbbb-bbbbbbbbbbbb-bbbbbbbb" },
+  { provider },
+);
+```
+
+:::caution
+Do not link any resources which are deployed into different Cloudflare accounts.
+:::
+
+---
+
 ## Components
 
 SST includes Cloudflare components for Workers, storage, queues, cron jobs, AI bindings, and more.


### PR DESCRIPTION
Closes https://github.com/anomalyco/sst/issues/6769

## Context
The Cloudflare provider is a bit weird in the way it expects you to specify the accountId on the resource, but API token on the provider.
SST made the choice to default the accountId to an environment variable for all the resources it provisions, as it is annoying to specify this for every resource, however this makes it difficult for multi-account deployments.
This is compounded as some of the resources can't be accessed/overridden by the transforms property (e.g. the custom domain of a worker).

## This Change
This change simply extends each cloudflare SST component with an optional accountId, which will be used if specified for provisioning/querying all resources within this component.
