### PR TITLE
Fix corrupted lambda dev bridge when using Workflow and Function

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2440,7 +2440,9 @@ export class Function extends Component implements Link.Linkable {
             const zipPath = path.resolve(
               $cli.paths.work,
               "artifacts",
-              dev ? `dev-bridge-${regionName}` : name,
+              dev
+                ? `dev-bridge-${regionName}-${logicalName(path.basename(bundle))}`
+                : name,
               "code.zip",
             );
             await fs.promises.mkdir(path.dirname(zipPath), {


### PR DESCRIPTION
## Problem

Fixes https://github.com/anomalyco/sst/issues/6804

The dev bridge code zip was written to a single shared path per region: `.sst/artifacts/dev-bridge-<region>/code.zip.`

In stacks that include both:

- non-durable functions (dev uses `dist/bridge`), and
- durable functions (dev uses `dist/nodejs-bridge`, e.g. Workflows),

SST can build/upload both bridge bundles concurrently during an update (like toggling an env var, adding a link etc). Because both writers targeted the same `code.zip`, the zip contents could interleave and become invalid, leading to `InvalidZipFileException` failures when Lambda tried to unzip the uploaded artifact. 

With the caching behavior this would lock the whole stack into a bad state that had to be completely removed and recreated. 

## Fix

This change makes the dev artifact output folder unique per bundle (includes `logicalName(path.basename(bundle)))`, so each bridge bundle gets its own `code.zip` and concurrent builds cannot corrupt each other.