### PR TITLE
Update lambda to allow Python 3.14 runtime

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -374,6 +374,7 @@ export interface FunctionArgs {
     | "python3.11"
     | "python3.12"
     | "python3.13"
+    | "python3.14"
   >;
   /**
    * Path to the source code directory for the function. By default, the handler is


### PR DESCRIPTION
## Summary

Adds `"python3.14"` to the `Runtime` type union in `aws/function.ts`. Mirrors #5126 (the python3.13 addition) — same one-line surgical scope.

## Why

- AWS Lambda gained python3.14 zip-runtime support in [November 2025](https://aws.amazon.com/about-aws/whats-new/2025/11/aws-lambda-python-314/)
- `public.ecr.aws/lambda/python:3.14` image is published (verified via `docker manifest inspect`)
- `@pulumi/aws@7.20.0` (the version SST 4.7+ ships) already exposes `Runtime.Python3d14: "python3.14"` in its enum

The only remaining blocker for SST users is this union.

## Verification

- [x] `bun run typecheck` passes (platform + sdk)
- [x] No version-specific dispatch needed: `function.ts:~2653` uses `runtime.includes("python")` (generic)
- [x] `platform/functions/docker/python.Dockerfile` regex `3.1[2-9]*` already covers 3.14, dnf branch correctly routes for AL2023-based image
- [x] `platform/functions/python-runtime/index.py` (dev-mode helper) is version-agnostic

## Notes

- Examples (`aws-python`, `aws-fastapi`, `aws-python-container`, `aws-python-huggingface`) intentionally left on their existing pins to mirror #5126's scope. Happy to follow up with example bumps in a separate PR if preferred.
- `workflow.ts` Runtime union (for AWS Lambda Durable Functions) is not touched — durable-functions python3.14 support is a separate verification track.