### PR TITLE
Use cache dir instead of config dir for pulumi plugins

### DIFF
--- a/pkg/global/global.go
+++ b/pkg/global/global.go
@@ -29,8 +29,22 @@ var configDir = (func() string {
 	return result
 }())
 
+var cacheDir = (func() string {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		panic(err)
+	}
+	result := filepath.Join(cache, "sst")
+	os.MkdirAll(result, 0755)
+	return result
+}())
+
 func ConfigDir() string {
 	return configDir
+}
+
+func CacheDir() string {
+	return cacheDir
 }
 
 func BinPath() string {

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -269,7 +269,7 @@ func (p *Project) Run(ctx context.Context, input *StackInput) error {
 			}
 			return nodeOptions
 		}(),
-		"PULUMI_HOME="+global.ConfigDir(),
+		"PULUMI_HOME="+global.CacheDir(),
 	)
 	if input.ServerPort != 0 {
 		env = append(env, "SST_SERVER=http://127.0.0.1:"+fmt.Sprint(input.ServerPort))


### PR DESCRIPTION
When pulumi install plugins, they all end up in XDG_CONFIG_HOME, however this is for small configs. Putting those large binaries into the cache dir.