### PR TITLE
Prevent `sst` module from being ignored in Python SDK

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -30,9 +30,11 @@ Issues = "https://github.com/anomalyco/sst/issues"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/sst"]
-artifacts = ["sst"]
 
 [tool.hatch.build.targets.sdist]
 include = ["src/sst", "pyproject.toml", "README.md"]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -32,6 +32,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sst"]
+artifacts = ["sst"]
 
 [tool.hatch.build.targets.sdist]
 include = ["src/sst", "pyproject.toml", "README.md"]


### PR DESCRIPTION
## Problem
References issue #6873 
Currently the `uv build` command ends up excluding the `sst` module from the final wheel that is produced. The problem is caused by the fact that hatchling picks up the root `.gitignore` which ignores all folders named `sst`. 

## Fix
Updated the `pyproject.toml` to explicitly include `sst` in the build artifacts. 

## Verification 
```
╭─   ~/Desktop/repos/sst/sdk/python   dev ··············  base  04:19:51 PM ─╮
╰─❯ cat pyproject.toml                                                            ─╯
[project]
name = "sst-sdk"
version = "0.2.0"
description = "Python SDK for SST — access linked resources in your SST app"
readme = "README.md"
license = "MIT"
requires-python = ">=3.9"
keywords = ["sst", "serverless", "aws", "lambda", "infrastructure"]
classifiers = [
    "Development Status :: 4 - Beta",
    "Intended Audience :: Developers",
    "License :: OSI Approved :: MIT License",
    "Programming Language :: Python :: 3",
    "Programming Language :: Python :: 3.9",
    "Programming Language :: Python :: 3.10",
    "Programming Language :: Python :: 3.11",
    "Programming Language :: Python :: 3.12",
    "Programming Language :: Python :: 3.13",
    "Topic :: Software Development :: Libraries",
]
dependencies = ["pycryptodomex==3.20.0"]

[project.urls]
Homepage = "https://sst.dev"
Documentation = "https://sst.dev/docs/reference/sdk/#python"
Repository = "https://github.com/anomalyco/sst"
Issues = "https://github.com/anomalyco/sst/issues"

[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"

[tool.hatch.build.targets.wheel]
packages = ["src/sst"]
artifacts = ["sst"]

[tool.hatch.build.targets.sdist]
include = ["src/sst", "pyproject.toml", "README.md"]

[dependency-groups]
dev = ["pytest>=8.4.2"]

╭─   ~/Desktop/repos/sst/sdk/python   dev ··············  base  04:19:59 PM ─╮
╰─❯ uv build                                                                      ─╯
Building source distribution...
Building wheel from source distribution...
Successfully built dist/sst_sdk-0.2.0.tar.gz
Successfully built dist/sst_sdk-0.2.0-py3-none-any.whl

╭─   ~/Desktop/repos/sst/sdk/python   dev ··············  base  04:20:03 PM ─╮
╰─❯ unzip -l dist/*.whl                                                           ─╯
Archive:  dist/sst_sdk-0.2.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     3318  02-02-2020 00:00   sst/__init__.py
     2691  02-02-2020 00:00   sst_sdk-0.2.0.dist-info/METADATA
       87  02-02-2020 00:00   sst_sdk-0.2.0.dist-info/WHEEL
      278  02-02-2020 00:00   sst_sdk-0.2.0.dist-info/RECORD
---------                     -------
     6374                     4 files
```