### PR TITLE
fix(cf-function): guard against null metadata to prevent 502s

### DIFF
--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -943,8 +943,13 @@ async function handler(event) {
     metadata = JSON.parse(v);
   } catch (e) {}
 
-  const response = await routeSite(kvNamespace, metadata);
-  return response || event.request;
+  if (!metadata) return event.request;
+  try {
+    const response = await routeSite(kvNamespace, metadata);
+    return response || event.request;
+  } catch (e) {
+    return event.request;
+  }
 }`,
           },
           { parent: self },

--- a/platform/src/components/aws/static-site.ts
+++ b/platform/src/components/aws/static-site.ts
@@ -1129,8 +1129,13 @@ async function handler(event) {
     metadata = JSON.parse(v);
   } catch (e) {}
 
-  const response = await routeSite(kvNamespace, metadata);
-  return response || event.request;
+  if (!metadata) return event.request;
+  try {
+    const response = await routeSite(kvNamespace, metadata);
+    return response || event.request;
+  } catch (e) {
+    return event.request;
+  }
 }`,
           },
           { parent: self },


### PR DESCRIPTION
## Summary

- When the KV store returns `null`/`undefined` for the metadata key — which can happen transiently as the KV entry propagates to edge nodes after a deployment — `routeSite` throws an uncaught `TypeError` accessing `metadata.base`, causing CloudFront to return a 502.
- The same guard is applied to both `static-site.ts` and `ssr-site.ts`.
- The fix fails open: if metadata is unavailable, the request is passed through to the default origin unchanged rather than crashing.

## Root cause

The issue is most visible when `errorPage` is configured on a `StaticSite`. When `errorPage` is set, SST stores `errorResponseCode: 404` in the KV metadata and omits `custom404`, disabling the function-level SPA fallback in favour of distribution-level `customErrorResponses`. This means unmatched requests go through an extra round-trip (original request → S3 403 → CloudFront fetches error page → function invoked again), doubling the exposure to the KV propagation window and making the 502 appear inconsistently depending on which edge node handles the request.

## Test plan

- [ ] Deploy a `StaticSite` with `errorPage` set, request a non-existent path — should return 404 with the error page, not 502
- [ ] Simulate a missing metadata key (e.g. delete the KV entry temporarily) — should pass through to origin rather than 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)