### PR TITLE
Fix `sst.aws.Dynamo` incorrectly passes empty rangeKey to pulumi

### DIFF
--- a/platform/src/components/aws/dynamo.ts
+++ b/platform/src/components/aws/dynamo.ts
@@ -557,7 +557,9 @@ export class Dynamo extends Component implements Link.Linkable {
                         }
                       : {
                           hashKey: index.hashKey,
-                          rangeKey: index.rangeKey,
+                          ...(index.rangeKey
+                            ? { rangeKey: index.rangeKey }
+                            : {}),
                         }),
                     ...(index.projection === "keys-only"
                       ? { projectionType: "KEYS_ONLY" }


### PR DESCRIPTION
Closes #6758

- Conditionally include `rangeKey` in global secondary index config only when it's defined
- Prevents Pulumi AWS v7 from coercing `undefined` to `""`, which fails validation because `""` isn't in the table's attribute definitions