### PR TITLE
Fix Discord release note formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$TAG"
           NOTES=$(gh release view "$TAG" --json body --jq .body \
             | sed -E "s|\(#([0-9]+)\)|([#\1](https://github.com/${{ github.repository }}/pull/\1))|g" \
-            | sed -E 's|^\[[a-f0-9]+\]\([^)]+\): ||' \
+            | sed -E 's|^\* \[[a-f0-9]+\]\([^)]+\): ||' \
             | sed '/^## Changelog$/d' \
             | sed -E 's|^(.+)$|- \1|')
           CONTENT=$(printf '🏷️ [**Release - %s**](%s)\n%s' "$TAG" "$RELEASE_URL" "$NOTES")


### PR DESCRIPTION
- Update the `sed` pattern in the Discord announcement step to consume the leading `* ` markdown bullet alongside the commit link prefix, since GitHub release notes are formatted as `* [hash](url): message`
- Without this change, the remaining `* ` plus our manually added `- ` produces `- * ` double bullets, and the commit hash remains visible in Discord