### PR TITLE
Add Discord release announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SST_GITHUB_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
 
       - name: Release JS SDK
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,15 @@ nfpms:
 #   description: "sst cli"
 #   license: Apache 2.0
 
+announce:
+  discord:
+    enabled: true
+    author: "GitHub"
+    icon_url: "https://github.com/fluidicon.png"
+    message_template: |
+      [**{{ .Tag }}**]({{ .ReleaseURL }})
+      {{ .ReleaseNotes }}
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
- Configure  to post release notes to Discord via webhook on every publish
- Pass  and  secrets to the GoReleaser action in the release workflow