### PR TITLE
Sync IAM permissions breakdown

### DIFF
--- a/www/src/content/docs/docs/iam-credentials.mdx
+++ b/www/src/content/docs/docs/iam-credentials.mdx
@@ -269,6 +269,7 @@ There are a couple of different things being bootstrapped and these are the perm
       "s3:CreateBucket",
       "s3:PutBucketVersioning",
       "s3:PutBucketNotification",
+      "s3:PutBucketPolicy",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
       "s3:GetObject",
@@ -375,7 +376,9 @@ The SST CLI also makes some AWS SDK calls to your account. Here are the IAM perm
       "ssm:GetParameter",
       "ssm:GetParameters",
       "ssm:GetParametersByPath",
-      "ssm:PutParameter"
+      "ssm:PutParameter",
+      "ssm:AddTagsToResource",
+      "ssm:ListTagsForResource"
     ],
     "Resource": [
       "arn:aws:ssm:us-east-1:112233445566:parameter/sst/*"
@@ -383,18 +386,16 @@ The SST CLI also makes some AWS SDK calls to your account. Here are the IAM perm
   }
   ```
 
-- And permissions to connect to the IoT endpoint in `sst dev` to run your functions [_Live_](/docs/live).
+- And permissions to connect to the AppSync endpoint in `sst dev` to run your functions [_Live_](/docs/live).
 
   ```json
   {
     "Sid": "LiveLambdaSocketConnection",
     "Effect": "Allow",
     "Action": [
-      "iot:DescribeEndpoint",
-      "iot:Connect",
-      "iot:Subscribe",
-      "iot:Publish",
-      "iot:Receive"
+      "appsync:EventSubscribe",
+      "appsync:EventPublish",
+      "appsync:EventConnect"
     ],
     "Resource": [
       "*"

--- a/www/src/content/docs/docs/iam-credentials.mdx
+++ b/www/src/content/docs/docs/iam-credentials.mdx
@@ -292,6 +292,8 @@ There are a couple of different things being bootstrapped and these are the perm
     "Action": [
       "s3:CreateBucket",
       "s3:PutBucketVersioning",
+      "s3:PutBucketNotification",
+      "s3:PutBucketPolicy",
       "s3:DeleteObject",
       "s3:GetObject",
       "s3:ListBucket",


### PR DESCRIPTION
The detailed IAM permissions breakdown in `iam-credentials.mdx` had drifted
out of sync with the copy-paste policy block at the top of the same page.

- Added missing `s3:PutBucketPolicy` to the `ManageBootstrapStateBucket` breakdown
- Added missing `ssm:AddTagsToResource` and `ssm:ListTagsForResource` to the
  `ManageSecrets` breakdown
- Updated `LiveLambdaSocketConnection` from IoT to AppSync permissions to reflect
  SST v3's migration away from IoT for the Live Lambda tunnel, and updated the
  prose description to match