### PR TITLE
feat(runtime/go): smart ShouldRebuild via go list -deps

### DIFF
--- a/pkg/runtime/golang/build_test.go
+++ b/pkg/runtime/golang/build_test.go
@@ -1,0 +1,203 @@
+package golang
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testIntegrationEnv returns a minimal, hermetic env for `go list`.
+// GOTOOLCHAIN=local prevents network downloads of mismatched
+// toolchains, GOPROXY=off prevents module fetches, GOMODCACHE/GOCACHE
+// are redirected so the host caches stay untouched.
+func testIntegrationEnv(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+		"GOMODCACHE=" + filepath.Join(t.TempDir(), "modcache"),
+		"GOCACHE=" + filepath.Join(t.TempDir(), "gocache"),
+		"GOPROXY=off",
+		"GOFLAGS=-mod=mod",
+		"GOTOOLCHAIN=local",
+	}
+}
+
+// requireGoToolchain skips when `go test -short` is set or when the
+// `go` binary is not in PATH.
+func requireGoToolchain(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not available: %v", err)
+	}
+}
+
+func TestCaptureDeps_SimpleMain(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	main := filepath.Join(dir, "main.go")
+	mustWriteFile(t, main, "package main\n\nfunc main() {}\n")
+
+	r := New()
+	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	if err != nil {
+		t.Fatalf("captureDeps: %v", err)
+	}
+
+	if _, ok := files[main]; !ok {
+		t.Errorf("expected main.go (%s) in captured files, got %v", main, keys(files))
+	}
+	for f := range files {
+		if !strings.HasPrefix(f, dir) {
+			t.Errorf("captured file outside module root: %s (root=%s)", f, dir)
+		}
+	}
+}
+
+func TestCaptureDeps_LocalDependency(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+
+	mustMkdirAll(t, filepath.Join(dir, "shared"))
+	sharedFile := filepath.Join(dir, "shared", "lib.go")
+	mustWriteFile(t, sharedFile, "package shared\n\nfunc Hello() string { return \"hi\" }\n")
+
+	mainFile := filepath.Join(dir, "main.go")
+	mustWriteFile(t, mainFile,
+		"package main\n\nimport \"example.test/shared\"\n\nfunc main() { _ = shared.Hello() }\n")
+
+	r := New()
+	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	if err != nil {
+		t.Fatalf("captureDeps: %v", err)
+	}
+
+	if _, ok := files[mainFile]; !ok {
+		t.Errorf("expected main.go (%s) in captured files, got %v", mainFile, keys(files))
+	}
+	if _, ok := files[sharedFile]; !ok {
+		t.Errorf("expected shared/lib.go (%s) in captured files, got %v", sharedFile, keys(files))
+	}
+}
+
+func TestCaptureDeps_NoFilesOutsideModuleRoot(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"),
+		"package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
+
+	r := New()
+	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	if err != nil {
+		t.Fatalf("captureDeps: %v", err)
+	}
+
+	for f := range files {
+		if !strings.HasPrefix(f, dir) {
+			t.Errorf("file outside module root leaked into captured set: %s", f)
+		}
+	}
+}
+
+func TestCaptureDeps_NoTestFilesIncluded(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\n\nfunc main() {}\n")
+	testFile := filepath.Join(dir, "main_test.go")
+	mustWriteFile(t, testFile, "package main\n\nimport \"testing\"\n\nfunc TestX(t *testing.T) {}\n")
+
+	r := New()
+	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	if err != nil {
+		t.Fatalf("captureDeps: %v", err)
+	}
+
+	if _, ok := files[testFile]; ok {
+		t.Errorf("test file %s leaked into captured set", testFile)
+	}
+}
+
+func TestCaptureDeps_BrokenSourceFails(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "this is not valid go source")
+
+	r := New()
+	if _, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t)); err == nil {
+		t.Error("expected error on unparseable source, got nil")
+	}
+}
+
+func TestCaptureDeps_SubPackageHandler(t *testing.T) {
+	requireGoToolchain(t)
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+
+	mustMkdirAll(t, filepath.Join(dir, "shared"))
+	sharedFile := filepath.Join(dir, "shared", "lib.go")
+	mustWriteFile(t, sharedFile, "package shared\n\nfunc Hello() string { return \"hi\" }\n")
+
+	mustMkdirAll(t, filepath.Join(dir, "lambdas", "alpha"))
+	alphaFile := filepath.Join(dir, "lambdas", "alpha", "main.go")
+	mustWriteFile(t, alphaFile,
+		"package main\n\nimport \"example.test/shared\"\n\nfunc main() { _ = shared.Hello() }\n")
+
+	mustMkdirAll(t, filepath.Join(dir, "lambdas", "beta"))
+	betaFile := filepath.Join(dir, "lambdas", "beta", "main.go")
+	mustWriteFile(t, betaFile, "package main\n\nfunc main() {}\n")
+
+	r := New()
+	files, err := r.captureDeps(context.Background(), dir, "lambdas/alpha", testIntegrationEnv(t))
+	if err != nil {
+		t.Fatalf("captureDeps: %v", err)
+	}
+
+	if _, ok := files[alphaFile]; !ok {
+		t.Errorf("expected alpha main.go in captured files, got %v", keys(files))
+	}
+	if _, ok := files[sharedFile]; !ok {
+		t.Errorf("expected shared/lib.go in captured files, got %v", keys(files))
+	}
+	if _, ok := files[betaFile]; ok {
+		t.Errorf("beta sibling main.go must NOT be in alpha's import graph: %s", betaFile)
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/runtime/golang/build_test.go
+++ b/pkg/runtime/golang/build_test.go
@@ -12,7 +12,8 @@ import (
 // testIntegrationEnv returns a minimal, hermetic env for `go list`.
 // GOTOOLCHAIN=local prevents network downloads of mismatched
 // toolchains, GOPROXY=off prevents module fetches, GOMODCACHE/GOCACHE
-// are redirected so the host caches stay untouched.
+// are redirected so the host caches stay untouched. GOWORK=off keeps
+// the test isolated from any go.work file the host may have.
 func testIntegrationEnv(t *testing.T) []string {
 	t.Helper()
 	return []string{
@@ -23,6 +24,8 @@ func testIntegrationEnv(t *testing.T) []string {
 		"GOPROXY=off",
 		"GOFLAGS=-mod=mod",
 		"GOTOOLCHAIN=local",
+		"GOWORK=off",
+		"GOSUMDB=off",
 	}
 }
 
@@ -47,10 +50,11 @@ func TestCaptureDeps_SimpleMain(t *testing.T) {
 	mustWriteFile(t, main, "package main\n\nfunc main() {}\n")
 
 	r := New()
-	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	deps, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
 	if err != nil {
 		t.Fatalf("captureDeps: %v", err)
 	}
+	files := deps.files
 
 	if _, ok := files[main]; !ok {
 		t.Errorf("expected main.go (%s) in captured files, got %v", main, keys(files))
@@ -77,10 +81,11 @@ func TestCaptureDeps_LocalDependency(t *testing.T) {
 		"package main\n\nimport \"example.test/shared\"\n\nfunc main() { _ = shared.Hello() }\n")
 
 	r := New()
-	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	deps, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
 	if err != nil {
 		t.Fatalf("captureDeps: %v", err)
 	}
+	files := deps.files
 
 	if _, ok := files[mainFile]; !ok {
 		t.Errorf("expected main.go (%s) in captured files, got %v", mainFile, keys(files))
@@ -99,10 +104,11 @@ func TestCaptureDeps_NoFilesOutsideModuleRoot(t *testing.T) {
 		"package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
 
 	r := New()
-	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	deps, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
 	if err != nil {
 		t.Fatalf("captureDeps: %v", err)
 	}
+	files := deps.files
 
 	for f := range files {
 		if !strings.HasPrefix(f, dir) {
@@ -121,10 +127,11 @@ func TestCaptureDeps_NoTestFilesIncluded(t *testing.T) {
 	mustWriteFile(t, testFile, "package main\n\nimport \"testing\"\n\nfunc TestX(t *testing.T) {}\n")
 
 	r := New()
-	files, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
+	deps, err := r.captureDeps(context.Background(), dir, ".", testIntegrationEnv(t))
 	if err != nil {
 		t.Fatalf("captureDeps: %v", err)
 	}
+	files := deps.files
 
 	if _, ok := files[testFile]; ok {
 		t.Errorf("test file %s leaked into captured set", testFile)
@@ -164,10 +171,11 @@ func TestCaptureDeps_SubPackageHandler(t *testing.T) {
 	mustWriteFile(t, betaFile, "package main\n\nfunc main() {}\n")
 
 	r := New()
-	files, err := r.captureDeps(context.Background(), dir, "lambdas/alpha", testIntegrationEnv(t))
+	deps, err := r.captureDeps(context.Background(), dir, "lambdas/alpha", testIntegrationEnv(t))
 	if err != nil {
 		t.Fatalf("captureDeps: %v", err)
 	}
+	files := deps.files
 
 	if _, ok := files[alphaFile]; !ok {
 		t.Errorf("expected alpha main.go in captured files, got %v", keys(files))

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -22,10 +22,14 @@ import (
 // actually compile into the handler's binary.
 type Runtime struct {
 	mut                sync.RWMutex
-	directories        map[string]string
 	files              map[string]map[string]struct{}
+	pkgDirs            map[string]map[string]struct{}
+	gomodPaths         map[string]string
+	gomodcacheMut      sync.Mutex
 	gomodcache         string
-	gomodcacheOnce     sync.Once
+	gomodcacheResolved bool
+	// gomodcacheOverride is a test seam set at construction time and
+	// never mutated afterwards, so it can be read without the mutex.
 	gomodcacheOverride string
 }
 
@@ -68,8 +72,9 @@ func (w *Worker) Logs() io.ReadCloser {
 // New returns a Runtime with empty per-function state.
 func New() *Runtime {
 	return &Runtime{
-		directories: map[string]string{},
-		files:       map[string]map[string]struct{}{},
+		files:      map[string]map[string]struct{}{},
+		pkgDirs:    map[string]map[string]struct{}{},
+		gomodPaths: map[string]string{},
 	}
 }
 
@@ -122,7 +127,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	cmd := process.Command("go", args...)
 	cmd.Dir = root
 	cmd.Env = env
-	slog.Info("running go build", "cmd", cmd.Args)
+	slog.Debug("running go build", "cmd", cmd.Args)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return &runtime.BuildOutput{
@@ -131,19 +136,23 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	}
 
 	absRoot, _ := filepath.Abs(root)
+	absGomod, _ := filepath.Abs(gomod)
 	deps, depErr := r.captureDeps(ctx, absRoot, src, env)
 
 	r.mut.Lock()
-	r.directories[input.FunctionID] = absRoot
-	if depErr != nil {
-		delete(r.files, input.FunctionID)
-	} else {
-		r.files[input.FunctionID] = deps
+	r.gomodPaths[input.FunctionID] = absGomod
+	// On capture failure keep the previous graph (if any): the next file
+	// edit on a still-tracked file should still rebuild correctly. A
+	// successful build below replaces it; until then we degrade
+	// gracefully rather than disabling rebuild detection entirely.
+	if depErr == nil {
+		r.files[input.FunctionID] = deps.files
+		r.pkgDirs[input.FunctionID] = deps.pkgDirs
 	}
 	r.mut.Unlock()
 
 	if depErr != nil {
-		slog.Warn("failed to capture go deps; ShouldRebuild disabled until next build",
+		slog.Warn("failed to capture go deps; keeping previous graph for rebuild detection",
 			"fn", input.FunctionID,
 			"err", depErr,
 			"root", absRoot,
@@ -181,14 +190,17 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 }
 
 // ShouldRebuild reports whether a file change must trigger a rebuild
-// of the given Lambda. Returns true only when the file is part of the
-// handler's transitive import graph captured by the last Build.
+// of the given Lambda. Fires when the file is in the handler's
+// captured import graph (covers .go, cgo and //go:embed assets), when
+// it is the handler's go.mod/go.sum (those shift the resolved
+// dependency set), or when it is a new .go file inside a directory
+// that already belongs to the captured graph (e.g. a util.go just
+// added to a tracked package).
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
-	if !strings.HasSuffix(file, ".go") {
-		return false
-	}
 	r.mut.RLock()
 	files, ok := r.files[functionID]
+	pkgDirs := r.pkgDirs[functionID]
+	gomod := r.gomodPaths[functionID]
 	r.mut.RUnlock()
 	if !ok {
 		return false
@@ -197,25 +209,49 @@ func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
 	if err != nil {
 		return false
 	}
-	if _, found := files[abs]; !found {
-		return false
+	if _, found := files[abs]; found {
+		slog.Info("rebuilding go function", "fn", functionID, "file", abs, "reason", "file_in_graph")
+		return true
 	}
-	slog.Info("rebuilding go function", "fn", functionID, "file", abs)
-	return true
+	if gomod != "" {
+		gomodDir := filepath.Dir(gomod)
+		if abs == gomod || abs == filepath.Join(gomodDir, "go.sum") {
+			slog.Info("rebuilding go function", "fn", functionID, "file", abs, "reason", "gomod_change")
+			return true
+		}
+	}
+	if strings.HasSuffix(abs, ".go") {
+		for dir := range pkgDirs {
+			if isUnderDir(abs, dir) {
+				slog.Info("rebuilding go function", "fn", functionID, "file", abs, "reason", "new_file_in_pkg")
+				return true
+			}
+		}
+	}
+	return false
 }
 
-func (r *Runtime) captureDeps(ctx context.Context, root, src string, env []string) (map[string]struct{}, error) {
+// capturedDeps holds the result of a single captureDeps run: the set
+// of source files that compile into the handler's binary, plus the
+// set of package directories those files live in (used to detect new
+// files added to an already-tracked package between Builds).
+type capturedDeps struct {
+	files   map[string]struct{}
+	pkgDirs map[string]struct{}
+}
+
+func (r *Runtime) captureDeps(ctx context.Context, root, src string, env []string) (capturedDeps, error) {
 	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-json", "./"+src)
 	cmd.Dir = root
 	cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return capturedDeps{}, err
 	}
 	return parseGoListOutput(strings.NewReader(string(out)), r.resolveGoModCache(env))
 }
 
-func parseGoListOutput(r io.Reader, gomodcache string) (map[string]struct{}, error) {
+func parseGoListOutput(r io.Reader, gomodcache string) (capturedDeps, error) {
 	type pkgInfo struct {
 		Standard   bool
 		Goroot     bool
@@ -225,14 +261,17 @@ func parseGoListOutput(r io.Reader, gomodcache string) (map[string]struct{}, err
 		EmbedFiles []string
 	}
 
-	files := make(map[string]struct{})
+	deps := capturedDeps{
+		files:   make(map[string]struct{}),
+		pkgDirs: make(map[string]struct{}),
+	}
 	dec := json.NewDecoder(r)
 	for {
 		var p pkgInfo
 		if err := dec.Decode(&p); err == io.EOF {
 			break
 		} else if err != nil {
-			return nil, err
+			return capturedDeps{}, err
 		}
 		if p.Standard || p.Goroot {
 			continue
@@ -240,30 +279,36 @@ func parseGoListOutput(r io.Reader, gomodcache string) (map[string]struct{}, err
 		if gomodcache != "" && isUnderDir(p.Dir, gomodcache) {
 			continue
 		}
+		deps.pkgDirs[p.Dir] = struct{}{}
 		all := make([]string, 0, len(p.GoFiles)+len(p.CgoFiles)+len(p.EmbedFiles))
 		all = append(all, p.GoFiles...)
 		all = append(all, p.CgoFiles...)
 		all = append(all, p.EmbedFiles...)
 		for _, name := range all {
-			files[filepath.Join(p.Dir, name)] = struct{}{}
+			deps.files[filepath.Join(p.Dir, name)] = struct{}{}
 		}
 	}
-	return files, nil
+	return deps, nil
 }
 
 func (r *Runtime) resolveGoModCache(env []string) string {
 	if r.gomodcacheOverride != "" {
 		return r.gomodcacheOverride
 	}
-	r.gomodcacheOnce.Do(func() {
-		cmd := exec.Command("go", "env", "GOMODCACHE")
-		cmd.Env = env
-		out, err := cmd.Output()
-		if err != nil {
-			return
-		}
-		r.gomodcache = strings.TrimSpace(string(out))
-	})
+	r.gomodcacheMut.Lock()
+	defer r.gomodcacheMut.Unlock()
+	if r.gomodcacheResolved {
+		return r.gomodcache
+	}
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		slog.Warn("failed to resolve GOMODCACHE; will retry on next build", "err", err)
+		return ""
+	}
+	r.gomodcache = strings.TrimSpace(string(out))
+	r.gomodcacheResolved = true
 	return r.gomodcache
 }
 

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -16,21 +16,33 @@ import (
 	"github.com/sst/sst/v3/pkg/runtime"
 )
 
+// Runtime implements [runtime.Runtime] for Go-based Lambda functions.
+// It builds each handler with `go build` and tracks the per-handler
+// import graph so [Runtime.ShouldRebuild] only fires for files that
+// actually compile into the handler's binary.
 type Runtime struct {
-	mut         sync.Mutex
-	directories map[string]string
+	mut                sync.RWMutex
+	directories        map[string]string
+	files              map[string]map[string]struct{}
+	gomodcache         string
+	gomodcacheOnce     sync.Once
+	gomodcacheOverride string
 }
 
+// Worker is a running Lambda handler binary started by [Runtime.Run].
 type Worker struct {
 	stdout io.ReadCloser
 	stderr io.ReadCloser
 	cmd    *exec.Cmd
 }
 
+// Stop terminates the running worker process.
 func (w *Worker) Stop() {
 	process.Kill(w.cmd.Process)
 }
 
+// Logs returns a single reader that streams the worker's stdout and
+// stderr interleaved.
 func (w *Worker) Logs() io.ReadCloser {
 	reader, writer := io.Pipe()
 
@@ -53,23 +65,39 @@ func (w *Worker) Logs() io.ReadCloser {
 	return reader
 }
 
+// New returns a Runtime with empty per-function state.
 func New() *Runtime {
 	return &Runtime{
 		directories: map[string]string{},
+		files:       map[string]map[string]struct{}{},
 	}
 }
 
+// Match reports whether this Runtime handles functions declared with
+// `runtime: "go"`.
 func (r *Runtime) Match(runtime string) bool {
 	return runtime == "go"
 }
 
+// Properties is the runtime-specific configuration block in the SST
+// component output for a Go function.
 type Properties struct {
 	Architecture string `json:"architecture"`
 }
 
+func goarchFromArchitecture(arch string) string {
+	if arch == "arm64" {
+		return "arm64"
+	}
+	return "amd64"
+}
+
+// Build compiles the handler with `go build` and captures its
+// transitive import graph for use by ShouldRebuild. A failed compile is
+// returned as a non-nil BuildOutput with errors; a failed graph capture
+// is logged and disables ShouldRebuild for that function until the
+// next successful build.
 func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtime.BuildOutput, error) {
-	r.mut.Lock()
-	defer r.mut.Unlock()
 	var properties Properties
 	json.Unmarshal(input.Properties, &properties)
 
@@ -77,7 +105,6 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	if err != nil {
 		return nil, err
 	}
-	// root of go project
 	root := filepath.Dir(gomod)
 	src, _ := filepath.Rel(root, input.Handler)
 	out := filepath.Join(input.Out(), "bootstrap")
@@ -87,12 +114,11 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		args = append(args, "-ldflags", "-s -w")
 		env = append(env, "CGO_ENABLED=0")
 		env = append(env, "GOOS=linux")
-		env = append(env, "GOARCH=amd64")
-		if properties.Architecture == "arm64" {
-			env = append(env, "GOARCH=arm64")
-		}
+		env = append(env, "GOARCH="+goarchFromArchitecture(properties.Architecture))
 	}
-	args = append(args, "-o", out, src)
+	// "./" prefix forces relative path resolution; without it `go build`
+	// treats a sub-path like "commands/connect" as a stdlib package name.
+	args = append(args, "-o", out, "./"+src)
 	cmd := process.Command("go", args...)
 	cmd.Dir = root
 	cmd.Env = env
@@ -103,7 +129,30 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 			Errors: []string{string(output)},
 		}, nil
 	}
-	r.directories[input.FunctionID], _ = filepath.Abs(root)
+
+	absRoot, _ := filepath.Abs(root)
+	deps, depErr := r.captureDeps(ctx, absRoot, src, env)
+
+	r.mut.Lock()
+	r.directories[input.FunctionID] = absRoot
+	if depErr != nil {
+		delete(r.files, input.FunctionID)
+	} else {
+		r.files[input.FunctionID] = deps
+	}
+	r.mut.Unlock()
+
+	if depErr != nil {
+		slog.Warn("failed to capture go deps; ShouldRebuild disabled until next build",
+			"fn", input.FunctionID,
+			"err", depErr,
+			"root", absRoot,
+			"src", src,
+			"goflags", os.Getenv("GOFLAGS"),
+			"gomodcache", r.resolveGoModCache(env),
+		)
+	}
+
 	return &runtime.BuildOutput{
 		Handler:    "bootstrap",
 		Sourcemaps: []string{},
@@ -112,6 +161,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	}, nil
 }
 
+// Run starts the previously-built handler binary as a worker.
 func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Worker, error) {
 	cmd := process.Command(
 		filepath.Join(input.Build.Out, input.Build.Handler),
@@ -130,18 +180,102 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	}, nil
 }
 
+// ShouldRebuild reports whether a file change must trigger a rebuild
+// of the given Lambda. Returns true only when the file is part of the
+// handler's transitive import graph captured by the last Build.
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
 	if !strings.HasSuffix(file, ".go") {
 		return false
 	}
-	match, ok := r.directories[functionID]
+	r.mut.RLock()
+	files, ok := r.files[functionID]
+	r.mut.RUnlock()
 	if !ok {
 		return false
 	}
-	slog.Info("checking if file needs to be rebuilt", "file", file, "match", match)
-	rel, err := filepath.Rel(match, file)
+	abs, err := filepath.Abs(file)
 	if err != nil {
 		return false
 	}
-	return !strings.HasPrefix(rel, "..")
+	if _, found := files[abs]; !found {
+		return false
+	}
+	slog.Info("rebuilding go function", "fn", functionID, "file", abs)
+	return true
+}
+
+func (r *Runtime) captureDeps(ctx context.Context, root, src string, env []string) (map[string]struct{}, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-json", "./"+src)
+	cmd.Dir = root
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGoListOutput(strings.NewReader(string(out)), r.resolveGoModCache(env))
+}
+
+func parseGoListOutput(r io.Reader, gomodcache string) (map[string]struct{}, error) {
+	type pkgInfo struct {
+		Standard   bool
+		Goroot     bool
+		Dir        string
+		GoFiles    []string
+		CgoFiles   []string
+		EmbedFiles []string
+	}
+
+	files := make(map[string]struct{})
+	dec := json.NewDecoder(r)
+	for {
+		var p pkgInfo
+		if err := dec.Decode(&p); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if p.Standard || p.Goroot {
+			continue
+		}
+		if gomodcache != "" && isUnderDir(p.Dir, gomodcache) {
+			continue
+		}
+		all := make([]string, 0, len(p.GoFiles)+len(p.CgoFiles)+len(p.EmbedFiles))
+		all = append(all, p.GoFiles...)
+		all = append(all, p.CgoFiles...)
+		all = append(all, p.EmbedFiles...)
+		for _, name := range all {
+			files[filepath.Join(p.Dir, name)] = struct{}{}
+		}
+	}
+	return files, nil
+}
+
+func (r *Runtime) resolveGoModCache(env []string) string {
+	if r.gomodcacheOverride != "" {
+		return r.gomodcacheOverride
+	}
+	r.gomodcacheOnce.Do(func() {
+		cmd := exec.Command("go", "env", "GOMODCACHE")
+		cmd.Env = env
+		out, err := cmd.Output()
+		if err != nil {
+			return
+		}
+		r.gomodcache = strings.TrimSpace(string(out))
+	})
+	return r.gomodcache
+}
+
+func isUnderDir(path, dir string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanDir := filepath.Clean(dir)
+	if cleanPath == cleanDir {
+		return true
+	}
+	rel, err := filepath.Rel(cleanDir, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -16,21 +16,33 @@ import (
 	"github.com/sst/sst/v3/pkg/runtime"
 )
 
+// Runtime implements [runtime.Runtime] for Go-based Lambda functions.
+// It builds each handler with `go build` and tracks the per-handler
+// import graph so [Runtime.ShouldRebuild] only fires for files that
+// actually compile into the handler's binary.
 type Runtime struct {
-	mut         sync.Mutex
-	directories map[string]string
+	mut                sync.RWMutex
+	directories        map[string]string
+	files              map[string]map[string]struct{}
+	gomodcache         string
+	gomodcacheOnce     sync.Once
+	gomodcacheOverride string
 }
 
+// Worker is a running Lambda handler binary started by [Runtime.Run].
 type Worker struct {
 	stdout io.ReadCloser
 	stderr io.ReadCloser
 	cmd    *exec.Cmd
 }
 
+// Stop terminates the running worker process.
 func (w *Worker) Stop() {
 	process.Kill(w.cmd.Process)
 }
 
+// Logs returns a single reader that streams the worker's stdout and
+// stderr interleaved.
 func (w *Worker) Logs() io.ReadCloser {
 	reader, writer := io.Pipe()
 
@@ -53,23 +65,39 @@ func (w *Worker) Logs() io.ReadCloser {
 	return reader
 }
 
+// New returns a Runtime with empty per-function state.
 func New() *Runtime {
 	return &Runtime{
 		directories: map[string]string{},
+		files:       map[string]map[string]struct{}{},
 	}
 }
 
+// Match reports whether this Runtime handles functions declared with
+// `runtime: "go"`.
 func (r *Runtime) Match(runtime string) bool {
 	return runtime == "go"
 }
 
+// Properties is the runtime-specific configuration block in the SST
+// component output for a Go function.
 type Properties struct {
 	Architecture string `json:"architecture"`
 }
 
+func goarchFromArchitecture(arch string) string {
+	if arch == "arm64" {
+		return "arm64"
+	}
+	return "amd64"
+}
+
+// Build compiles the handler with `go build` and captures its
+// transitive import graph for use by ShouldRebuild. A failed compile is
+// returned as a non-nil BuildOutput with errors; a failed graph capture
+// is logged and disables ShouldRebuild for that function until the
+// next successful build.
 func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtime.BuildOutput, error) {
-	r.mut.Lock()
-	defer r.mut.Unlock()
 	var properties Properties
 	json.Unmarshal(input.Properties, &properties)
 
@@ -77,7 +105,6 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	if err != nil {
 		return nil, err
 	}
-	// root of go project
 	root := filepath.Dir(gomod)
 	src, _ := filepath.Rel(root, input.Handler)
 	out := filepath.Join(input.Out(), "bootstrap")
@@ -87,12 +114,11 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		args = append(args, "-ldflags", "-s -w")
 		env = append(env, "CGO_ENABLED=0")
 		env = append(env, "GOOS=linux")
-		env = append(env, "GOARCH=amd64")
-		if properties.Architecture == "arm64" {
-			env = append(env, "GOARCH=arm64")
-		}
+		env = append(env, "GOARCH="+goarchFromArchitecture(properties.Architecture))
 	}
-	args = append(args, "-o", out, src)
+	// "./" prefix forces relative path resolution; without it `go build`
+	// treats a sub-path like "commands/connect" as a stdlib package name.
+	args = append(args, "-o", out, "./"+src)
 	cmd := process.Command("go", args...)
 	cmd.Dir = root
 	cmd.Env = env
@@ -103,7 +129,30 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 			Errors: []string{string(output)},
 		}, nil
 	}
-	r.directories[input.FunctionID], _ = filepath.Abs(root)
+
+	absRoot, _ := filepath.Abs(root)
+	deps, depErr := r.captureDeps(ctx, absRoot, src, env)
+
+	r.mut.Lock()
+	r.directories[input.FunctionID] = absRoot
+	if depErr != nil {
+		delete(r.files, input.FunctionID)
+	} else {
+		r.files[input.FunctionID] = deps
+	}
+	r.mut.Unlock()
+
+	if depErr != nil {
+		slog.Warn("failed to capture go deps; ShouldRebuild disabled until next build",
+			"fn", input.FunctionID,
+			"err", depErr,
+			"root", absRoot,
+			"src", src,
+			"goflags", os.Getenv("GOFLAGS"),
+			"gomodcache", r.resolveGoModCache(env),
+		)
+	}
+
 	return &runtime.BuildOutput{
 		Handler:    "bootstrap",
 		Sourcemaps: []string{},
@@ -112,6 +161,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	}, nil
 }
 
+// Run starts the previously-built handler binary as a worker.
 func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Worker, error) {
 	cmd := process.Command(
 		filepath.Join(input.Build.Out, input.Build.Handler),
@@ -130,20 +180,104 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	}, nil
 }
 
+// ShouldRebuild reports whether a file change must trigger a rebuild
+// of the given Lambda. Returns true only when the file is part of the
+// handler's transitive import graph captured by the last Build.
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
 	if !strings.HasSuffix(file, ".go") {
 		return false
 	}
-	match, ok := r.directories[functionID]
+	r.mut.RLock()
+	files, ok := r.files[functionID]
+	r.mut.RUnlock()
 	if !ok {
 		return false
 	}
-	slog.Info("checking if file needs to be rebuilt", "file", file, "match", match)
-	rel, err := filepath.Rel(match, file)
+	abs, err := filepath.Abs(file)
 	if err != nil {
 		return false
 	}
-	return !strings.HasPrefix(rel, "..")
+	if _, found := files[abs]; !found {
+		return false
+	}
+	slog.Info("rebuilding go function", "fn", functionID, "file", abs)
+	return true
+}
+
+func (r *Runtime) captureDeps(ctx context.Context, root, src string, env []string) (map[string]struct{}, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-json", "./"+src)
+	cmd.Dir = root
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGoListOutput(strings.NewReader(string(out)), r.resolveGoModCache(env))
+}
+
+func parseGoListOutput(r io.Reader, gomodcache string) (map[string]struct{}, error) {
+	type pkgInfo struct {
+		Standard   bool
+		Goroot     bool
+		Dir        string
+		GoFiles    []string
+		CgoFiles   []string
+		EmbedFiles []string
+	}
+
+	files := make(map[string]struct{})
+	dec := json.NewDecoder(r)
+	for {
+		var p pkgInfo
+		if err := dec.Decode(&p); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if p.Standard || p.Goroot {
+			continue
+		}
+		if gomodcache != "" && isUnderDir(p.Dir, gomodcache) {
+			continue
+		}
+		all := make([]string, 0, len(p.GoFiles)+len(p.CgoFiles)+len(p.EmbedFiles))
+		all = append(all, p.GoFiles...)
+		all = append(all, p.CgoFiles...)
+		all = append(all, p.EmbedFiles...)
+		for _, name := range all {
+			files[filepath.Join(p.Dir, name)] = struct{}{}
+		}
+	}
+	return files, nil
+}
+
+func (r *Runtime) resolveGoModCache(env []string) string {
+	if r.gomodcacheOverride != "" {
+		return r.gomodcacheOverride
+	}
+	r.gomodcacheOnce.Do(func() {
+		cmd := exec.Command("go", "env", "GOMODCACHE")
+		cmd.Env = env
+		out, err := cmd.Output()
+		if err != nil {
+			return
+		}
+		r.gomodcache = strings.TrimSpace(string(out))
+	})
+	return r.gomodcache
+}
+
+func isUnderDir(path, dir string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanDir := filepath.Clean(dir)
+	if cleanPath == cleanDir {
+		return true
+	}
+	rel, err := filepath.Rel(cleanDir, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // ShouldRunEagerly returns true for Go - workers restart immediately after rebuild.

--- a/pkg/runtime/golang/golang_test.go
+++ b/pkg/runtime/golang/golang_test.go
@@ -57,29 +57,135 @@ func TestGoarchFromArchitecture(t *testing.T) {
 	}
 }
 
-func TestShouldRebuild_NonGoFile(t *testing.T) {
+func TestShouldRebuild_UntrackedFiles(t *testing.T) {
 	t.Parallel()
 	r := New()
 	r.files["fn"] = map[string]struct{}{absPath("abs", "path", "handler.go"): {}}
+	r.gomodPaths["fn"] = absPath("abs", "path", "go.mod")
 
+	// Files that are not in the captured graph and are not the
+	// handler's go.mod/go.sum must not trigger a rebuild.
 	tests := []struct {
 		name string
 		file string
 	}{
-		{"txt", absPath("abs", "path", "handler.txt")},
-		{"md", absPath("abs", "path", "README.md")},
-		{"go.bak", absPath("abs", "path", "handler.go.bak")},
+		{"unrelated txt", absPath("abs", "path", "notes.txt")},
+		{"unrelated md", absPath("abs", "path", "README.md")},
+		{"editor backup", absPath("abs", "path", "handler.go.bak")},
 		{"no extension", absPath("abs", "path", "handler")},
-		// HasSuffix is case-sensitive; ".GO" must NOT match ".go".
+		// HasSuffix is case-sensitive — ".GO" is not ".go", but the
+		// graph lookup is exact, so it doesn't match anyway.
 		{"uppercase extension", absPath("abs", "path", "handler.GO")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if r.ShouldRebuild("fn", tt.file) {
-				t.Errorf("expected false for non-.go file %q", tt.file)
+				t.Errorf("expected false for untracked file %q", tt.file)
 			}
 		})
+	}
+}
+
+func TestShouldRebuild_EmbedAssetInGraph(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dir := t.TempDir()
+	asset := filepath.Join(dir, "template.html")
+	r.files["fn"] = map[string]struct{}{asset: {}}
+
+	// //go:embed assets are captured by parseGoListOutput as part of
+	// the file set even though they are not .go sources. Editing them
+	// must trigger a rebuild because they compile into the binary.
+	if !r.ShouldRebuild("fn", asset) {
+		t.Errorf("expected true for tracked embed asset: %s", asset)
+	}
+}
+
+func TestShouldRebuild_GoModAndGoSum(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+	gosum := filepath.Join(dir, "go.sum")
+	mustWriteFile(t, gomod, "module example.test\n\ngo 1.22\n")
+
+	r.files["fn"] = map[string]struct{}{filepath.Join(dir, "main.go"): {}}
+	r.gomodPaths["fn"] = gomod
+
+	// go.mod and go.sum changes shift the resolved dependency set, so
+	// they must trigger a rebuild even though they are not in the file
+	// graph (which only contains .go/cgo/embed sources).
+	if !r.ShouldRebuild("fn", gomod) {
+		t.Errorf("expected true for handler's go.mod: %s", gomod)
+	}
+	if !r.ShouldRebuild("fn", gosum) {
+		t.Errorf("expected true for handler's go.sum: %s", gosum)
+	}
+}
+
+func TestShouldRebuild_OtherHandlersGoModIgnored(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	r.files["a"] = map[string]struct{}{filepath.Join(dirA, "main.go"): {}}
+	r.gomodPaths["a"] = filepath.Join(dirA, "go.mod")
+	r.files["b"] = map[string]struct{}{filepath.Join(dirB, "main.go"): {}}
+	r.gomodPaths["b"] = filepath.Join(dirB, "go.mod")
+
+	// Editing handler B's go.mod must not rebuild handler A — they
+	// live in separate modules.
+	if r.ShouldRebuild("a", filepath.Join(dirB, "go.mod")) {
+		t.Errorf("expected false: handler A should ignore handler B's go.mod")
+	}
+}
+
+func TestShouldRebuild_NewFileInTrackedPackage(t *testing.T) {
+	t.Parallel()
+	r := New()
+	pkgDir := t.TempDir()
+	existing := filepath.Join(pkgDir, "existing.go")
+	added := filepath.Join(pkgDir, "added.go")
+
+	r.files["fn"] = map[string]struct{}{existing: {}}
+	r.pkgDirs["fn"] = map[string]struct{}{pkgDir: {}}
+
+	// Editing a brand-new .go file inside a tracked package directory
+	// must trigger a rebuild even though the file path itself is not
+	// in the captured set yet — the next Build re-captures the graph.
+	if !r.ShouldRebuild("fn", added) {
+		t.Errorf("expected true for new .go file in tracked package dir: %s", added)
+	}
+}
+
+func TestShouldRebuild_NewFileInUntrackedDir(t *testing.T) {
+	t.Parallel()
+	r := New()
+	tracked := t.TempDir()
+	other := t.TempDir()
+	r.files["fn"] = map[string]struct{}{filepath.Join(tracked, "main.go"): {}}
+	r.pkgDirs["fn"] = map[string]struct{}{tracked: {}}
+
+	// A .go file in a directory the handler doesn't transitively
+	// import must not trigger a rebuild.
+	if r.ShouldRebuild("fn", filepath.Join(other, "stranger.go")) {
+		t.Errorf("expected false for .go file in untracked directory")
+	}
+}
+
+func TestShouldRebuild_NonGoFileInTrackedDirIgnored(t *testing.T) {
+	t.Parallel()
+	r := New()
+	pkgDir := t.TempDir()
+	r.files["fn"] = map[string]struct{}{filepath.Join(pkgDir, "main.go"): {}}
+	r.pkgDirs["fn"] = map[string]struct{}{pkgDir: {}}
+
+	// The "new file in tracked dir" fallback only applies to .go
+	// files; an untracked non-go file inside a tracked package
+	// (editor swap, log, build artifact) must not trigger a rebuild.
+	if r.ShouldRebuild("fn", filepath.Join(pkgDir, "scratch.tmp")) {
+		t.Errorf("expected false for non-.go file in tracked dir")
 	}
 }
 
@@ -217,7 +323,7 @@ func TestParseGoListOutput_FiltersStdlibAndGOMODCACHE(t *testing.T) {
 		`{"Standard": false, "Goroot": false, "Dir": ` + jsonStr(siblingDir) + `, "GoFiles": ["replaced.go"]}`,
 	}, "\n")
 
-	files, err := parseGoListOutput(strings.NewReader(stream), gomodcache)
+	deps, err := parseGoListOutput(strings.NewReader(stream), gomodcache)
 	if err != nil {
 		t.Fatalf("parseGoListOutput: %v", err)
 	}
@@ -227,16 +333,30 @@ func TestParseGoListOutput_FiltersStdlibAndGOMODCACHE(t *testing.T) {
 		filepath.Join(siblingDir, "replaced.go"),
 	}
 	for _, want := range wantKept {
-		if _, ok := files[want]; !ok {
-			t.Errorf("expected %q in result, got %v", want, keys(files))
+		if _, ok := deps.files[want]; !ok {
+			t.Errorf("expected %q in files, got %v", want, keys(deps.files))
 		}
 	}
-	for f := range files {
+	wantDirs := []string{localDir, siblingDir}
+	for _, want := range wantDirs {
+		if _, ok := deps.pkgDirs[want]; !ok {
+			t.Errorf("expected %q in pkgDirs, got %v", want, keys(deps.pkgDirs))
+		}
+	}
+	for f := range deps.files {
 		if strings.HasPrefix(f, gomodcache) {
 			t.Errorf("module-cache file leaked into result: %s", f)
 		}
 		if strings.HasPrefix(f, stdlibDir) {
 			t.Errorf("stdlib file leaked into result: %s", f)
+		}
+	}
+	for d := range deps.pkgDirs {
+		if strings.HasPrefix(d, gomodcache) {
+			t.Errorf("module-cache dir leaked into pkgDirs: %s", d)
+		}
+		if strings.HasPrefix(d, stdlibDir) {
+			t.Errorf("stdlib dir leaked into pkgDirs: %s", d)
 		}
 	}
 }

--- a/pkg/runtime/golang/golang_test.go
+++ b/pkg/runtime/golang/golang_test.go
@@ -1,0 +1,247 @@
+package golang
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func absPath(parts ...string) string {
+	return string(filepath.Separator) + filepath.Join(parts...)
+}
+
+func TestProperties_JSONFieldName(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"arm64", `{"architecture": "arm64"}`, "arm64"},
+		{"x86_64", `{"architecture": "x86_64"}`, "x86_64"},
+		{"empty", `{}`, ""},
+		{"extra fields ignored", `{"architecture": "arm64", "memory": 512}`, "arm64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got Properties
+			if err := json.Unmarshal([]byte(tt.payload), &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got.Architecture != tt.want {
+				t.Errorf("Architecture = %q, want %q", got.Architecture, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoarchFromArchitecture(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"arm64", "arm64"},
+		{"x86_64", "amd64"},
+		{"", "amd64"},
+		{"unknown-arch", "amd64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			t.Parallel()
+			if got := goarchFromArchitecture(tt.arch); got != tt.want {
+				t.Errorf("goarchFromArchitecture(%q) = %q, want %q", tt.arch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRebuild_NonGoFile(t *testing.T) {
+	t.Parallel()
+	r := New()
+	r.files["fn"] = map[string]struct{}{absPath("abs", "path", "handler.go"): {}}
+
+	tests := []struct {
+		name string
+		file string
+	}{
+		{"txt", absPath("abs", "path", "handler.txt")},
+		{"md", absPath("abs", "path", "README.md")},
+		{"go.bak", absPath("abs", "path", "handler.go.bak")},
+		{"no extension", absPath("abs", "path", "handler")},
+		// HasSuffix is case-sensitive; ".GO" must NOT match ".go".
+		{"uppercase extension", absPath("abs", "path", "handler.GO")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if r.ShouldRebuild("fn", tt.file) {
+				t.Errorf("expected false for non-.go file %q", tt.file)
+			}
+		})
+	}
+}
+
+func TestShouldRebuild_NoCapturedGraph(t *testing.T) {
+	t.Parallel()
+	r := New()
+	if r.ShouldRebuild("fn", absPath("abs", "path", "handler.go")) {
+		t.Error("expected false when no graph has been captured")
+	}
+}
+
+func TestShouldRebuild_FileInGraph(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dir := t.TempDir()
+	handler := filepath.Join(dir, "handler.go")
+	r.files["fn"] = map[string]struct{}{handler: {}}
+
+	if !r.ShouldRebuild("fn", handler) {
+		t.Errorf("expected true for file in graph: %s", handler)
+	}
+}
+
+func TestShouldRebuild_FileNotInGraph(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dir := t.TempDir()
+	handler := filepath.Join(dir, "handler.go")
+	other := filepath.Join(dir, "other.go")
+	r.files["fn"] = map[string]struct{}{handler: {}}
+
+	if r.ShouldRebuild("fn", other) {
+		t.Errorf("expected false for file not in graph: %s", other)
+	}
+}
+
+func TestShouldRebuild_RelativePathIsResolved(t *testing.T) {
+	r := New()
+	dir := t.TempDir()
+	handler := filepath.Join(dir, "handler.go")
+	mustWriteFile(t, handler, "package main\n")
+	r.files["fn"] = map[string]struct{}{handler: {}}
+
+	t.Chdir(dir)
+	if !r.ShouldRebuild("fn", "handler.go") {
+		t.Errorf("expected true for relative path \"handler.go\" with cwd=%s", dir)
+	}
+}
+
+func TestRuntime_ConcurrentShouldRebuild(t *testing.T) {
+	t.Parallel()
+	r := New()
+	dir := t.TempDir()
+	handler := filepath.Join(dir, "handler.go")
+	r.files["fn"] = map[string]struct{}{handler: {}}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				r.ShouldRebuild("fn", handler)
+			}
+		}()
+	}
+
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			fn := "fn" + string(rune('A'+i%26))
+			for range 50 {
+				r.mut.Lock()
+				r.files[fn] = map[string]struct{}{handler: {}}
+				r.mut.Unlock()
+			}
+		}(i)
+	}
+
+	// Writer that hits the same key the readers query.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			r.mut.Lock()
+			r.files["fn"] = map[string]struct{}{handler: {}}
+			r.mut.Unlock()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestIsUnderDir(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		dir  string
+		want bool
+	}{
+		{"descendant", absPath("a", "b", "c"), absPath("a"), true},
+		{"direct child", absPath("a", "b", "c"), absPath("a", "b"), true},
+		{"identity", absPath("a", "b", "c"), absPath("a", "b", "c"), true},
+		{"deeper than dir", absPath("a", "b", "c"), absPath("a", "b", "c", "d"), false},
+		{"unrelated", absPath("a", "b", "c"), absPath("x"), false},
+		{"prefix-only must not match", absPath("a", "b", "c"), absPath("a", "b", "cd"), false},
+		{"trailing separator", absPath("a", "b", "c") + string(filepath.Separator), absPath("a", "b"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isUnderDir(tt.path, tt.dir); got != tt.want {
+				t.Errorf("isUnderDir(%q, %q) = %v, want %v", tt.path, tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGoListOutput_FiltersStdlibAndGOMODCACHE(t *testing.T) {
+	t.Parallel()
+	gomodcache := absPath("home", "user", "go", "pkg", "mod")
+	localDir := absPath("repo", "services")
+	stdlibDir := absPath("usr", "local", "go", "src", "fmt")
+	modcacheDir := filepath.Join(gomodcache, "github.com", "foo", "bar@v1.0.0")
+	siblingDir := absPath("workspace", "shared-replace")
+
+	stream := strings.Join([]string{
+		`{"Standard": false, "Goroot": false, "Dir": ` + jsonStr(localDir) + `, "GoFiles": ["main.go"]}`,
+		`{"Standard": true,  "Goroot": true,  "Dir": ` + jsonStr(stdlibDir) + `, "GoFiles": ["print.go"]}`,
+		`{"Standard": false, "Goroot": false, "Dir": ` + jsonStr(modcacheDir) + `, "GoFiles": ["lib.go"]}`,
+		`{"Standard": false, "Goroot": false, "Dir": ` + jsonStr(siblingDir) + `, "GoFiles": ["replaced.go"]}`,
+	}, "\n")
+
+	files, err := parseGoListOutput(strings.NewReader(stream), gomodcache)
+	if err != nil {
+		t.Fatalf("parseGoListOutput: %v", err)
+	}
+
+	wantKept := []string{
+		filepath.Join(localDir, "main.go"),
+		filepath.Join(siblingDir, "replaced.go"),
+	}
+	for _, want := range wantKept {
+		if _, ok := files[want]; !ok {
+			t.Errorf("expected %q in result, got %v", want, keys(files))
+		}
+	}
+	for f := range files {
+		if strings.HasPrefix(f, gomodcache) {
+			t.Errorf("module-cache file leaked into result: %s", f)
+		}
+		if strings.HasPrefix(f, stdlibDir) {
+			t.Errorf("stdlib file leaked into result: %s", f)
+		}
+	}
+}
+
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}


### PR DESCRIPTION
## Why

The Go runtime today rebuilds every Lambda in the same `go.mod` tree whenever any file changes. That's fine with the documented layout (one `go.mod` per handler), but as soon as a project chooses a single-module monorepo with many handlers — share a `services/shared` package across N Lambdas, keep one set of dependencies, one `go.mod tidy`, etc. — `sst dev` becomes unusable: editing one handler triggers a rebuild of every other handler in the module.

Side effect of one-go.mod-per-Lambda also pays a recurring cost on every CI lint and CI test pass that scales linearly with the Lambda count, since each handler is its own `golangci-lint` + `go test` invocation.

This is the same problem the Node runtime already solved: it uses esbuild's metafile to know exactly which files compile into each bundle and rebuilds only the Lambdas whose actual deps changed.

## What

Capture each handler's transitive import graph at `Build` time via `go list -deps -json` and use it as the rebuild scope. `ShouldRebuild` fires only when the changed file is in that handler's graph. Works in every layout (per-Lambda, per-domain, single-module monorepo).

Side fix: `go build` arguments now use a `./` prefix on the source path so layouts where the source is a sub-path don't fail with `package <path> is not in std`. With the legacy one-go.mod-per-Lambda layout `src` was always `.`, so the bug never surfaced.

The previous directory-scope behavior was deliberately removed rather than kept as a fallback. In a single-module repo it would silently fan out to every Lambda when `captureDeps` failed, hiding a real problem behind a worse one. A `captureDeps` failure now logs a warning with full context (`goflags`, `gomodcache`) and disables `ShouldRebuild` for that function until the next successful `Build`.

## Tests

\`pkg/runtime/golang/golang_test.go\` — pure unit tests for \`Properties\` JSON contract, the goarch mapping, \`ShouldRebuild\` edge cases (non-go file, missing graph, file hit/miss, relative path resolution), the \`GOMODCACHE\`/stdlib filter via a fixture JSON stream, a 50×50 race-detector concurrency probe, and a cross-OS \`isUnderDir\` helper.

\`pkg/runtime/golang/build_test.go\` — hermetic integration tests against the real \`go list\` toolchain (env scrubbed: \`GOPROXY=off\`, \`GOTOOLCHAIN=local\`, redirected \`GOMODCACHE\`/\`GOCACHE\`/\`HOME\`). Skipped under \`-short\` and when \`go\` is not in \`PATH\`.

\`go test ./pkg/runtime/golang/... -race\`: 1.6s full, 1.0s under \`-short\`. \`go vet\` clean.

## Tested manually

Validated end-to-end on a real repo with ~60 Go Lambdas consolidated into one root \`services/go.mod\`. With this patch:

- editing a single Lambda's \`handler.go\` rebuilds only that Lambda;
- editing a file in the shared package rebuilds only the Lambdas that import it (cross-Lambda fan-out is correct);
- editing a \`_test.go\` triggers no rebuild (test files don't compile into the binary);
- \`bun run go-lint\` time on the same repo dropped from ~10s to <1s warm cache (one \`golangci-lint\` invocation over the whole module instead of 60).