### PR TITLE
Cleanup Hono example

### DIFF
--- a/examples/aws-hono/src/index.ts
+++ b/examples/aws-hono/src/index.ts
@@ -19,7 +19,7 @@ app.get("/", async (c) => {
     Bucket: Resource.MyBucket.name,
   });
 
-  return c.text('ykse');
+  return c.text(await getSignedUrl(s3, command));
 });
 
 app.get("/latest", async (c) => {

--- a/examples/aws-hono/sst.config.ts
+++ b/examples/aws-hono/sst.config.ts
@@ -7,9 +7,6 @@ export default $config({
       removal: input?.stage === "production" ? "retain" : "remove",
       protect: input?.stage === "production",
       home: "aws",
-      watcher: {
-        ignore: ["example/*"]
-      }
     };
   },
   async run() {
@@ -18,12 +15,6 @@ export default $config({
       url: true,
       link: [bucket],
       handler: "src/index.handler",
-    });
-
-    new sst.aws.Function("Hono2", {
-      url: true,
-      link: [bucket],
-      handler: "example/index.handler",
     });
   },
 });


### PR DESCRIPTION
- Remove extra `Hono2` function and watcher config that were added for testing
- Restore root endpoint to return actual S3 signed URL instead of placeholder text