### PR TITLE
Fix duplicate CloudWatch role URN on fresh accounts

### DIFF
--- a/platform/src/components/aws/helpers/apigateway-account.ts
+++ b/platform/src/components/aws/helpers/apigateway-account.ts
@@ -53,7 +53,7 @@ export function setupApiGatewayAccount(
       {
         cloudwatchRoleArn: useCloudWatchRole(opts).arn,
       },
-      { provider: opts.provider },
+      { retainOnDelete: true, provider: opts.provider },
     );
   });
 }

--- a/platform/src/components/aws/helpers/apigateway-account.ts
+++ b/platform/src/components/aws/helpers/apigateway-account.ts
@@ -6,6 +6,34 @@ import {
 } from "@pulumi/pulumi";
 import { $print } from "../../component";
 
+let cloudWatchRole: iam.Role | undefined;
+
+function useCloudWatchRole(opts: ComponentResourceOptions) {
+  const partition = getPartitionOutput(undefined, opts).partition;
+  cloudWatchRole ??= new iam.Role(
+    `APIGatewayPushToCloudWatchLogsRole`,
+    {
+      assumeRolePolicy: jsonStringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: {
+              Service: "apigateway.amazonaws.com",
+            },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      }),
+      managedPolicyArns: [
+        interpolate`arn:${partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs`,
+      ],
+    },
+    { retainOnDelete: true, provider: opts.provider },
+  );
+  return cloudWatchRole;
+}
+
 export function setupApiGatewayAccount(
   namePrefix: string,
   opts: ComponentResourceOptions,
@@ -20,33 +48,10 @@ export function setupApiGatewayAccount(
   return account.cloudwatchRoleArn.apply((arn) => {
     if (arn) return account;
 
-    const partition = getPartitionOutput(undefined, opts).partition;
-    const role = new iam.Role(
-      `APIGatewayPushToCloudWatchLogsRole`,
-      {
-        assumeRolePolicy: jsonStringify({
-          Version: "2012-10-17",
-          Statement: [
-            {
-              Effect: "Allow",
-              Principal: {
-                Service: "apigateway.amazonaws.com",
-              },
-              Action: "sts:AssumeRole",
-            },
-          ],
-        }),
-        managedPolicyArns: [
-          interpolate`arn:${partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs`,
-        ],
-      },
-      { retainOnDelete: true, provider: opts.provider },
-    );
-
     return new apigateway.Account(
       `${namePrefix}APIGatewayAccountSetup`,
       {
-        cloudwatchRoleArn: role.arn,
+        cloudwatchRoleArn: useCloudWatchRole(opts).arn,
       },
       { provider: opts.provider },
     );


### PR DESCRIPTION
Fixes #6199, likely #6677 too. I was also getting this error

On a fresh AWS account `cloudwatchRoleArn` is unset, so the guard in `setupApiGatewayAccount` never short-circuits and every gateway registers an `iam.Role` under the same logical name — two or more gateways and the deploy fails with `Duplicate resource URN`. It dies before the ARN is written back, so retries hit the same race. Any account that ever completed a single-gateway deploy short-circuits, which is why this has been hard to reproduce.

Commit 1 registers the role once per process, same as the `LambdaEncryptionKey` dedupe in `function.ts`. No logical names change, so existing stacks see no churn.

Commit 2: since terraform-provider-aws v6, destroying `aws_api_gateway_account` [resets `cloudwatchRoleArn` to null](https://github.com/hashicorp/terraform-provider-aws/blob/v6.33.0/internal/service/apigateway/account.go#L218-L239). The setup only exists in the program while the ARN is unset, so bootstrap never converges: set, reset on the next deploy, bootstrap again with a fresh orphan role — the pile-up in #6677. `retainOnDelete: true` keeps the account-wide setting in place and the cycle converges after the first deploy.
