### PR TITLE
Fix external Resources in Cloudflare SSR sites during `sst dev`

### DIFF
--- a/platform/src/components/cloudflare/helpers/wrangler.ts
+++ b/platform/src/components/cloudflare/helpers/wrangler.ts
@@ -15,9 +15,11 @@ export type WranglerLinkInclude = {
 export type WranglerLink = {
   name: string;
   include: WranglerLinkInclude[];
+  properties?: Record<string, unknown>;
 };
 
 export function createWranglerConfig(input: {
+  appName: string;
   appStage: string;
   name: string;
   frameworkConfig?: Record<string, any>;
@@ -37,7 +39,13 @@ export function createWranglerConfig(input: {
     config.account_id = input.accountID;
   }
 
-  const vars = { ...(input.environment ?? {}) };
+  const vars: Record<string, string> = {
+    ...(input.environment ?? {}),
+    SST_RESOURCE_App: JSON.stringify({
+      name: input.appName,
+      stage: input.appStage,
+    }),
+  };
   const kvNamespaces: Record<string, any>[] = [];
   const r2Buckets: Record<string, any>[] = [];
   const d1Databases: Record<string, any>[] = [];
@@ -51,7 +59,13 @@ export function createWranglerConfig(input: {
     const binding = link.include.find(
       (item) => item.type === "cloudflare.binding",
     );
-    if (!binding) continue;
+    // Links without a native Cloudflare binding (Secret, sst.aws.*, custom
+    // Linkable, etc.) are surfaced as JSON-stringified vars so they match
+    // the `secret_text` deploy path handled in `worker.ts buildBindings`.
+    if (!binding) {
+      vars[link.name] = JSON.stringify(link.properties ?? {});
+      continue;
+    }
 
     const properties = binding.properties ?? {};
     switch (binding.binding) {

--- a/platform/src/components/cloudflare/ssr-site.ts
+++ b/platform/src/components/cloudflare/ssr-site.ts
@@ -170,6 +170,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
         frameworkConfig,
       ]).apply(([environment, links, compatibility, frameworkConfig]) => {
         return createWranglerConfig({
+          appName: $app.name,
           appStage: $app.stage,
           name,
           frameworkConfig,
@@ -201,6 +202,7 @@ export abstract class SsrSite extends Component implements Link.Linkable {
           }).apply(({ urn, link }) => ({
             name: urn.split("::").at(-1)!,
             include: link.include ?? [],
+            properties: link.properties,
           })),
         );
         return linkBindings.length > 0 ? all(linkBindings) : [];

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -2,7 +2,10 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "sst",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/resource/node.js",
+    "./dist/resource/cloudflare.js"
+  ],
   "version": "0.0.0",
   "main": "./dist/index.js",
   "repository": {


### PR DESCRIPTION
Closes #6806

- Generate `SST_RESOURCE_App` and JSON-stringify non-binding linked resources into `wrangler.jsonc` vars for Cloudflare SSR sites in `sst dev`. Previously only native Cloudflare bindings (R2, KV, D1) were emitted, so `Resource.MySecret.value` threw "SST links are not active" in dev mode.