### PR TITLE
Fix AWS client namespace collision

### DIFF
--- a/sdk/js/src/aws/bus.ts
+++ b/sdk/js/src/aws/bus.ts
@@ -1,4 +1,4 @@
-import { aws } from "./client.js";
+import { awsFetch, type AwsOptions } from "./client.js";
 import { Resource } from "../resource/index.js";
 import { event } from "../event/index.js";
 import { EventBridgeEvent, EventBridgeHandler, Context } from "aws-lambda";
@@ -37,7 +37,7 @@ export namespace bus {
     properties: Definition["$input"],
     options?: {
       metadata?: Definition["$metadata"];
-      aws?: aws.Options;
+      aws?: AwsOptions;
     },
   ): Promise<any> {
     const evt =
@@ -48,7 +48,7 @@ export namespace bus {
             metadata: options?.metadata || {},
           }
         : await def.create(properties, options?.metadata);
-    const res = await aws.fetch(
+    const res = await awsFetch(
       "events",
       "/",
       {

--- a/sdk/js/src/aws/client.ts
+++ b/sdk/js/src/aws/client.ts
@@ -29,55 +29,47 @@ async function getCredentials(url: string): Promise<EC2Credentials> {
 
 type AwsFetchOptions = Exclude<Parameters<AwsClient["fetch"]>[1], null | undefined>;
 
-export namespace aws {
-  export type Options = Exclude<
-    Parameters<AwsClient["fetch"]>[1],
-    null | undefined
-  >["aws"];
-
-  export async function client(): Promise<AwsClient> {
-    if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
-      return new AwsClient({
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
-        region: process.env.AWS_REGION,
-      });
-    }
-
-    if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
-      const credentials = await getCredentials(
-        "http://169.254.170.2" +
-          process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
-      );
-      return new AwsClient({
-        accessKeyId: credentials.AccessKeyId,
-        secretAccessKey: credentials.SecretAccessKey,
-        sessionToken: credentials.Token,
-        region: process.env.AWS_REGION,
-      });
-    }
-
-    throw new Error("No AWS credentials found");
-  }
-
-  export async function fetch(
-    service: string,
-    path: string,
-    init: Omit<AwsFetchOptions, "aws">,
-    options?: { aws?: Options },
-  ) {
-    const c = await client();
-    const region = options?.aws?.region ?? c.region;
-    return c.fetch(`https://${service}.${region}.amazonaws.com${path}`, {
-      ...init,
-      aws: options?.aws,
-    });
-  }
-}
+export type AwsOptions = Exclude<
+  Parameters<AwsClient["fetch"]>[1],
+  null | undefined
+>["aws"];
 
 export async function client(): Promise<AwsClient> {
-  return aws.client();
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    return new AwsClient({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.AWS_REGION,
+    });
+  }
+
+  if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
+    const credentials = await getCredentials(
+      "http://169.254.170.2" +
+        process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+    );
+    return new AwsClient({
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.Token,
+      region: process.env.AWS_REGION,
+    });
+  }
+
+  throw new Error("No AWS credentials found");
 }
 
-export type AwsOptions = aws.Options;
+export async function awsFetch(
+  service: string,
+  path: string,
+  init: Omit<AwsFetchOptions, "aws">,
+  options?: { aws?: AwsOptions },
+) {
+  const c = await client();
+  const region = options?.aws?.region ?? c.region;
+  return c.fetch(`https://${service}.${region}.amazonaws.com${path}`, {
+    ...init,
+    aws: options?.aws,
+  });
+}

--- a/sdk/js/src/aws/task.ts
+++ b/sdk/js/src/aws/task.ts
@@ -1,4 +1,4 @@
-import { aws } from "./client.js";
+import { awsFetch, type AwsOptions } from "./client.js";
 /**
  * The `task` client SDK is available through the following.
  *
@@ -62,7 +62,7 @@ export namespace task {
      * Configure the options for the [aws4fetch](https://github.com/mhart/aws4fetch)
      * [`AWSClient`](https://github.com/mhart/aws4fetch?tab=readme-ov-file#new-awsclientoptions) used internally by the SDK.
      */
-    aws?: aws.Options;
+    aws?: AwsOptions;
   }
 
   export interface RunOptions extends Options {
@@ -152,7 +152,7 @@ export namespace task {
     task: string,
     options?: Options
   ): Promise<DescribeResponse> {
-    const res = await aws.fetch("ecs", "/", {
+    const res = await awsFetch("ecs", "/", {
       method: "POST",
       headers: {
         "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeTasks",
@@ -223,7 +223,7 @@ export namespace task {
     environment?: Record<string, string>,
     options?: RunOptions
   ): Promise<RunResponse> {
-    const res = await aws.fetch("ecs", "/", {
+    const res = await awsFetch("ecs", "/", {
       method: "POST",
       headers: {
         "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.RunTask",
@@ -316,7 +316,7 @@ export namespace task {
     task: string,
     options?: Options
   ): Promise<StopResponse> {
-    const res = await aws.fetch("ecs", "/", {
+    const res = await awsFetch("ecs", "/", {
       method: "POST",
       headers: {
         "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.StopTask",

--- a/sdk/js/src/aws/workflow.ts
+++ b/sdk/js/src/aws/workflow.ts
@@ -1,5 +1,5 @@
 import * as durable from "@aws/durable-execution-sdk-js";
-import { aws } from "./client.js";
+import { awsFetch, type AwsOptions } from "./client.js";
 
 /**
  * The `workflow` SDK is a thin wrapper around the
@@ -119,7 +119,7 @@ export namespace workflow {
      * Configure the options for the [aws4fetch](https://github.com/mhart/aws4fetch)
      * [`AWSClient`](https://github.com/mhart/aws4fetch?tab=readme-ov-file#new-awsclientoptions) used internally by the SDK.
      */
-    aws?: aws.Options;
+    aws?: AwsOptions;
   }
 
   export interface StartResponse {
@@ -243,7 +243,7 @@ export namespace workflow {
     const query = new URLSearchParams({
       Qualifier: resource.qualifier,
     });
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2015-03-31/functions/${encodeURIComponent(
         resource.name,
@@ -310,7 +310,7 @@ export namespace workflow {
     if (startedBefore) params.set("StartedBefore", startedBefore);
     if (direction === "desc") params.set("ReverseOrder", "true");
 
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/functions/${encodeURIComponent(
         resource.name,
@@ -339,7 +339,7 @@ export namespace workflow {
     arn: string,
     options?: Options,
   ): Promise<DescribeResponse> {
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/durable-executions/${encodeURIComponent(arn)}`,
       {
@@ -376,7 +376,7 @@ export namespace workflow {
     input?: StopInput,
     options?: Options,
   ): Promise<StopResponse> {
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/durable-executions/${encodeURIComponent(arn)}/stop`,
       {
@@ -417,7 +417,7 @@ export namespace workflow {
     input: SucceedInput<TPayload> = {},
     options?: Options,
   ): Promise<void> {
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/durable-execution-callbacks/${encodeURIComponent(
         token,
@@ -448,7 +448,7 @@ export namespace workflow {
     input: FailInput,
     options?: Options,
   ): Promise<void> {
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/durable-execution-callbacks/${encodeURIComponent(
         token,
@@ -478,7 +478,7 @@ export namespace workflow {
     token: string,
     options?: Options,
   ): Promise<void> {
-    const response = await aws.fetch(
+    const response = await awsFetch(
       "lambda",
       `/2025-12-01/durable-execution-callbacks/${encodeURIComponent(
         token,

--- a/sdk/js/src/vector/index.ts
+++ b/sdk/js/src/vector/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from "../resource/index.js";
-import { aws } from "../aws/client.js";
+import { client } from "../aws/client.js";
 
 export interface PutEvent {
   /**
@@ -296,7 +296,7 @@ async function invokeFunction<T>(
   attempts = 0
 ): Promise<T> {
   try {
-    const c = await aws.client();
+    const c = await client();
     const endpoint = `https://lambda.${process.env.AWS_REGION}.amazonaws.com/2015-03-31`;
     const response = await c.fetch(
       `${endpoint}/functions/${functionName}/invocations`,


### PR DESCRIPTION
## Summary

- Remove `export namespace aws` from `sdk/js/src/aws/client.ts` which compiled to a mutable `var aws` IIFE that collides with other `aws` identifiers when esbuild flattens module scopes
- Replace with plain function exports (`client`, `awsFetch`) and `AwsOptions` type
- Update all internal consumers (`task.ts`, `bus.ts`, `workflow.ts`, `vector/index.ts`)

Closes #6803