### PR TITLE
Allow `sst diff` to run before first deploy

### DIFF
--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -71,7 +71,7 @@ func (p *Project) Run(ctx context.Context, input *StackInput) error {
 	defer workdir.Cleanup()
 
 	var passphrase string
-	if input.Command == "deploy" || input.Dev {
+	if input.Command == "deploy" || input.Command == "diff" || input.Dev {
 		passphrase, err = provider.GetOrCreatePassphrase(p.home, p.app.Name, p.app.Stage)
 	} else {
 		passphrase, err = provider.GetPassphrase(p.home, p.app.Name, p.app.Stage)
@@ -99,7 +99,7 @@ func (p *Project) Run(ctx context.Context, input *StackInput) error {
 	_, err = workdir.Pull()
 	if err != nil {
 		if errors.Is(err, provider.ErrStateNotFound) {
-			if input.Command != "deploy" {
+			if input.Command != "deploy" && input.Command != "diff" {
 				return ErrStageNotFound
 			}
 			cmd := process.Command(global.PulumiPath(), "stack", "init", "organization/"+p.app.Name+"/"+p.app.Stage)


### PR DESCRIPTION
## Summary

Closes #6869.

`sst diff` currently hard-exits with `stage not found` when run on a stage that has never been deployed. This PR makes `sst diff` work on fresh stages by letting it fall through into the existing `pulumi stack init` path that `deploy` uses, then runs `pulumi preview` against empty state, emitting the full creation plan as expected.

## Why this is fixing a bug, not changing intended behavior

Two pieces of SST's own documentation already describe `sst diff` working before any deploy:

- **`www/src/content/docs/docs/policy-packs.mdx` line 6:**
  > "Policy packs let you enforce rules on your infrastructure **before deploying**. They use Pulumi Policy Packs under the hood, and **work with the `sst deploy`, `sst diff` and `sst dev` commands**."

- **`cmd/sst/diff.go` lines 34–35 (the `sst diff --help` text):**
  > "This is useful for cases when you pull some changes from a teammate and want to see what will be deployed; **before doing the actual deploy**."

The current code contradicts both. Pulumi natively handles `preview` against empty state by emitting all resources as creations — SST's wrapper was the only thing blocking this.

## Test plan

Reproduced the bug, applied the fix, re-tested end-to-end against real AWS.

- [x] **Before fix** — `sst diff --stage <fresh-stage>` exits with `stage not found`
- [x] **After fix** — same command runs `pulumi preview` against empty state and emits resources marked `+ create` (Bucket + Function expanded into underlying S3, IAM, Lambda, and CloudWatch resources)
- [x] No behavior change for `sst diff` on an already-deployed stage
- [x] Existing Go tests pass (`go test ./cmd/sst/...`)
