### PR TITLE
feat(sdk/aws/workflow): Add stepWithRollbackV2 to fix rollback registration and config

### DIFF
--- a/sdk/js/src/aws/workflow.ts
+++ b/sdk/js/src/aws/workflow.ts
@@ -6,7 +6,7 @@ import { awsFetch, type AwsOptions } from "./client.js";
  * [`@aws/durable-execution-sdk-js`](https://www.npmjs.com/package/@aws/durable-execution-sdk-js)
  * package and the AWS Lambda durable execution APIs.
  *
- * SST also adds a few helpers on top, including `ctx.stepWithRollback()`,
+ * SST also adds a few helpers on top, including `ctx.stepWithRollbackV2()`,
  * `ctx.rollbackAll()`, and `ctx.waitUntil()`.
  *
  * @example
@@ -15,19 +15,22 @@ import { awsFetch, type AwsOptions } from "./client.js";
  * ```
  *
  * @example
- * Use `stepWithRollback()` and `rollbackAll()` to register compensating actions.
+ * Use `stepWithRollbackV2()` to give each step an `undo`, and `rollbackAll()` to
+ * run those undos in reverse on failure. Since the undo is registered before the
+ * step runs, `result` is `undefined` if the step failed partway through — so
+ * reconcile against external state (e.g. look it up by an idempotency key).
  *
  * ```ts title="src/workflow.ts"
  * import { workflow } from "sst/aws/workflow";
  *
- * export const handler = workflow.handler(async (_event, ctx) => {
+ * export const handler = workflow.handler(async (event, ctx) => {
+ *   const idempotencyKey = event.idempotencyKey;
  *   try {
- *     const order = await ctx.stepWithRollback("create-order", {
- *       run: async () => ({ orderId: "order_123" }),
+ *     const order = await ctx.stepWithRollbackV2("create-order", {
+ *       run: async () => createOrder({ idempotencyKey }),
  *       undo: async (error, result) => {
- *         await fetch(`https://example.com/orders/${result.orderId}`, {
- *           method: "DELETE",
- *         });
+ *         const order = result ?? (await findOrder({ idempotencyKey }));
+ *         if (order) await deleteOrder(order.id);
  *       },
  *     });
  *
@@ -70,11 +73,47 @@ export namespace workflow {
     /**
      * Execute a durable step and register a compensating rollback step if it succeeds.
      * If `run` throws, nothing is added to the rollback stack for that step.
+     *
+     * @deprecated Use {@link stepWithRollbackV2}, which registers the undo
+     * *before* the step runs (so side effects from a failed step still roll back)
+     * and configures the undo separately.
      */
     stepWithRollback<TOutput>(
       name: string,
       handler: StepWithRollbackHandler<TOutput, TLogger>,
       config?: StepConfig<TOutput>,
+    ): durable.DurablePromise<TOutput>;
+    /**
+     * Execute a durable step and register its `undo` *before* the step runs, so a
+     * step that fails after a side effect still rolls back via {@link rollbackAll}.
+     *
+     * Since the result doesn't exist yet at registration, `undo` receives
+     * `TOutput | undefined` (`undefined` when the step failed), so it must
+     * reconcile against external state and be idempotent. Configure the undo step
+     * with `config.undoConfig`; it inherits nothing from the run config.
+     *
+     * @example
+     * ```ts
+     * await ctx.stepWithRollbackV2(
+     *   "charge-card",
+     *   {
+     *     run: async () => chargeCard({ idempotencyKey: key }),
+     *     undo: async (error, result) => {
+     *       const charge = result ?? (await findChargeByKey(key));
+     *       if (charge) await refundCharge(charge.id);
+     *     },
+     *   },
+     *   {
+     *     retryStrategy: createRetryStrategy({ maxAttempts: 3 }),
+     *     undoConfig: { retryStrategy: createRetryStrategy({ maxAttempts: 10 }) },
+     *   },
+     * );
+     * ```
+     */
+    stepWithRollbackV2<TOutput>(
+      name: string,
+      handler: StepWithRollbackHandlerV2<TOutput, TLogger>,
+      config?: StepWithRollbackConfig<TOutput>,
     ): durable.DurablePromise<TOutput>;
     /**
      * Wait until the provided time. Delays are rounded up to the nearest second.
@@ -682,6 +721,32 @@ interface StepWithRollbackHandler<
   ) => Promise<void>;
 }
 
+interface StepWithRollbackHandlerV2<
+  TOutput = any,
+  TLogger extends durable.DurableLogger = durable.DurableLogger,
+> {
+  /**
+   * The durable step to execute.
+   */
+  run: durable.StepFunc<TOutput, TLogger>;
+  /**
+   * Called during rollback. `value` is `undefined` if the step failed before
+   * recording a result, so reconcile against external state instead of trusting it.
+   */
+  undo: (
+    error: unknown,
+    value: TOutput | undefined,
+    context: Parameters<durable.StepFunc<void, TLogger>>[0],
+  ) => Promise<void>;
+}
+
+type StepWithRollbackConfig<TOutput = any> = durable.StepConfig<TOutput> & {
+  /**
+   * Configuration for the compensating undo step.
+   */
+  undoConfig?: durable.StepConfig<void>;
+};
+
 interface StartInput<TPayload = unknown> {
   /**
    * The unique name for this workflow execution.
@@ -845,6 +910,46 @@ function withRollback<
             );
           },
         });
+
+        return result;
+      });
+    },
+  });
+
+  Object.defineProperty(wrapped, "stepWithRollbackV2", {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: function <TOutput>(
+      name: string,
+      handler: StepWithRollbackHandlerV2<TOutput, TLogger>,
+      config?: StepWithRollbackConfig<TOutput>,
+    ): durable.DurablePromise<TOutput> {
+      const { undoConfig, ...runConfig } = config || {};
+
+      return new durable.DurablePromise(async () => {
+        const entry: RollbackEntry<TLogger> & { result?: TOutput } = {
+          name,
+          result: undefined,
+          execute: async (
+            error: unknown,
+            rollbackContext: durable.DurableContext<TLogger>,
+          ) => {
+            await rollbackContext.step(
+              `Undo '${name}'`,
+              (stepContext) => handler.undo(error, entry.result, stepContext),
+              undoConfig,
+            );
+          },
+        };
+
+        // Register before the step runs so a side effect that escapes a failing
+        // step is still rolled back.
+        rollbackState.undoStack.push(entry);
+
+        const result = await context.step(name, handler.run, runConfig);
+
+        entry.result = result;
 
         return result;
       });

--- a/sdk/js/test/workflow.test.ts
+++ b/sdk/js/test/workflow.test.ts
@@ -554,3 +554,450 @@ describe("workflow rollback runner", () => {
     expect(calls).toEqual(["run:step-a", "undo:step-a"]);
   });
 });
+
+describe("workflow rollback v2 runner", () => {
+  beforeAll(async () => {
+    await LocalDurableTestRunner.setupTestEnvironment({ skipTime: true });
+  });
+
+  afterAll(async () => {
+    await LocalDurableTestRunner.teardownTestEnvironment();
+  });
+
+  it("registers and drains the failing step's undo with an undefined result", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+    let undoResult: unknown = "unset";
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2(
+          "charge",
+          {
+            run: async () => {
+              calls.push("run:charge:side-effect");
+              throw new Error("post-write failure");
+            },
+            undo: async (error, result) => {
+              errors.push((error as Error).message);
+              undoResult = result;
+              calls.push("undo:charge");
+            },
+          },
+          { retryStrategy: () => ({ shouldRetry: false }) },
+        );
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual(["run:charge:side-effect", "undo:charge"]);
+    expect(errors).toEqual(["post-write failure"]);
+    expect(undoResult).toBeUndefined();
+  });
+
+  it("runs the failing step's undo first, then earlier steps (LIFO)", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2("step-a", {
+          run: async () => {
+            calls.push("run:a");
+            return "result-a";
+          },
+          undo: async (error, value) => {
+            errors.push(`a:${(error as Error).message}`);
+            calls.push(`undo:a:${value}`);
+          },
+        });
+
+        await ctx.stepWithRollbackV2(
+          "step-b",
+          {
+            run: async () => {
+              calls.push("run:b:side-effect");
+              throw new Error("boom");
+            },
+            undo: async (error, value) => {
+              errors.push(`b:${(error as Error).message}`);
+              calls.push(`undo:b:${value}`);
+            },
+          },
+          { retryStrategy: () => ({ shouldRetry: false }) },
+        );
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual([
+      "run:a",
+      "run:b:side-effect",
+      "undo:b:undefined",
+      "undo:a:result-a",
+    ]);
+    expect(errors).toEqual(["b:boom", "a:boom"]);
+  });
+
+  it("lets undo reconcile against external state and no-op when nothing happened", async () => {
+    const externalStore = new Set<string>();
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2<{ id: string }>(
+          "provision",
+          {
+            run: async () => {
+              calls.push("run:provision");
+              throw new Error("failed before side effect");
+            },
+            undo: async (error, result) => {
+              errors.push((error as Error).message);
+              const id = result?.id;
+              if (id && externalStore.has(id)) {
+                externalStore.delete(id);
+                calls.push("undo:deleted");
+              } else {
+                calls.push("undo:noop");
+              }
+            },
+          },
+          { retryStrategy: () => ({ shouldRetry: false }) },
+        );
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual(["run:provision", "undo:noop"]);
+    expect(errors).toEqual(["failed before side effect"]);
+    expect(externalStore.size).toBe(0);
+  });
+
+  it("backfills real results so a later failure's undos see actual output", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2("step-a", {
+          run: async () => {
+            calls.push("run:a");
+            return "result-a";
+          },
+          undo: async (error, value) => {
+            errors.push(`a:${(error as Error).message}`);
+            calls.push(`undo:a:${value}`);
+          },
+        });
+
+        await ctx.stepWithRollbackV2("step-b", {
+          run: async () => {
+            calls.push("run:b");
+            return "result-b";
+          },
+          undo: async (error, value) => {
+            errors.push(`b:${(error as Error).message}`);
+            calls.push(`undo:b:${value}`);
+          },
+        });
+
+        await ctx.step("fail", async () => {
+          throw new Error("boom");
+        });
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual([
+      "run:a",
+      "run:b",
+      "undo:b:result-b",
+      "undo:a:result-a",
+    ]);
+    expect(errors).toEqual(["b:boom", "a:boom"]);
+  });
+
+  it("retries undo per undoConfig, independent of the run config", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+    let undoAttempts = 0;
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2(
+          "step-a",
+          {
+            run: async () => {
+              calls.push("run:a");
+              return "result-a";
+            },
+            undo: async (error) => {
+              errors.push((error as Error).message);
+              undoAttempts++;
+              calls.push(`undo-attempt:${undoAttempts}`);
+              if (undoAttempts === 1) {
+                throw new Error("retry undo once");
+              }
+            },
+          },
+          {
+            retryStrategy: () => ({ shouldRetry: true, delay: { seconds: 1 } }),
+            undoConfig: {
+              retryStrategy: (_error, attempt) => ({
+                shouldRetry: attempt < 2,
+                delay: { seconds: 1 },
+              }),
+            },
+          },
+        );
+
+        await ctx.step("fail", async () => {
+          throw new Error("boom");
+        });
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual(["run:a", "undo-attempt:1", "undo-attempt:2"]);
+    expect(errors).toEqual(["boom", "boom"]);
+    expect(
+      runner.getOperation("Undo 'step-a'").getStepDetails()?.attempt,
+    ).toBe(2);
+  });
+
+  it("does not inherit the run retryStrategy for undo when undoConfig is omitted", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+    let undoAttempts = 0;
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2(
+          "step-a",
+          {
+            run: async () => {
+              calls.push("run:a");
+              return "result-a";
+            },
+            undo: async (error) => {
+              errors.push((error as Error).message);
+              undoAttempts++;
+              calls.push(`undo-attempt:${undoAttempts}`);
+              throw new Error("undo always fails");
+            },
+          },
+          {
+            retryStrategy: () => ({ shouldRetry: false }),
+          },
+        );
+
+        await ctx.step("fail", async () => {
+          throw new Error("boom");
+        });
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(undoAttempts).toBeGreaterThan(1);
+    expect(errors).toHaveLength(undoAttempts);
+    expect(errors.every((message) => message === "boom")).toBe(true);
+    expect(execution.getError().errorType).toBe("RollbackError");
+    expect(execution.getError().errorMessage).toContain("step-a");
+  });
+
+  it("backfills survive a wait-induced replay", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2("step-a", {
+          run: async () => {
+            calls.push("run:a");
+            return "result-a";
+          },
+          undo: async (error, value) => {
+            errors.push(`a:${(error as Error).message}`);
+            calls.push(`undo:a:${value}`);
+          },
+        });
+
+        await ctx.wait("pause", { seconds: 1 });
+
+        await ctx.stepWithRollbackV2("step-b", {
+          run: async () => {
+            calls.push("run:b");
+            return "result-b";
+          },
+          undo: async (error, value) => {
+            errors.push(`b:${(error as Error).message}`);
+            calls.push(`undo:b:${value}`);
+          },
+        });
+
+        await ctx.step("fail", async () => {
+          throw new Error("boom");
+        });
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual([
+      "run:a",
+      "run:b",
+      "undo:b:result-b",
+      "undo:a:result-a",
+    ]);
+    expect(errors).toEqual(["b:boom", "a:boom"]);
+  });
+
+  it("includes the failing step's undo after a replay", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2("step-a", {
+          run: async () => {
+            calls.push("run:a");
+            return "result-a";
+          },
+          undo: async (error, value) => {
+            errors.push(`a:${(error as Error).message}`);
+            calls.push(`undo:a:${value}`);
+          },
+        });
+
+        await ctx.wait("pause", { seconds: 1 });
+
+        await ctx.stepWithRollbackV2(
+          "step-b",
+          {
+            run: async () => {
+              calls.push("run:b:side-effect");
+              throw new Error("boom");
+            },
+            undo: async (error, value) => {
+              errors.push(`b:${(error as Error).message}`);
+              calls.push(`undo:b:${value}`);
+            },
+          },
+          { retryStrategy: () => ({ shouldRetry: false }) },
+        );
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls).toEqual([
+      "run:a",
+      "run:b:side-effect",
+      "undo:b:undefined",
+      "undo:a:result-a",
+    ]);
+    expect(errors).toEqual(["b:boom", "a:boom"]);
+  });
+
+  it("stops rollback on undo failure and reports the failing step", async () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    const handler = workflow.handler(async (_event, ctx) => {
+      try {
+        await ctx.stepWithRollbackV2("step-a", {
+          run: async () => {
+            calls.push("run:a");
+            return "result-a";
+          },
+          undo: async (error) => {
+            errors.push(`a:${(error as Error).message}`);
+            calls.push("undo:a");
+          },
+        });
+
+        await ctx.stepWithRollbackV2(
+          "step-b",
+          {
+            run: async () => {
+              calls.push("run:b");
+              return "result-b";
+            },
+            undo: async (error) => {
+              errors.push(`b:${(error as Error).message}`);
+              calls.push("undo:b");
+              throw new Error("undo failed");
+            },
+          },
+          { undoConfig: { retryStrategy: () => ({ shouldRetry: false }) } },
+        );
+
+        await ctx.step("fail", async () => {
+          throw new Error("boom");
+        });
+      } catch (error) {
+        await ctx.rollbackAll(error);
+        throw error;
+      }
+    });
+
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+    const execution = await runner.run();
+
+    expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+    expect(calls.slice(0, 2)).toEqual(["run:a", "run:b"]);
+    expect(calls.slice(2).every((call) => call === "undo:b")).toBe(true);
+    expect(calls).not.toContain("undo:a");
+    expect(errors.every((message) => message === "b:boom")).toBe(true);
+    expect(execution.getError().errorType).toBe("RollbackError");
+    expect(execution.getError().errorMessage).toContain("step-b");
+  });
+});

--- a/sdk/js/test/workflow.test.ts
+++ b/sdk/js/test/workflow.test.ts
@@ -1,10 +1,26 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   ExecutionStatus,
   LocalDurableTestRunner,
 } from "@aws/durable-execution-sdk-js-testing";
-import { aws } from "../src/aws/client.ts";
-import { workflow } from "../src/aws/workflow.ts";
+import * as realClient from "../src/aws/client.ts";
+
+type FetchImpl = typeof realClient.awsFetch;
+
+let fetchImpl: FetchImpl = () => {
+  throw new Error("awsFetch is not stubbed");
+};
+
+mock.module("../src/aws/client.ts", () => ({
+  ...realClient,
+  awsFetch: (...args: Parameters<FetchImpl>) => fetchImpl(...args),
+}));
+
+const { workflow } = await import("../src/aws/workflow.ts");
+
+afterAll(() => {
+  fetchImpl = realClient.awsFetch;
+});
 
 function jsonResponse(body: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(body), {
@@ -17,18 +33,18 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 }
 
 describe("workflow client", () => {
-  const originalFetch = aws.fetch;
+  const originalFetch = fetchImpl;
 
   beforeEach(() => {
-    aws.fetch = originalFetch;
+    fetchImpl = originalFetch;
   });
 
   afterEach(() => {
-    aws.fetch = originalFetch;
+    fetchImpl = originalFetch;
   });
 
   it("starts a workflow execution", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2015-03-31/functions/my-workflow/invocations?Qualifier=live",
@@ -73,7 +89,7 @@ describe("workflow client", () => {
       init: RequestInit;
     }[] = [];
 
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       requests.push({ service, path, init });
       const url = new URL(`https://example.com${path}`);
       const status = url.searchParams.getAll("Statuses")[0];
@@ -149,7 +165,7 @@ describe("workflow client", () => {
   it("rejects multiple statuses", async () => {
     let calls = 0;
 
-    aws.fetch = async () => {
+    fetchImpl = async () => {
       calls += 1;
       return jsonResponse({ DurableExecutions: [] });
     };
@@ -165,7 +181,7 @@ describe("workflow client", () => {
   });
 
   it("describes a workflow execution", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2025-12-01/durable-executions/arn%3Aworkflow%3Alive%2Fexecution-123",
@@ -193,7 +209,7 @@ describe("workflow client", () => {
   });
 
   it("stops a workflow execution with a normalized error payload", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2025-12-01/durable-executions/arn%3Aworkflow%3Alive%2Fexecution-123/stop",
@@ -230,7 +246,7 @@ describe("workflow client", () => {
   });
 
   it("succeeds a workflow callback", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2025-12-01/durable-execution-callbacks/callback-token/succeed",
@@ -252,7 +268,7 @@ describe("workflow client", () => {
   });
 
   it("fails a workflow callback", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2025-12-01/durable-execution-callbacks/callback-token/fail",
@@ -277,7 +293,7 @@ describe("workflow client", () => {
   });
 
   it("heartbeats a workflow callback", async () => {
-    aws.fetch = async (service, path, init) => {
+    fetchImpl = async (service, path, init) => {
       expect(service).toBe("lambda");
       expect(path).toBe(
         "/2025-12-01/durable-execution-callbacks/callback-token/heartbeat",


### PR DESCRIPTION
Fixes #6902 and #6903.

Two problems with `stepWithRollback` today:

- A step's undo is only registered *after* the step succeeds, so a step that has a side effect and then fails leaves nothing to roll it back (#6902).
- The undo reuses the step's own config, so you can't give rollbacks their own retry strategy (#6903).

To avoid a breaking change, this adds `stepWithRollbackV2` that fixes both. we now register the undo before the step runs, passes the result to the undo as `TOutput | undefined`. this way undo reconciles against real state when the step failed, and takes a separate `undoConfig`. 

The old `stepWithRollback` is kept and marked `@deprecated`.

The workflow test file was also broken before this. it stubbed an `aws.fetch` export that doesn't exist, so the whole file threw on import and none of the tests ran (these SDK tests aren't in CI, so I guess it went unnoticed). The first commit fixes that by mocking `awsFetch` via `mock.module` instead, so the suite actually loads before the V2 work builds on it.