### PR TITLE
Fix `sst add` requiring Prettier (or other dependencies)

### DIFF
--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -612,6 +612,12 @@ var root = &cli.Command{
 						return err
 					}
 				}
+				if p.NeedsInstall() {
+					err := p.Install()
+					if err != nil {
+						return err
+					}
+				}
 				entry, err := project.FindProvider(pkg, "latest", pkg)
 				if err != nil {
 					return util.NewReadableError(err, "Could not find provider "+pkg)

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -30,6 +30,9 @@ func (err *ErrProviderVersionTooLow) Error() string {
 }
 
 func (p *Project) NeedsInstall() bool {
+	if _, err := os.Stat(filepath.Join(p.PathPlatformDir(), "node_modules")); err != nil {
+		return true
+	}
 	if len(p.app.Providers) != len(p.lock) {
 		return true
 	}


### PR DESCRIPTION
## Summary
- treat missing platform `node_modules` as requiring install
- install platform dependencies before `sst add` runs its AST editor
- prevent missing Prettier errors on fresh platform copies

## Testing
- `go test ./pkg/project/... ./cmd/sst/...`
- `bun run --cwd platform test -- test/ast/add.test.ts`
- local CLI against a temporary `examples/cloudflare-worker` copy
- verified `sst add cloudflare`, subsequent provider add, and recovery after removing `.sst/platform/node_modules`