### PR TITLE
Fix `sst dev` debugger in JetBrains editors

### DIFF
--- a/pkg/runtime/node/node.go
+++ b/pkg/runtime/node/node.go
@@ -210,6 +210,18 @@ var esSourcemapMap = map[string]esbuild.SourceMap{
 
 var NODE_EXTENSIONS = []string{".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"}
 
+var EDITOR_ENV = []string{
+	"VSCODE_INSPECTOR_OPTIONS",
+	"JB_IDE_HOST",
+	"JB_IDE_PORT",
+	"JB_INTERPRETER",
+	"JB_NODE_DEBUG_CONNECTION_GATEWAY_HOST",
+	"JB_NODE_DEBUG_CONNECTION_GATEWAY_PORT",
+	"JETBRAINS_NODE_BIND_HOST",
+	"JETBRAINS_NODE_DEBUGGER_ATTACH_TO_HELPERS",
+	"JETBRAINS_NODE_DEBUGGER_VERBOSE_LOGGING",
+}
+
 func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Worker, error) {
 	cmd := process.Command(
 		"node",
@@ -224,7 +236,11 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	)
 	cmd.Env = input.Env
 	cmd.Env = append(cmd.Env, "NODE_OPTIONS="+os.Getenv("NODE_OPTIONS"))
-	cmd.Env = append(cmd.Env, "VSCODE_INSPECTOR_OPTIONS="+os.Getenv("VSCODE_INSPECTOR_OPTIONS"))
+	for _, key := range EDITOR_ENV {
+		if value := os.Getenv(key); value != "" {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+	}
 	cmd.Env = append(cmd.Env, "AWS_LAMBDA_RUNTIME_API="+input.Server)
 	slog.Info("starting worker", "server", input.Server)
 	cmd.Dir = input.Build.Out


### PR DESCRIPTION
Closes #6837

- Add `EDITOR_ENV` list containing JetBrains debugger environment variables (`JB_IDE_HOST`, `JB_IDE_PORT`, etc.)
- Forward these variables from the host environment into Node.js Lambda workers alongside existing `NODE_OPTIONS` and `VSCODE_INSPECTOR_OPTIONS`
- JetBrains IDEs inject a debug connector via `NODE_OPTIONS` but rely on companion env vars to know which IDE port to connect to; without them the connector crashes with `ERR_MISSING_ARGS` because `JB_IDE_PORT` is missing