### PR TITLE
Add Cloudflare domain redirects and aliases

### DIFF
--- a/platform/src/components/cloudflare/astro.ts
+++ b/platform/src/components/cloudflare/astro.ts
@@ -104,6 +104,28 @@ export interface AstroArgs extends SsrSiteArgs {
    *   domain: "my-app.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "my-app.com",
+   *     redirects: ["www.my-app.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.my-app.com",
+   *     aliases: ["app2.my-app.com"]
+   *   }
+   * }
+   * ```
    */
   domain?: SsrSiteArgs["domain"];
   /**
@@ -157,6 +179,32 @@ export interface AstroArgs extends SsrSiteArgs {
  * ```js {2} title="sst.config.ts"
  * new sst.cloudflare.Astro("MyWeb", {
  *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.Astro("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Add domain aliases
+ *
+ * Allow visitors to use alternate domains without redirecting.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.Astro("MyWeb", {
+ *   domain: {
+ *     name: "app1.my-app.com",
+ *     aliases: ["app2.my-app.com"]
+ *   }
  * });
  * ```
  *

--- a/platform/src/components/cloudflare/experimental/solid-start.ts
+++ b/platform/src/components/cloudflare/experimental/solid-start.ts
@@ -89,6 +89,28 @@ export interface SolidStartArgs extends SsrSiteArgs {
    *   domain: "my-app.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "my-app.com",
+   *     redirects: ["www.my-app.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.my-app.com",
+   *     aliases: ["app2.my-app.com"]
+   *   }
+   * }
+   * ```
    */
   domain?: SsrSiteArgs["domain"];
   /**
@@ -138,6 +160,32 @@ export interface SolidStartArgs extends SsrSiteArgs {
  * ```js {2} title="sst.config.ts"
  * new sst.cloudflare.SolidStart("MyWeb", {
  *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.SolidStart("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Add domain aliases
+ *
+ * Allow visitors to use alternate domains without redirecting.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.SolidStart("MyWeb", {
+ *   domain: {
+ *     name: "app1.my-app.com",
+ *     aliases: ["app2.my-app.com"]
+ *   }
  * });
  * ```
  *

--- a/platform/src/components/cloudflare/react-router.ts
+++ b/platform/src/components/cloudflare/react-router.ts
@@ -105,6 +105,28 @@ export interface ReactRouterArgs extends SsrSiteArgs {
    *   domain: "my-app.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "my-app.com",
+   *     redirects: ["www.my-app.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.my-app.com",
+   *     aliases: ["app2.my-app.com"]
+   *   }
+   * }
+   * ```
    */
   domain?: SsrSiteArgs["domain"];
   /**
@@ -158,6 +180,32 @@ export interface ReactRouterArgs extends SsrSiteArgs {
  * ```js {2} title="sst.config.ts"
  * new sst.cloudflare.ReactRouter("MyWeb", {
  *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.ReactRouter("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Add domain aliases
+ *
+ * Allow visitors to use alternate domains without redirecting.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.ReactRouter("MyWeb", {
+ *   domain: {
+ *     name: "app1.my-app.com",
+ *     aliases: ["app2.my-app.com"]
+ *   }
  * });
  * ```
  *

--- a/platform/src/components/cloudflare/ssr-site.ts
+++ b/platform/src/components/cloudflare/ssr-site.ts
@@ -20,7 +20,7 @@ export type Plan = {
 };
 
 export interface SsrSiteArgs extends BaseSsrSiteArgs {
-  domain?: Input<string>;
+  domain?: WorkerArgs["domain"];
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.

--- a/platform/src/components/cloudflare/static-site-v2.ts
+++ b/platform/src/components/cloudflare/static-site-v2.ts
@@ -95,8 +95,30 @@ export interface StaticSiteV2Args extends Omit<BaseStaticSiteArgs, "vite"> {
    *   domain: "domain.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "domain.com",
+   *     redirects: ["www.domain.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.domain.com",
+   *     aliases: ["app2.domain.com"]
+   *   }
+   * }
+   * ```
    */
-  domain?: Input<string>;
+  domain?: WorkerArgs["domain"];
   /**
    * Configure trailing slash behavior for HTML pages.
    *
@@ -201,6 +223,32 @@ export interface StaticSiteV2Args extends Omit<BaseStaticSiteArgs, "vite"> {
  * ```js {2}
  * new sst.cloudflare.StaticSiteV2("MyWeb", {
  *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4}
+ * new sst.cloudflare.StaticSiteV2("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Add domain aliases
+ *
+ * Allow visitors to use alternate domains without redirecting.
+ *
+ * ```js {4}
+ * new sst.cloudflare.StaticSiteV2("MyWeb", {
+ *   domain: {
+ *     name: "app1.my-app.com",
+ *     aliases: ["app2.my-app.com"]
+ *   }
  * });
  * ```
  *

--- a/platform/src/components/cloudflare/static-site.ts
+++ b/platform/src/components/cloudflare/static-site.ts
@@ -5,10 +5,9 @@ import { ComponentResourceOptions, all, output } from "@pulumi/pulumi";
 import { Kv, KvArgs } from "./kv.js";
 import { Component, Prettify, Transform, transform } from "../component.js";
 import { Link } from "../link.js";
-import { Input } from "../input.js";
 import { globSync } from "glob";
 import { KvData } from "./providers/kv-data.js";
-import { Worker } from "./worker.js";
+import { Worker, WorkerArgs } from "./worker.js";
 import { getContentType } from "../base/base-site.js";
 import {
   BaseStaticSiteArgs,
@@ -100,8 +99,30 @@ export interface StaticSiteArgs extends BaseStaticSiteArgs {
    *   domain: "domain.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "domain.com",
+   *     redirects: ["www.domain.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.domain.com",
+   *     aliases: ["app2.domain.com"]
+   *   }
+   * }
+   * ```
    */
-  domain?: Input<string>;
+  domain?: WorkerArgs["domain"];
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.

--- a/platform/src/components/cloudflare/tan-stack-start.ts
+++ b/platform/src/components/cloudflare/tan-stack-start.ts
@@ -106,6 +106,28 @@ export interface TanStackStartArgs extends SsrSiteArgs {
    *   domain: "my-app.com"
    * }
    * ```
+   *
+   * Redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "my-app.com",
+   *     redirects: ["www.my-app.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.my-app.com",
+   *     aliases: ["app2.my-app.com"]
+   *   }
+   * }
+   * ```
    */
   domain?: SsrSiteArgs["domain"];
   /**
@@ -159,6 +181,32 @@ export interface TanStackStartArgs extends SsrSiteArgs {
  * ```js {2} title="sst.config.ts"
  * new sst.cloudflare.TanStackStart("MyWeb", {
  *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.TanStackStart("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Add domain aliases
+ *
+ * Allow visitors to use alternate domains without redirecting.
+ *
+ * ```js {4} title="sst.config.ts"
+ * new sst.cloudflare.TanStackStart("MyWeb", {
+ *   domain: {
+ *     name: "app1.my-app.com",
+ *     aliases: ["app2.my-app.com"]
+ *   }
  * });
  * ```
  *

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -761,13 +761,7 @@ export class Worker extends Component implements Link.Linkable {
     function createAliases() {
       if (!domain) return;
 
-      const seen = new Set<string>();
       for (const [i, hostname] of domain.aliases.entries()) {
-        if (typeof hostname === "string") {
-          if (seen.has(hostname)) continue;
-          seen.add(hostname);
-        }
-
         const zone = new ZoneLookup(
           `${name}Alias${i}ZoneLookup`,
           {
@@ -794,13 +788,7 @@ export class Worker extends Component implements Link.Linkable {
     function createRedirects() {
       if (!domain) return;
 
-      const seen = new Set<string>();
       for (const [i, hostname] of domain.redirects.entries()) {
-        if (typeof hostname === "string") {
-          if (seen.has(hostname)) continue;
-          seen.add(hostname);
-        }
-
         const resourceName = `${name}Redirect${i}`;
         const zone = new ZoneLookup(
           `${resourceName}ZoneLookup`,

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -11,7 +11,7 @@ import {
 import * as cf from "@pulumi/cloudflare";
 import type { Loader } from "esbuild";
 import type { EsbuildOptions } from "../esbuild.js";
-import { Component, Transform, transform } from "../component";
+import { Component, Prettify, Transform, transform } from "../component";
 import { WorkerUrl } from "./providers/worker-url.js";
 import { WorkerPlacement } from "./providers/worker-placement.js";
 import { Link } from "../link.js";
@@ -27,6 +27,59 @@ import { getContentType } from "../base/base-site";
 import { prefixName } from "../naming";
 import { existsAsync } from "../../util/fs";
 import { normalizeCompatibility } from "./helpers/compatibility.js";
+
+export interface WorkerDomainArgs {
+  /**
+   * The custom domain you want to use.
+   *
+   * @example
+   * ```js
+   * {
+   *   domain: {
+   *     name: "example.com"
+   *   }
+   * }
+   * ```
+   */
+  name: Input<string>;
+  /**
+   * Alternate domains to be used. Visitors to the alternate domains will be redirected to the
+   * main `name`.
+   *
+   * :::note
+   * Unlike the `aliases` option, this will redirect visitors back to the main `name`.
+   * :::
+   *
+   * @example
+   * Use this to create a `www.` version of your domain and redirect visitors to the apex domain.
+   * ```js {4}
+   * {
+   *   domain: {
+   *     name: "domain.com",
+   *     redirects: ["www.domain.com"]
+   *   }
+   * }
+   * ```
+   */
+  redirects?: Input<string>[];
+  /**
+   * Alias domains that should be used. Unlike the `redirects` option, this keeps your visitors
+   * on this alias domain.
+   *
+   * @example
+   * So if your users visit `app2.domain.com`, they will stay on `app2.domain.com` in their
+   * browser.
+   * ```js {4}
+   * {
+   *   domain: {
+   *     name: "app1.domain.com",
+   *     aliases: ["app2.domain.com"]
+   *   }
+   * }
+   * ```
+   */
+  aliases?: Input<string>[];
+}
 
 export interface WorkerArgs {
   /**
@@ -63,8 +116,30 @@ export interface WorkerArgs {
    *   domain: "domain.com"
    * }
    * ```
+   *
+   * You can also redirect alternate domains to the main domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "domain.com",
+   *     redirects: ["www.domain.com"]
+   *   }
+   * }
+   * ```
+   *
+   * Or keep visitors on alternate domains with aliases.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "app1.domain.com",
+   *     aliases: ["app2.domain.com"]
+   *   }
+   * }
+   * ```
    */
-  domain?: Input<string>;
+  domain?: Input<string> | Prettify<WorkerDomainArgs>;
   /**
    * Configure how your function is bundled.
    *
@@ -305,7 +380,7 @@ export class Worker extends Component implements Link.Linkable {
   private script: cf.WorkersScript;
   private workerUrl: WorkerUrl;
   private workerPlacement?: WorkerPlacement;
-  private workerDomain?: cf.WorkerDomain;
+  private workerDomain?: cf.WorkersCustomDomain;
 
   constructor(name: string, args: WorkerArgs, opts?: ComponentResourceOptions) {
     super(__pulumiType, name, args, opts);
@@ -315,6 +390,7 @@ export class Worker extends Component implements Link.Linkable {
     const dev = normalizeDev();
     const urlEnabled = normalizeUrl();
     const compatibility = normalizeCompatibility(args);
+    const domain = normalizeDomain();
 
     const bindings = buildBindings();
     const iamCredentials = createAwsCredentials();
@@ -391,6 +467,28 @@ export class Worker extends Component implements Link.Linkable {
 
     function normalizeUrl() {
       return output(args.url).apply((v) => v ?? false);
+    }
+
+    function normalizeDomain() {
+      if (!args.domain) return;
+
+      if (
+        typeof args.domain === "object" &&
+        args.domain !== null &&
+        "name" in args.domain
+      ) {
+        return {
+          name: args.domain.name,
+          aliases: args.domain.aliases ?? [],
+          redirects: args.domain.redirects ?? [],
+        };
+      }
+
+      return {
+        name: args.domain,
+        aliases: [],
+        redirects: [],
+      };
     }
 
     function buildBindings() {
@@ -634,28 +732,114 @@ export class Worker extends Component implements Link.Linkable {
     }
 
     function createWorkersDomain() {
-      if (!args.domain) return;
+      if (!domain) return;
 
-      const zone = new ZoneLookup(
+      const primaryDomain = createWorkersCustomDomain(
+        `${name}Domain`,
+        domain.name,
         `${name}ZoneLookup`,
+      );
+      createAdditionalWorkerDomains();
+      createRedirects();
+
+      return primaryDomain;
+    }
+
+    function createWorkersCustomDomain(
+      resourceName: string,
+      hostname: Input<string>,
+      zoneResourceName = `${resourceName}ZoneLookup`,
+    ) {
+      const zone = new ZoneLookup(
+        zoneResourceName,
         {
           accountId: DEFAULT_ACCOUNT_ID,
-          domain: args.domain,
+          domain: hostname,
         },
         { parent },
       );
 
       return new cf.WorkersCustomDomain(
-        `${name}Domain`,
+        resourceName,
         {
           accountId: DEFAULT_ACCOUNT_ID,
           service: script.scriptName,
-          hostname: args.domain,
+          hostname,
           zoneId: zone.id,
           environment: "production",
         },
         { parent },
       );
+    }
+
+    function createAdditionalWorkerDomains() {
+      if (!domain) return;
+
+      const seen = new Set<string>();
+      for (const [i, hostname] of domain.aliases.entries()) {
+        if (typeof hostname === "string") {
+          if (seen.has(hostname)) continue;
+          seen.add(hostname);
+        }
+        createWorkersCustomDomain(`${name}Alias${i}Domain`, hostname);
+      }
+    }
+
+    function createRedirects() {
+      if (!domain) return;
+
+      const seen = new Set<string>();
+      for (const [i, hostname] of domain.redirects.entries()) {
+        if (typeof hostname === "string") {
+          if (seen.has(hostname)) continue;
+          seen.add(hostname);
+        }
+
+        const resourceName = `${name}Redirect${i}`;
+        const zone = new ZoneLookup(
+          `${resourceName}ZoneLookup`,
+          {
+            accountId: DEFAULT_ACCOUNT_ID,
+            domain: hostname,
+          },
+          { parent },
+        );
+
+        new cf.DnsRecord(
+          `${resourceName}Record`,
+          {
+            zoneId: zone.id,
+            name: hostname,
+            type: "AAAA",
+            content: "100::",
+            proxied: true,
+            ttl: 1,
+          },
+          { parent },
+        );
+
+        new cf.PageRule(
+          `${resourceName}Rule`,
+          {
+            zoneId: zone.id,
+            target: interpolate`${hostname}/*`,
+            priority: i + 1,
+            status: "active",
+            actions: {
+              forwardingUrl: {
+                statusCode: 301,
+                url: all([domain.name, hostname]).apply(
+                  ([domainName, hostname]) => {
+                    const wildcardCount = hostname.match(/\*/g)?.length ?? 0;
+                    return `https://${domainName}/$${wildcardCount + 1}`;
+                  },
+                ),
+              },
+            },
+          },
+          { parent },
+        );
+      }
     }
   }
 

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -414,6 +414,8 @@ export class Worker extends Component implements Link.Linkable {
     const workerUrl = createWorkersUrl();
     const workerPlacement = createWorkerPlacement();
     const workerDomain = createWorkersDomain();
+    createAliases();
+    createRedirects();
 
     this.script = script;
     this.workerUrl = workerUrl;
@@ -734,15 +736,11 @@ export class Worker extends Component implements Link.Linkable {
     function createWorkersDomain() {
       if (!domain) return;
 
-      const primaryDomain = createWorkersCustomDomain(
+      return createWorkersCustomDomain(
         `${name}Domain`,
         domain.name,
         `${name}ZoneLookup`,
       );
-      createAdditionalWorkerDomains();
-      createRedirects();
-
-      return primaryDomain;
     }
 
     function createWorkersCustomDomain(
@@ -772,7 +770,7 @@ export class Worker extends Component implements Link.Linkable {
       );
     }
 
-    function createAdditionalWorkerDomains() {
+    function createAliases() {
       if (!domain) return;
 
       const seen = new Set<string>();

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -736,33 +736,21 @@ export class Worker extends Component implements Link.Linkable {
     function createWorkersDomain() {
       if (!domain) return;
 
-      return createWorkersCustomDomain(
-        `${name}Domain`,
-        domain.name,
-        `${name}ZoneLookup`,
-      );
-    }
-
-    function createWorkersCustomDomain(
-      resourceName: string,
-      hostname: Input<string>,
-      zoneResourceName = `${resourceName}ZoneLookup`,
-    ) {
       const zone = new ZoneLookup(
-        zoneResourceName,
+        `${name}ZoneLookup`,
         {
           accountId: DEFAULT_ACCOUNT_ID,
-          domain: hostname,
+          domain: domain.name,
         },
         { parent },
       );
 
       return new cf.WorkersCustomDomain(
-        resourceName,
+        `${name}Domain`,
         {
           accountId: DEFAULT_ACCOUNT_ID,
           service: script.scriptName,
-          hostname,
+          hostname: domain.name,
           zoneId: zone.id,
           environment: "production",
         },
@@ -779,7 +767,27 @@ export class Worker extends Component implements Link.Linkable {
           if (seen.has(hostname)) continue;
           seen.add(hostname);
         }
-        createWorkersCustomDomain(`${name}Alias${i}Domain`, hostname);
+
+        const zone = new ZoneLookup(
+          `${name}Alias${i}ZoneLookup`,
+          {
+            accountId: DEFAULT_ACCOUNT_ID,
+            domain: hostname,
+          },
+          { parent },
+        );
+
+        new cf.WorkersCustomDomain(
+          `${name}Alias${i}Domain`,
+          {
+            accountId: DEFAULT_ACCOUNT_ID,
+            service: script.scriptName,
+            hostname,
+            zoneId: zone.id,
+            environment: "production",
+          },
+          { parent },
+        );
       }
     }
 

--- a/platform/src/components/cloudflare/worker.ts
+++ b/platform/src/components/cloudflare/worker.ts
@@ -828,11 +828,8 @@ export class Worker extends Component implements Link.Linkable {
             actions: {
               forwardingUrl: {
                 statusCode: 301,
-                url: all([domain.name, hostname]).apply(
-                  ([domainName, hostname]) => {
-                    const wildcardCount = hostname.match(/\*/g)?.length ?? 0;
-                    return `https://${domainName}/$${wildcardCount + 1}`;
-                  },
+                url: output(domain.name).apply(
+                  (domainName) => `https://${domainName}/$1`,
                 ),
               },
             },

--- a/platform/src/components/component.ts
+++ b/platform/src/components/component.ts
@@ -182,6 +182,7 @@ export class Component extends ComponentResource {
               "aws:sqs/queuePolicy:QueuePolicy",
               "aws:ssm/parameter:Parameter",
               "cloudflare:index/dnsRecord:DnsRecord",
+              "cloudflare:index/pageRule:PageRule",
               "cloudflare:index/workersCronTrigger:WorkersCronTrigger",
               "cloudflare:index/workersCustomDomain:WorkersCustomDomain",
               "cloudflare:index/queueConsumer:QueueConsumer",


### PR DESCRIPTION
Closes #6821
- Allow `domain` to be configured as an object with `name`, `aliases`, and `redirects` for all Cloudflare components
- Create `WorkersCustomDomain` resources for the primary domain and aliases so they serve the Worker directly
- Create proxied `DnsRecord` and `PageRule` resources for redirect domains to forward traffic to the primary domain while preserving path and query parameters
- Update internal `workerDomain` field type to match the actual `WorkersCustomDomain` resource type