### PR TITLE
Fix SSR site CloudFront invalidation for server-only changes

### DIFF
--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -1858,8 +1858,32 @@ async function handler(event) {
     }
 
     function createInvalidation() {
-      all([args.invalidation, outputPath, plan]).apply(
-        ([invalidationRaw, outputPath, plan]) => {
+      // Resolve server/image-optimizer code hashes so that server-only code
+      // changes also trigger a CloudFront invalidation. Without this, the
+      // version below is derived purely from static assets and an SSR deploy
+      // that only changes the Lambda bundle produces an identical hash,
+      // causing Pulumi to skip the DistributionInvalidation update.
+      const serverCodeHashes = servers.apply((list) =>
+        all(list.map(({ server }) => server.nodes.function.codeSha256)),
+      );
+      const imageOptimizerCodeHash = imageOptimizer.apply(
+        (opt) => opt?.nodes.function.codeSha256,
+      );
+
+      all([
+        args.invalidation,
+        outputPath,
+        plan,
+        serverCodeHashes,
+        imageOptimizerCodeHash,
+      ]).apply(
+        ([
+          invalidationRaw,
+          outputPath,
+          plan,
+          serverCodeHashes,
+          imageOptimizerCodeHash,
+        ]) => {
           // Normalize invalidation
           if (invalidationRaw === false) return;
           const invalidation = {
@@ -1896,6 +1920,12 @@ async function handler(event) {
             invalidationBuildId = plan.buildId;
           } else {
             const hash = crypto.createHash("md5");
+
+            // Fold in server bundle hashes so that changes to server-only
+            // code (e.g. loaders, handlers) invalidate the CloudFront cache
+            // even when no static assets changed.
+            serverCodeHashes.forEach((h) => hash.update(h));
+            if (imageOptimizerCodeHash) hash.update(imageOptimizerCodeHash);
 
             cachedS3Files.forEach((item) => {
               // The below options are needed to support following symlinks when building zip files:


### PR DESCRIPTION
Closes #6797

- Include `codeSha256` of server Lambda functions and image optimizer in the `DistributionInvalidation` version hash, so server-only code changes trigger a CloudFront invalidation even when static assets are unchanged
- Previously the invalidation `version` was derived only from static asset filenames and contents, so SSR deploys that only changed the server bundle produced an identical hash and Pulumi silently skipped the invalidation