### PR TITLE
Fix duplicated "the" typo in global docs

### DIFF
--- a/platform/src/global.d.ts
+++ b/platform/src/global.d.ts
@@ -75,7 +75,7 @@ declare global {
   export const $linkable: typeof import("./components/link").Link.linkable;
 
   /**
-   * A convenience reference to the the [`util`](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/) module from Pulumi.
+   * A convenience reference to the [`util`](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/) module from Pulumi.
    *
    * This is useful for working with components. You can use these without importing or installing the Pulumi SDK.
    *


### PR DESCRIPTION
One-line typo fix in `platform/src/global.d.ts`: "A convenience reference to the the [`util`](...) module from Pulumi." → "A convenience reference to the [`util`](...) module from Pulumi.". No code/behavior change.