### PR TITLE
Encrypt bootstrap SSM parameter to survive org re-encryption policies

### DIFF
--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -154,7 +154,7 @@ func (p *AwsProvider) Bootstrap(region string) (*AwsBootstrapData, error) {
 	slog.Info("fetching bootstrap")
 	result, err := ssmClient.GetParameter(ctx, &ssm.GetParameterInput{
 		Name:           aws.String(SSM_NAME_BOOTSTRAP),
-		WithDecryption: aws.Bool(false),
+		WithDecryption: aws.Bool(true),
 	})
 	if result != nil && result.Parameter.Value != nil {
 		slog.Info("found existing bootstrap", "data", *result.Parameter.Value)
@@ -187,7 +187,7 @@ func (p *AwsProvider) Bootstrap(region string) (*AwsBootstrapData, error) {
 			ctx,
 			&ssm.PutParameterInput{
 				Name:      aws.String(SSM_NAME_BOOTSTRAP),
-				Type:      ssmTypes.ParameterTypeString,
+				Type:      ssmTypes.ParameterTypeSecureString,
 				Overwrite: aws.Bool(true),
 				Value:     aws.String(string(data)),
 			},


### PR DESCRIPTION
Closes #6856

## Summary

- Change the `/sst/bootstrap` SSM parameter from `String` to `SecureString` and read it with `WithDecryption: true`
- Prevents breakage when an AWS organization policy automatically re-encrypts unencrypted SSM parameters
- Matches the pattern already used by the passphrase parameter in the same file

## Motivation

Some AWS organizations enforce policies that automatically convert unencrypted SSM parameters to `SecureString`. Once this happens, the bootstrap parameter becomes unreadable because SST calls `GetParameter` with `WithDecryption: false`, which returns encrypted ciphertext instead of the plaintext JSON.

## Changes

Two changes in `pkg/project/provider/aws.go` inside `Bootstrap()`:

1. `GetParameter` for `/sst/bootstrap`: `WithDecryption` changed from `false` to `true`
2. `PutParameter` for `/sst/bootstrap`: `Type` changed from `ParameterTypeString` to `ParameterTypeSecureString`

## Backward Compatibility

This is safe for existing deployments with unencrypted `String` bootstrap parameters:

- **Reading**: From the [AWS docs](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html), `WithDecryption` *"is ignored for `String` and `StringList` parameter types."* Existing unencrypted parameters are returned identically.
- **Writing**: The parameter is only rewritten when the bootstrap version advances. At that point, `PutParameter` with `Overwrite: true` allows changing the type from `String` to `SecureString` seamlessly.