### PR TITLE
Fix Resource availability in Next.js and Cloudflare SSR sites

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -2,7 +2,10 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "sst",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/resource/node.js",
+    "./dist/resource/cloudflare.js"
+  ],
   "version": "0.0.0",
   "main": "./dist/index.js",
   "repository": {


### PR DESCRIPTION
Closes #6806

- Fix tree-shaking of `resource/node.ts` side effects by whitelisting `dist/resource/node.js` and `dist/resource/cloudflare.js` in `sideEffects`. Next.js bundlers were skipping the module because `Resource` is now exported from a separate file, so the environment-loading code was never executed.
- Generate `SST_RESOURCE_App` and JSON-stringify non-binding linked resources into `wrangler.jsonc` vars for Cloudflare SSR sites in `sst dev`. Previously only native Cloudflare bindings (R2, KV, D1) were emitted, so `Resource.MySecret.value` threw "SST links are not active" in dev mode.