### PR TITLE
Emphasize `npm install` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ Build full-stack apps on your own infrastructure.
 
 ## Installation
 
-If you are using SST as a part of your Node project, we recommend installing it locally.
+For Node projects, install SST locally so the CLI version is tracked with your app.
 
 ```bash
 npm install sst
+```
+
+You can then run the CLI with your package manager.
+
+```bash
+npx sst dev
 ```
 
 If you are not using Node, you can install the CLI globally.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build full-stack apps on your own infrastructure.
 
 ## Installation
 
-For JavaScript or TypeScript projects, install SST locally so the CLI version is tracked with your app. You can then run the CLI with the same package manager.
+For JavaScript projects, install SST locally so the CLI version is tracked with your app. You can then run the CLI with the same package manager.
 
 ```bash
 npm install sst
@@ -25,7 +25,7 @@ npm install sst
 # yarn add sst
 ```
 
-If you are not using JavaScript or TypeScript, you can install the CLI globally.
+If you are not using JavaScript, you can install the CLI globally.
 
 ```bash
 curl -fsSL https://sst.dev/install | bash

--- a/README.md
+++ b/README.md
@@ -16,19 +16,16 @@ Build full-stack apps on your own infrastructure.
 
 ## Installation
 
-For Node projects, install SST locally so the CLI version is tracked with your app.
+For JavaScript or TypeScript projects, install SST locally so the CLI version is tracked with your app. You can then run the CLI with the same package manager.
 
 ```bash
 npm install sst
+# pnpm add sst
+# bun add sst
+# yarn add sst
 ```
 
-You can then run the CLI with your package manager.
-
-```bash
-npx sst dev
-```
-
-If you are not using Node, you can install the CLI globally.
+If you are not using JavaScript or TypeScript, you can install the CLI globally.
 
 ```bash
 curl -fsSL https://sst.dev/install | bash

--- a/www/src/content/docs/docs/index.mdx
+++ b/www/src/content/docs/docs/index.mdx
@@ -268,19 +268,57 @@ Learn more about our [monorepo setup](/docs/set-up-a-monorepo/).
 
 ## CLI
 
-To make this all work, SST comes with a [CLI](/docs/reference/cli/). For Node projects, install SST locally in your project so the CLI version is tracked with your app.
+To make this all work, SST comes with a [CLI](/docs/reference/cli/). For JavaScript projects, install SST locally in your project so the CLI version is tracked with your app.
 
-```bash
-npm install sst
-```
+<Tabs syncKey="package-manager">
+  <TabItem label="npm">
+  ```bash
+  npm install sst
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  pnpm add sst
+  ```
+  </TabItem>
+  <TabItem label="Bun">
+  ```bash
+  bun add sst
+  ```
+  </TabItem>
+  <TabItem label="Yarn">
+  ```bash
+  yarn add sst
+  ```
+  </TabItem>
+</Tabs>
 
 You can then run the CLI with your package manager.
 
-```bash
-npx sst dev
-```
+<Tabs syncKey="package-manager">
+  <TabItem label="npm">
+  ```bash
+  npx sst dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```bash
+  pnpm exec sst dev
+  ```
+  </TabItem>
+  <TabItem label="Bun">
+  ```bash
+  bun sst dev
+  ```
+  </TabItem>
+  <TabItem label="Yarn">
+  ```bash
+  yarn sst dev
+  ```
+  </TabItem>
+</Tabs>
 
-If you are not using Node, you can install the CLI globally.
+If you are not using JavaScript, you can install the CLI globally.
 
 ```bash
 curl -fsSL https://sst.dev/install | bash

--- a/www/src/content/docs/docs/index.mdx
+++ b/www/src/content/docs/docs/index.mdx
@@ -268,13 +268,19 @@ Learn more about our [monorepo setup](/docs/set-up-a-monorepo/).
 
 ## CLI
 
-To make this all work, SST comes with a [CLI](/docs/reference/cli/). You can install it as a part of your Node project.
+To make this all work, SST comes with a [CLI](/docs/reference/cli/). For Node projects, install SST locally in your project so the CLI version is tracked with your app.
 
 ```bash
 npm install sst
 ```
 
-Or if you are not using Node, you can install it globally.
+You can then run the CLI with your package manager.
+
+```bash
+npx sst dev
+```
+
+If you are not using Node, you can install the CLI globally.
 
 ```bash
 curl -fsSL https://sst.dev/install | bash


### PR DESCRIPTION
## Summary
- emphasize local `npm install sst` for Node projects
- show running SST through the project package manager with `npx sst dev`
- keep the global install path as the fallback for non-Node projects

## Testing
- git diff --check

Closes #6851
