### PR TITLE
Fix site builder promise leak by resolving args before acquiring semaphore

### DIFF
--- a/platform/src/components/aws/helpers/site-builder.ts
+++ b/platform/src/components/aws/helpers/site-builder.ts
@@ -1,4 +1,4 @@
-import { all, output, CustomResourceOptions } from "@pulumi/pulumi";
+import { output, CustomResourceOptions } from "@pulumi/pulumi";
 import { Semaphore } from "../../../util/semaphore";
 import { local } from "@pulumi/command";
 
@@ -11,9 +11,9 @@ export function siteBuilder(
   args: local.CommandArgs,
   opts?: CustomResourceOptions,
 ) {
-  const ready = output(limiter.acquire(name));
-  // Wait for the all args values to be resolved before acquiring the semaphore
-  return all([args, ready]).apply(([args]) => {
+  // Wait for all arg values to be resolved before acquiring the semaphore.
+  return output(args).apply(async (args) => {
+    await limiter.acquire(name);
 
     let waitOn;
 


### PR DESCRIPTION
Related #6724

- Change `site-builder.ts` to resolve all `args` values before acquiring the build concurrency semaphore, matching the already-fixed `container-builder.ts` pattern
- Prevents dangling promises when multiple sites are present, which caused Pulumi promise leaks and blocked site builds during `sst refresh` and `sst deploy`