### PR TITLE
Fix watcher race condition

### DIFF
--- a/cmd/sst/mosaic/watcher/watcher.go
+++ b/cmd/sst/mosaic/watcher/watcher.go
@@ -339,6 +339,17 @@ func Start(ctx context.Context, config WatchConfig) error {
 					if err != nil {
 						return err
 					}
+
+					// Catch nested dirs/files created while fsnotify attaches to the new dir.
+					select {
+					case <-time.After(50 * time.Millisecond):
+					case <-ctx.Done():
+						return nil
+					}
+					err = watchTree(event.Name, true)
+					if err != nil {
+						return err
+					}
 					continue
 				}
 			}


### PR DESCRIPTION
- Fix race condition where fsnotify misses nested directory creation events when os.MkdirAll creates directories faster than the watcher can attach to them
- Add a 50ms delayed rescan after discovering a new directory to catch any nested directories created during the initial watch attachment