### PR TITLE
Fix Python SDK source names in examples

### DIFF
--- a/examples/aws-fastapi/functions/pyproject.toml
+++ b/examples/aws-fastapi/functions/pyproject.toml
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-fastapi/functions/pyproject.toml
+++ b/examples/aws-fastapi/functions/pyproject.toml
@@ -2,7 +2,7 @@
 name = "functions"
 version = "0.1.0"
 description = "Lambda function handlers"
-dependencies = ["core", "sst", "fastapi==0.115.8", "mangum==0.19.0"]
+dependencies = ["core", "sst-sdk", "fastapi==0.115.8", "mangum==0.19.0"]
 requires-python = "==3.11.*"
 
 [build-system]
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-fastapi/pyproject.toml
+++ b/examples/aws-fastapi/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-fastapi/pyproject.toml
+++ b/examples/aws-fastapi/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python-container/custom_dockerfile/pyproject.toml
+++ b/examples/aws-python-container/custom_dockerfile/pyproject.toml
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python-container/custom_dockerfile/pyproject.toml
+++ b/examples/aws-python-container/custom_dockerfile/pyproject.toml
@@ -2,7 +2,7 @@
 name = "custom_dockerfile"
 version = "0.1.0"
 description = "Custom Dockerfile"
-dependencies = ["core", "sst"]
+dependencies = ["core", "sst-sdk"]
 requires-python = "==3.11.*"
 
 [build-system]
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python-container/functions/pyproject.toml
+++ b/examples/aws-python-container/functions/pyproject.toml
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python-container/functions/pyproject.toml
+++ b/examples/aws-python-container/functions/pyproject.toml
@@ -2,7 +2,7 @@
 name = "functions"
 version = "0.1.0"
 description = "Lambda function (container-mode)handlers"
-dependencies = ["core", "sst"]
+dependencies = ["core", "sst-sdk"]
 requires-python = "==3.11.*"
 
 [build-system]
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python-container/pyproject.toml
+++ b/examples/aws-python-container/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core", "custom_dockerfile"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python-container/pyproject.toml
+++ b/examples/aws-python-container/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core", "custom_dockerfile"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python-huggingface/pyproject.toml
+++ b/examples/aws-python-huggingface/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.12.*"
 members = ["functions"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python-huggingface/pyproject.toml
+++ b/examples/aws-python-huggingface/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.12.*"
 members = ["functions"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python/functions/pyproject.toml
+++ b/examples/aws-python/functions/pyproject.toml
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python/functions/pyproject.toml
+++ b/examples/aws-python/functions/pyproject.toml
@@ -2,7 +2,7 @@
 name = "functions"
 version = "0.1.0"
 description = "Lambda function handlers"
-dependencies = ["core", "sst"]
+dependencies = ["core", "sst-sdk"]
 requires-python = "==3.11.*"
 
 [build-system]
@@ -11,4 +11,4 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 core = { workspace = true }
-sst = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }
+sst-sdk = { git = "https://github.com/sst/sst.git", branch = "dev", subdirectory = "sdk/python" }

--- a/examples/aws-python/pyproject.toml
+++ b/examples/aws-python/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python/pyproject.toml
+++ b/examples/aws-python/pyproject.toml
@@ -13,4 +13,4 @@ requires-python = "==3.11.*"
 members = ["functions", "core"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-python/sst.config.ts
+++ b/examples/aws-python/sst.config.ts
@@ -58,11 +58,14 @@
  *     print(Resource.MyLinkableValue.foo)
  * ```
  *
- * Where the `sst` package can be added to your `pyproject.toml`.
+ * Where the `sst-sdk` package can be added to your `pyproject.toml`.
  *
  * ```toml title="functions/pyproject.toml"
+ * [project]
+ * dependencies = ["sst-sdk"]
+ *
  * [tool.uv.sources]
- * sst = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }
+ * sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }
  * ```
  *
  * You also want to set the Python version in your `pyproject.toml` to the same

--- a/examples/aws-python/sst.config.ts
+++ b/examples/aws-python/sst.config.ts
@@ -62,7 +62,7 @@
  *
  * ```toml title="functions/pyproject.toml"
  * [tool.uv.sources]
- * sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+ * sst = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }
  * ```
  *
  * You also want to set the Python version in your `pyproject.toml` to the same

--- a/examples/aws-workflow-python/invoker/pyproject.toml
+++ b/examples/aws-workflow-python/invoker/pyproject.toml
@@ -3,7 +3,7 @@ name = "invoker"
 version = "0.1.0"
 description = "A SST app"
 dependencies = [
-    "sst",
+    "sst-sdk",
     "boto3 (>=1.42.59,<2.0.0)"
 ]
 requires-python = "==3.13.*"
@@ -18,4 +18,4 @@ packages = ["main"]
 
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/invoker/pyproject.toml
+++ b/examples/aws-workflow-python/invoker/pyproject.toml
@@ -18,4 +18,4 @@ packages = ["main"]
 
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/pyproject.toml
+++ b/examples/aws-workflow-python/pyproject.toml
@@ -14,4 +14,4 @@ requires-python = "==3.13.*"
 members = ["workflow", "invoker", "resolver"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/pyproject.toml
+++ b/examples/aws-workflow-python/pyproject.toml
@@ -3,7 +3,7 @@ name = "app"
 version = "0.1.0"
 description = "A SST app"
 dependencies = [
-    "sst",
+    "sst-sdk",
     "aws-durable-execution-sdk-python (>=1.3.0,<2.0.0)",
     "boto3 (>=1.42.59,<2.0.0)"
 ]
@@ -14,4 +14,4 @@ requires-python = "==3.13.*"
 members = ["workflow", "invoker", "resolver"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/resolver/pyproject.toml
+++ b/examples/aws-workflow-python/resolver/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A SST app"
 authors = [{ name = "Nick Wall", email = "mail@walln.dev" }]
 dependencies = [
-    "sst",
+    "sst-sdk",
     "boto3 (>=1.42.59,<2.0.0)"
 ]
 requires-python = "==3.13.*"
@@ -19,4 +19,4 @@ packages = ["main"]
 
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/resolver/pyproject.toml
+++ b/examples/aws-workflow-python/resolver/pyproject.toml
@@ -19,4 +19,4 @@ packages = ["main"]
 
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/workflow/pyproject.toml
+++ b/examples/aws-workflow-python/workflow/pyproject.toml
@@ -18,4 +18,4 @@ build-backend = "hatchling.build"
 packages = ["main"]
 
 [tool.uv.sources]
-sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/examples/aws-workflow-python/workflow/pyproject.toml
+++ b/examples/aws-workflow-python/workflow/pyproject.toml
@@ -3,7 +3,7 @@ name = "workflow"
 version = "0.1.0"
 description = "A SST app"
 dependencies = [
-    "sst",
+    "sst-sdk",
     "aws-durable-execution-sdk-python (>=1.3.0,<2.0.0)",
     "boto3 (>=1.42.59,<2.0.0)"
 ]
@@ -18,4 +18,4 @@ build-backend = "hatchling.build"
 packages = ["main"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1636,11 +1636,14 @@ export interface FunctionArgs {
  *       print(Resource.MyBucket.name)
  *   ```
  *
- *   Where the `sst` package can be added to your `pyproject.toml`.
+ *   Where the `sst-sdk` package can be added to your `pyproject.toml`.
  *
  *   ```toml title="functions/pyproject.toml"
+ *   [project]
+ *   dependencies = ["sst-sdk"]
+ *
  *   [tool.uv.sources]
- *   sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+ *   sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }
  *   ```
  *   </TabItem>
  *   <TabItem label="Go">

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -24,7 +24,7 @@ If you were previously installing the SDK from GitHub:
 dependencies = ["sst"]
 
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst", subdirectory = "sdk/python" }
+sst = { git = "https://github.com/anomalyco/sst", subdirectory = "sdk/python" }
 ```
 
 Update your `pyproject.toml` to use the PyPI package instead:

--- a/www/src/content/docs/docs/reference/sdk.mdx
+++ b/www/src/content/docs/docs/reference/sdk.mdx
@@ -100,8 +100,11 @@ SST uses [uv](https://docs.astral.sh/uv/) to package your Python functions. Your
 To use the SDK, add it to your `pyproject.toml`.
 
 ```toml title="functions/pyproject.toml"
+[project]
+dependencies = ["sst-sdk"]
+
 [tool.uv.sources]
-sst = { git = "https://github.com/sst/sst.git", subdirectory = "sdk/python", branch = "dev" }
+sst-sdk = { git = "https://github.com/anomalyco/sst.git", subdirectory = "sdk/python", branch = "dev" }
 ```
 
 And in your function, import the `resource` module and access the linked resource.


### PR DESCRIPTION
Fixes #6868.

The Python SDK package metadata now uses `sst-sdk`, but several example `pyproject.toml` files still depended on/source-mapped it as `sst`. `uv` rejects that with a package metadata name mismatch.

This updates the affected Python examples so dependency names and `[tool.uv.sources]` keys match `sst-sdk` while keeping the package source path unchanged.

Validation:
- `uv lock --dry-run` in `examples/aws-python`
- `uv lock --dry-run` in `examples/aws-fastapi`
- `git diff --check`