### PR TITLE
Limit CloudFront Function name length in domain redirects

### DIFF
--- a/platform/src/components/aws/https-redirect.ts
+++ b/platform/src/components/aws/https-redirect.ts
@@ -2,7 +2,7 @@ import { ComponentResourceOptions, all, output } from "@pulumi/pulumi";
 import { DnsValidatedCertificate } from "./dns-validated-certificate.js";
 import { Bucket } from "./bucket.js";
 import { Component } from "../component.js";
-import { logicalName } from "../naming.js";
+import { logicalName, physicalName } from "../naming.js";
 import { useProvider } from "./helpers/provider.js";
 import { Input } from "../input.js";
 import { Dns } from "../dns.js";
@@ -140,6 +140,7 @@ export class HttpsRedirect extends Component {
                 functionArn: new cloudfront.Function(
                   `${name}CloudfrontFunctionRequest`,
                   {
+                    name: physicalName(64, `${name}CloudfrontFunctionRequest`),
                     runtime: "cloudfront-js-2.0",
                     code: `
 import cf from "cloudfront";
@@ -148,6 +149,7 @@ async function handler(event) {
   return event.request;
 }`,
                   },
+                  { ignoreChanges: ["name"] },
                 ).arn,
               },
             ],


### PR DESCRIPTION
Closes #6874.

When you use `sst.aws.Astro` with `domain.redirects` and a moderately long component name, the deploy currently fails:

```
Value 'FlowOfficeMarketingWebsiteCdnRedirectCloudfrontFunctionRequest-204822d'
at 'name' failed to satisfy constraint: Member must have length less than or equal to 64
```

The CloudFront Function in the redirect path gets a logical name built from `${componentName}CdnRedirectCloudfrontFunctionRequest`, and Pulumi's auto-naming appends a random suffix on top of that. For component names longer than ~20 characters, the resulting physical name exceeds AWS's 64-character limit.

The fix takes over naming explicitly with the existing `physicalName(64, ...)` helper, paired with `ignoreChanges: ["name"]`. This is the same pattern already used in:

- `function.ts` for the Lambda log group
- `apigatewayv2.ts` for the API Gateway access log

`ignoreChanges` matters here: it makes the change non-disruptive for users whose redirects already work. Their existing CloudFront Function is preserved from Pulumi state, nothing gets replaced.

### Scope

I kept this PR to `https-redirect.ts` only. The same `${name}CloudfrontFunctionRequest` pattern exists in `router.ts`, `ssr-site.ts`, and `static-site.ts`, but those use the site's name directly (no `...CdnRedirect...` cascade in front of it), so they're not overflowing today. Happy to follow up on those in a separate PR if there's interest.

### Test plan

- [x] `bun tsc --noEmit` in `platform/` passes
- [x] Verified `physicalName(64, ...)` outputs stay ≤64 chars and match `[a-zA-Z0-9-_]{1,64}` for inputs from 3 to 100+ chars, including the exact 62-char name from the bug report (output: 64 chars)
