### PR TITLE
Format Discord release announcements with PR links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG"
           NOTES=$(gh release view "$TAG" --json body --jq .body \
             | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
+            | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
             | sed '/^## Changelog$/d')
           CONTENT=$(printf '[**%s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
           PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
             | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
             | sed '/^## Changelog$/d' \
             | sed -E 's|^(.+)$|- \1|')
-          CONTENT=$(printf '[**%s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
+          CONTENT=$(printf '🏷️ [**Release - %s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
           PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')
           curl -fsS -X POST -H "Content-Type: application/json" \
             -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,23 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SST_GITHUB_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
 
-      - name: Announce on Discord
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG"
-          NOTES=$(gh release view "$TAG" --json body --jq .body \
-            | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
-            | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
-            | sed '/^## Changelog$/d' \
-            | sed -E 's|^(.+)$|- \1|')
-          CONTENT=$(printf '🏷️ [**Release - %s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
-          PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')
-          curl -fsS -X POST -H "Content-Type: application/json" \
-            -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
-
       - name: Release JS SDK
         run: |
           cd sdk/js
@@ -116,3 +99,20 @@ jobs:
           cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+
+      - name: Announce on Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG"
+          NOTES=$(gh release view "$TAG" --json body --jq .body \
+            | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
+            | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
+            | sed '/^## Changelog$/d' \
+            | sed -E 's|^(.+)$|- \1|')
+          CONTENT=$(printf '🏷️ [**Release - %s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
+          PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,8 @@ jobs:
           NOTES=$(gh release view "$TAG" --json body --jq .body \
             | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
             | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
-            | sed '/^## Changelog$/d')
+            | sed '/^## Changelog$/d' \
+            | sed -E 's|^(.+)$|- \1|')
           CONTENT=$(printf '[**%s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
           PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')
           curl -fsS -X POST -H "Content-Type: application/json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SST_GITHUB_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
+
+      - name: Announce on Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG"
+          NOTES=$(gh release view "$TAG" --json body --jq .body \
+            | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
+            | sed '/^## Changelog$/d')
+          CONTENT=$(printf '[**%s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")
+          PAYLOAD=$(jq -n --arg c "$CONTENT" '{content:$c, flags:4}')
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
 
       - name: Release JS SDK
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,7 +66,7 @@ announce:
     endpoint_url: "{{ .Env.DISCORD_WEBHOOK_URL }}"
     content_type: "application/json"
     message_template: |
-      {"content":"[**{{ .Tag }}**](<<{{ .ReleaseURL }}>>)\n{{ replace (reverseFilter .ReleaseNotes "^## Changelog") "\n" "\\n" }}","flags":4}
+      {"content":"[**{{ .Tag }}**]({{ .ReleaseURL }})\n{{ replace (reverseFilter .ReleaseNotes "^## Changelog") "\n" "\\n" }}","flags":4}
 
 changelog:
   use: git

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,7 @@ announce:
 
 changelog:
   use: git
-  abbrev: -1
+  format: "[{{ .SHA }}](https://github.com/anomalyco/sst/commit/{{ .SHA }}): {{ .Message }}"
   sort: asc
   filters:
     exclude:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,11 +66,11 @@ announce:
     endpoint_url: "{{ .Env.DISCORD_WEBHOOK_URL }}"
     content_type: "application/json"
     message_template: |
-      {"content":"[**{{ .Tag }}**]({{ .ReleaseURL }})\n{{ replace .ReleaseNotes "\n" "\\n" }}"}
+      {"content":"[**{{ .Tag }}**](<<{{ .ReleaseURL }}>>)\n{{ replace (reverseFilter .ReleaseNotes "^## Changelog") "\n" "\\n" }}","flags":4}
 
 changelog:
   use: git
-  format: "[{{ .SHA }}](https://github.com/anomalyco/sst/commit/{{ .SHA }}): {{ .Message }}"
+  abbrev: -1
   sort: asc
   filters:
     exclude:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,22 +52,6 @@ nfpms:
       {{- if eq .Os "darwin" }}mac
       {{- else }}{{ .Os }}{{ end }}-{{ .Arch }}
 
-# scoop:
-#   bucket:
-#     owner: sst
-#     name: scoop-bucket
-#   homepage: "https://github.com/sst/ion"
-#   description: "sst cli"
-#   license: Apache 2.0
-
-announce:
-  webhook:
-    enabled: true
-    endpoint_url: "{{ .Env.DISCORD_WEBHOOK_URL }}"
-    content_type: "application/json"
-    message_template: |
-      {"content":"[**{{ .Tag }}**]({{ .ReleaseURL }})\n{{ replace (reverseFilter .ReleaseNotes "^## Changelog") "\n" "\\n" }}","flags":4}
-
 changelog:
   use: git
   format: "[{{ .SHA }}](https://github.com/anomalyco/sst/commit/{{ .SHA }}): {{ .Message }}"


### PR DESCRIPTION
- Move Discord release announcements out of `.goreleaser.yml` into a dedicated workflow step to gain full control over the message content
- Format messages with a `🏷️ Release - vX.X.X` clickable title and bullet list entries
- Transform `(#NNN)` references into clickable markdown links pointing to the corresponding PR/issue page
- Strip commit hash links from Discord messages to avoid clutter while preserving them in GitHub release notes
- Suppress Discord auto-embeds using the `SUPPRESS_EMBEDS` flag to keep messages clean