### PR TITLE
Re-run `FunctionEnvironmentUpdate` when Lambda changes

### DIFF
--- a/pkg/server/resource/aws-function-environment-update.go
+++ b/pkg/server/resource/aws-function-environment-update.go
@@ -11,9 +11,10 @@ type FunctionEnvironmentUpdate struct {
 }
 
 type FunctionEnvironmentUpdateInputs struct {
-	FunctionName string            `json:"functionName"`
-	Environment  map[string]string `json:"environment"`
-	Region       string            `json:"region"`
+	FunctionName         string            `json:"functionName"`
+	Environment          map[string]string `json:"environment"`
+	Region               string            `json:"region"`
+	FunctionLastModified string            `json:"functionLastModified"`
 }
 
 type FunctionEnvironmentUpdateOutputs struct{}

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -3065,6 +3065,7 @@ export class Function extends Component implements Link.Linkable {
         functionName: this.name,
         environment,
         region: getRegionOutput(undefined, { parent: this }).region,
+        functionLastModified: this.function.lastModified,
       },
       { parent: this },
     );

--- a/platform/src/components/aws/providers/function-environment-update.ts
+++ b/platform/src/components/aws/providers/function-environment-update.ts
@@ -14,6 +14,10 @@ export interface FunctionEnvironmentUpdateInputs {
    * The region of the function to update.
    */
   region: Input<string>;
+  /**
+   * The last modified timestamp of the function to update
+   */
+  functionLastModified: Input<string>;
 }
 
 /**


### PR DESCRIPTION
Fixes #6919 

## Problem

When the Lambda's environment is updated through the main `Function` resource, `FunctionEnvironmentUpdate` does not re-run. Its inputs (`environment`, `functionName`, etc.) are unchanged, so Pulumi skips it — even though the underlying Lambda was just updated.

That means env vars added via `addEnvironment()` are not reconciled: they can be left stale on the function or out of sync with what the resource expects.

## Solution

Pass `function.lastModified` into `FunctionEnvironmentUpdate` as a new `functionLastModified` input. AWS updates this timestamp whenever the Lambda changes, so Pulumi treats it as an input change and re-runs the custom resource's update.

## Changes

- Wire `this.function.lastModified` through `Function.addEnvironment()` in `function.ts`
- Add `functionLastModified` to the TypeScript provider inputs
- Add `FunctionLastModified` to the Go resource inputs struct

---

## Testing

I reproduced the bug with [this code](https://github.com/achadha235/sst-add-env-bug)  and ensured it was fixed with this change


- [x] Deploy an app using `fn.addEnvironment()` (e.g. function with `url: true`)
- [x] Change the function handler/code and redeploy
- [x] Confirm lazily added env vars are still present on the Lambda after deploy