### PR TITLE
Fix Cloudflare unenv config decoding with VS Code auto attach

### DIFF
--- a/examples/cloudflare-worker/sst.config.ts
+++ b/examples/cloudflare-worker/sst.config.ts
@@ -14,6 +14,10 @@ export default $config({
       handler: "./index.ts",
       link: [bucket],
       url: true,
+      compatibility: {
+        date: "2025-01-01",
+        flags: ["nodejs_compat"],
+      },
     });
 
     return {

--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -255,6 +255,7 @@ func (w *Runtime) getUnenv(ctx context.Context, cfgPath string, compatibility co
 		string(payload),
 	)
 	cmd.Dir = path.ResolvePlatformDir(cfgPath)
+	cmd.Env = []string{}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load cloudflare unenv config: %w\n%s", err, output)


### PR DESCRIPTION
Closes #6755

- Clear environment variables for the internal Node.js process that resolves `@cloudflare/unenv-preset` config
- Prevents VS Code auto attach debugger from injecting `Debugger listening...` messages into stdout, which caused JSON parsing to fail