### PR TITLE
Add `state.retention` option to prevent big state buckets

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -47,8 +47,16 @@ type App struct {
 }
 
 type State struct {
-	Purge    bool `json:"purge"`
-	Compress bool `json:"compress"`
+	Purge     bool `json:"purge"`
+	Compress  bool `json:"compress"`
+	Retention *int `json:"retention"`
+}
+
+func validateState(state *State) error {
+	if state != nil && state.Retention != nil && *state.Retention < 1 {
+		return util.NewReadableError(nil, `The "state.retention" property must be a positive integer.`)
+	}
+	return nil
 }
 
 type Watch struct {
@@ -319,6 +327,10 @@ console.log("~j" + JSON.stringify(await mod.app({
 
 			if proj.app.Removal == "" {
 				proj.app.Removal = "retain"
+			}
+
+			if err := validateState(proj.app.State); err != nil {
+				return nil, err
 			}
 
 			if proj.app.Version != "" && input.Version != "dev" {

--- a/pkg/project/provider/aws.go
+++ b/pkg/project/provider/aws.go
@@ -685,6 +685,113 @@ func (a *AwsHome) cleanup(key, app, stage string) error {
 	return nil
 }
 
+func (a *AwsHome) prune(app, stage string, retention int) error {
+	bootstrap, err := a.provider.Bootstrap(a.provider.config.Region)
+	if err != nil {
+		return err
+	}
+	s3Client := s3.NewFromConfig(a.provider.config)
+	prefix := path.Join("snapshot", app, stage) + "/"
+
+	var keys []string
+	var continuationToken *string
+	for {
+		out, err := s3Client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bootstrap.State),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, object := range out.Contents {
+			keys = append(keys, aws.ToString(object.Key))
+		}
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			break
+		}
+		continuationToken = out.NextContinuationToken
+	}
+
+	for _, updateID := range staleUpdateIDs(keys, retention) {
+		for _, kind := range historyKinds {
+			key := a.pathForData(kind, app, path.Join(stage, updateID))
+			if err := a.purgePrefix(s3Client, bootstrap.State, key); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Completed snapshots are the retained history, so intermediate versions of
+	// the mutable current-state object are redundant once the snapshot is stored.
+	if err := a.pruneNoncurrentVersions(s3Client, bootstrap.State, a.pathForData("app", app, stage)); err != nil {
+		return err
+	}
+	// Preserve the active lock while removing versions left by prior updates.
+	return a.pruneNoncurrentVersions(s3Client, bootstrap.State, a.pathForData("lock", app, stage))
+}
+
+func (a *AwsHome) pruneNoncurrentVersions(s3Client *s3.Client, bucket, key string) error {
+	var keyMarker, versionMarker *string
+	var ids []s3types.ObjectIdentifier
+	for {
+		out, err := s3Client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+			Bucket:          aws.String(bucket),
+			Prefix:          aws.String(key),
+			KeyMarker:       keyMarker,
+			VersionIdMarker: versionMarker,
+		})
+		if err != nil {
+			return err
+		}
+
+		ids = append(ids, noncurrentVersionIdentifiers(out, key)...)
+
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			break
+		}
+		keyMarker = out.NextKeyMarker
+		versionMarker = out.NextVersionIdMarker
+	}
+	return a.deleteObjectVersions(s3Client, bucket, ids)
+}
+
+func noncurrentVersionIdentifiers(out *s3.ListObjectVersionsOutput, key string) []s3types.ObjectIdentifier {
+	ids := make([]s3types.ObjectIdentifier, 0, len(out.Versions)+len(out.DeleteMarkers))
+	for _, version := range out.Versions {
+		if aws.ToString(version.Key) == key && !aws.ToBool(version.IsLatest) {
+			ids = append(ids, s3types.ObjectIdentifier{Key: version.Key, VersionId: version.VersionId})
+		}
+	}
+	for _, marker := range out.DeleteMarkers {
+		if aws.ToString(marker.Key) == key && !aws.ToBool(marker.IsLatest) {
+			ids = append(ids, s3types.ObjectIdentifier{Key: marker.Key, VersionId: marker.VersionId})
+		}
+	}
+	return ids
+}
+
+func (a *AwsHome) deleteObjectVersions(s3Client *s3.Client, bucket string, ids []s3types.ObjectIdentifier) error {
+	for i := 0; i < len(ids); i += 1000 {
+		end := i + 1000
+		if end > len(ids) {
+			end = len(ids)
+		}
+		out, err := s3Client.DeleteObjects(context.TODO(), &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucket),
+			Delete: &s3types.Delete{Objects: ids[i:end], Quiet: aws.Bool(true)},
+		})
+		if err != nil {
+			return err
+		}
+		if len(out.Errors) > 0 {
+			item := out.Errors[0]
+			return fmt.Errorf("failed to delete state object %s version %s: %s", aws.ToString(item.Key), aws.ToString(item.VersionId), aws.ToString(item.Message))
+		}
+	}
+	return nil
+}
+
 func (a *AwsHome) purge(app, stage string) error {
 	bootstrap, err := a.provider.Bootstrap(a.provider.config.Region)
 	if err != nil {
@@ -735,18 +842,8 @@ func (a *AwsHome) purgePrefix(s3Client *s3.Client, bucket, prefix string) error 
 			ids = append(ids, s3types.ObjectIdentifier{Key: dm.Key, VersionId: dm.VersionId})
 		}
 
-		// DeleteObjects accepts at most 1000 keys per call.
-		for i := 0; i < len(ids); i += 1000 {
-			end := i + 1000
-			if end > len(ids) {
-				end = len(ids)
-			}
-			if _, err := s3Client.DeleteObjects(context.TODO(), &s3.DeleteObjectsInput{
-				Bucket: aws.String(bucket),
-				Delete: &s3types.Delete{Objects: ids[i:end], Quiet: aws.Bool(true)},
-			}); err != nil {
-				return err
-			}
+		if err := a.deleteObjectVersions(s3Client, bucket, ids); err != nil {
+			return err
 		}
 
 		if out.IsTruncated == nil || !*out.IsTruncated {

--- a/pkg/project/provider/aws_retention_test.go
+++ b/pkg/project/provider/aws_retention_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+func TestNoncurrentVersionIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	key := "app/my-app/production.json"
+	out := &s3.ListObjectVersionsOutput{
+		Versions: []s3types.ObjectVersion{
+			{Key: aws.String(key), VersionId: aws.String("current"), IsLatest: aws.Bool(true)},
+			{Key: aws.String(key), VersionId: aws.String("old-state"), IsLatest: aws.Bool(false)},
+			{Key: aws.String("app/my-app/production.json.backup"), VersionId: aws.String("other"), IsLatest: aws.Bool(false)},
+		},
+		DeleteMarkers: []s3types.DeleteMarkerEntry{
+			{Key: aws.String(key), VersionId: aws.String("old-marker"), IsLatest: aws.Bool(false)},
+		},
+	}
+
+	got := noncurrentVersionIdentifiers(out, key)
+	want := []s3types.ObjectIdentifier{
+		{Key: aws.String(key), VersionId: aws.String("old-state")},
+		{Key: aws.String(key), VersionId: aws.String("old-marker")},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}

--- a/pkg/project/provider/cloudflare.go
+++ b/pkg/project/provider/cloudflare.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,6 +179,79 @@ func (c *CloudflareHome) removeData(kind, app, stage string) error {
 	return nil
 }
 
+func (c *CloudflareHome) listObjects(prefix string) ([]string, error) {
+	type r2Object struct {
+		Key string `json:"key"`
+	}
+	type r2Response struct {
+		Result []r2Object `json:"result"`
+		Info   struct {
+			Cursor      string `json:"cursor"`
+			IsTruncated bool   `json:"is_truncated"`
+		} `json:"result_info"`
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	var keys []string
+	cursor := ""
+	for {
+		query := url.Values{"prefix": []string{prefix}, "per_page": []string{"1000"}}
+		if cursor != "" {
+			query.Set("cursor", cursor)
+		}
+		listPath := "/accounts/" + c.provider.identifier.Identifier + "/r2/buckets/" + c.bootstrap.State + "/objects?" + query.Encode()
+		data, err := makeRequestContext(c.provider.api, context.Background(), http.MethodGet, listPath, nil)
+		if err != nil {
+			return nil, err
+		}
+		var response r2Response
+		if err := json.Unmarshal(data, &response); err != nil {
+			return nil, err
+		}
+		for _, object := range response.Result {
+			keys = append(keys, object.Key)
+		}
+		if !response.Info.IsTruncated || response.Info.Cursor == "" {
+			break
+		}
+		cursor = response.Info.Cursor
+	}
+	return keys, nil
+}
+
+func (c *CloudflareHome) prune(app, stage string, retention int) error {
+	prefix := filepath.Join("snapshot", app, stage) + "/"
+	keys, err := c.listObjects(prefix)
+	if err != nil {
+		return err
+	}
+	stale := map[string]struct{}{}
+	for _, updateID := range staleUpdateIDs(keys, retention) {
+		stale[updateID] = struct{}{}
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+	for _, kind := range historyKinds {
+		keys, err := c.listObjects(filepath.Join(kind, app, stage) + "/")
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			updateID, ok := updateIDFromKey(key)
+			if _, isStale := stale[updateID]; !ok || !isStale {
+				continue
+			}
+			if err := c.removeData(kind, app, filepath.Join(stage, updateID)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (c *CloudflareHome) purge(app, stage string) error {
 	// Single-file keys.
 	for _, key := range []string{"app", "secret"} {
@@ -195,27 +269,14 @@ func (c *CloudflareHome) purge(app, stage string) error {
 }
 
 func (c *CloudflareHome) purgePrefix(prefix string) error {
-	type r2Object struct {
-		Key string `json:"key"`
-	}
-	type r2Response struct {
-		Result []r2Object `json:"result"`
-	}
-
-	c.Lock()
-	defer c.Unlock()
-
-	listPath := "/accounts/" + c.provider.identifier.Identifier + "/r2/buckets/" + c.bootstrap.State + "/objects?prefix=" + prefix
-	data, err := makeRequestContext(c.provider.api, context.Background(), http.MethodGet, listPath, nil)
+	keys, err := c.listObjects(prefix)
 	if err != nil {
 		return err
 	}
-	var response r2Response
-	if err := json.Unmarshal(data, &response); err != nil {
-		return err
-	}
-	for _, obj := range response.Result {
-		_, err := makeRequestContext(c.provider.api, context.Background(), http.MethodDelete, "/accounts/"+c.provider.identifier.Identifier+"/r2/buckets/"+c.bootstrap.State+"/objects/"+obj.Key, nil)
+	for _, key := range keys {
+		c.Lock()
+		_, err := makeRequestContext(c.provider.api, context.Background(), http.MethodDelete, "/accounts/"+c.provider.identifier.Identifier+"/r2/buckets/"+c.bootstrap.State+"/objects/"+key, nil)
+		c.Unlock()
 		if err != nil {
 			return err
 		}

--- a/pkg/project/provider/local.go
+++ b/pkg/project/provider/local.go
@@ -13,10 +13,18 @@ import (
 )
 
 type LocalHome struct {
+	root string
 }
 
 func NewLocalHome() *LocalHome {
 	return &LocalHome{}
+}
+
+func (l *LocalHome) configDir() string {
+	if l.root != "" {
+		return l.root
+	}
+	return global.ConfigDir()
 }
 
 func (l *LocalHome) Bootstrap() error {
@@ -65,6 +73,32 @@ func (l *LocalHome) removeData(key, app, stage string) error {
 	return os.Remove(p)
 }
 
+func (l *LocalHome) prune(app, stage string, retention int) error {
+	dir := filepath.Join(l.configDir(), "state", "snapshot", app, stage)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	keys := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			keys = append(keys, entry.Name())
+		}
+	}
+	for _, updateID := range staleUpdateIDs(keys, retention) {
+		for _, kind := range historyKinds {
+			if err := l.removeData(kind, app, filepath.Join(stage, updateID)); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (l *LocalHome) purge(app, stage string) error {
 	// Single-file keys.
 	for _, key := range []string{"app", "secret"} {
@@ -75,7 +109,7 @@ func (l *LocalHome) purge(app, stage string) error {
 	}
 	// Folder-style keys.
 	for _, key := range []string{"update", "summary", "eventlog", "snapshot"} {
-		dir := filepath.Join(global.ConfigDir(), "state", key, app, stage)
+		dir := filepath.Join(l.configDir(), "state", key, app, stage)
 		if err := os.RemoveAll(dir); err != nil {
 			return err
 		}
@@ -108,11 +142,11 @@ func (c *LocalHome) getPassphrase(app, stage string) (string, error) {
 }
 
 func (l *LocalHome) pathForData(key, app, stage string) string {
-	return filepath.Join(global.ConfigDir(), "state", key, app, fmt.Sprintf("%v.json", stage))
+	return filepath.Join(l.configDir(), "state", key, app, fmt.Sprintf("%v.json", stage))
 }
 
 func (a *LocalHome) listStages(app string) ([]string, error) {
-	path := filepath.Join(global.ConfigDir(), "state", "app", app)
+	path := filepath.Join(a.configDir(), "state", "app", app)
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -135,6 +169,6 @@ func (a *LocalHome) listStages(app string) ([]string, error) {
 func (c *LocalHome) info() (util.KeyValuePairs[string], error) {
 	return util.KeyValuePairs[string]{
 		{Key: "Provider", Value: "Local"},
-		{Key: "Path", Value: global.ConfigDir()},
+		{Key: "Path", Value: c.configDir()},
 	}, nil
 }

--- a/pkg/project/provider/local_retention_test.go
+++ b/pkg/project/provider/local_retention_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestLocalRetentionPrunesUpdateHistory(t *testing.T) {
+	t.Parallel()
+
+	home := &LocalHome{root: t.TempDir()}
+	app := "my-app"
+	stage := "production"
+	updateIDs := []string{
+		"fffffe987654000000000001",
+		"fffffe987654000000000002",
+		"fffffe987654000000000003",
+		"fffffe987654000000000004",
+		"fffffe987654000000000005",
+	}
+
+	for _, updateID := range updateIDs {
+		for _, kind := range []string{"snapshot", "eventlog", "update"} {
+			if err := home.putData(kind, app, stage+"/"+updateID, bytes.NewReader([]byte(updateID))); err != nil {
+				t.Fatalf("writing %s failed: %v", kind, err)
+			}
+		}
+	}
+	if err := home.putData("app", app, stage, bytes.NewReader([]byte("current"))); err != nil {
+		t.Fatalf("writing current state failed: %v", err)
+	}
+
+	if err := home.prune(app, stage, 3); err != nil {
+		t.Fatalf("prune failed: %v", err)
+	}
+
+	for i, updateID := range updateIDs {
+		for _, kind := range []string{"snapshot", "eventlog", "update"} {
+			_, err := os.Stat(home.pathForData(kind, app, stage+"/"+updateID))
+			if i < 3 && err != nil {
+				t.Fatalf("expected retained %s/%s: %v", kind, updateID, err)
+			}
+			if i >= 3 && !os.IsNotExist(err) {
+				t.Fatalf("expected pruned %s/%s, got %v", kind, updateID, err)
+			}
+		}
+	}
+	if _, err := os.Stat(home.pathForData("app", app, stage)); err != nil {
+		t.Fatalf("expected current state to remain: %v", err)
+	}
+}

--- a/pkg/project/provider/provider.go
+++ b/pkg/project/provider/provider.go
@@ -29,6 +29,7 @@ type Home interface {
 	getPassphrase(app, stage string) (string, error)
 	listStages(app string) ([]string, error)
 	cleanup(key, app, stage string) error
+	prune(app, stage string, retention int) error
 	purge(app, stage string) error
 	removePassphrase(app, stage string) error
 	info() (util.KeyValuePairs[string], error)
@@ -181,6 +182,11 @@ func Cleanup(backend Home, app, stage string) error {
 		return err
 	}
 	return nil
+}
+
+func Prune(backend Home, app, stage string, retention int) error {
+	slog.Info("pruning state history", "app", app, "stage", stage, "retention", retention)
+	return backend.prune(app, stage, retention)
 }
 
 func Purge(backend Home, app, stage string) error {

--- a/pkg/project/provider/retention.go
+++ b/pkg/project/provider/retention.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"encoding/hex"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/sst/sst/v3/pkg/id"
+)
+
+var historyKinds = []string{"snapshot", "eventlog", "update", "summary"}
+
+func staleUpdateIDs(keys []string, retention int) []string {
+	updateIDs := make([]string, 0, len(keys))
+	seen := map[string]struct{}{}
+	for _, key := range keys {
+		updateID, ok := updateIDFromKey(key)
+		if !ok {
+			continue
+		}
+		if _, ok := seen[updateID]; ok {
+			continue
+		}
+		seen[updateID] = struct{}{}
+		updateIDs = append(updateIDs, updateID)
+	}
+
+	// Descending IDs encode newer timestamps as lexicographically smaller values.
+	sort.Strings(updateIDs)
+	if len(updateIDs) <= retention {
+		return nil
+	}
+	return updateIDs[retention:]
+}
+
+func updateIDFromKey(key string) (string, bool) {
+	updateID := strings.TrimSuffix(path.Base(key), ".json")
+	if len(updateID) != id.LENGTH {
+		return "", false
+	}
+	if _, err := hex.DecodeString(updateID); err != nil {
+		return "", false
+	}
+	return updateID, true
+}

--- a/pkg/project/provider/retention_test.go
+++ b/pkg/project/provider/retention_test.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStaleUpdateIDs(t *testing.T) {
+	t.Parallel()
+
+	keys := []string{
+		"snapshot/app/stage/fffffe987654000000000005.json",
+		"snapshot/app/stage/fffffe987654000000000002.json",
+		"snapshot/app/stage/fffffe987654000000000004.json",
+		"snapshot/app/stage/fffffe987654000000000001.json",
+		"snapshot/app/stage/fffffe987654000000000003.json",
+	}
+
+	got := staleUpdateIDs(keys, 3)
+	want := []string{
+		"fffffe987654000000000004",
+		"fffffe987654000000000005",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestStaleUpdateIDsIgnoresUnknownKeys(t *testing.T) {
+	t.Parallel()
+
+	keys := []string{
+		"snapshot/app/stage/fffffe987654000000000001.json",
+		"snapshot/app/stage/fffffe987654000000000002.json",
+		"snapshot/app/stage/not-an-update.json",
+		"snapshot/app/stage/fffffe987654000000000001.json",
+	}
+
+	got := staleUpdateIDs(keys, 1)
+	want := []string{"fffffe987654000000000002"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestStaleUpdateIDsWithinRetention(t *testing.T) {
+	t.Parallel()
+
+	keys := []string{
+		"snapshot/app/stage/fffffe987654000000000001.json",
+		"snapshot/app/stage/fffffe987654000000000002.json",
+	}
+
+	if got := staleUpdateIDs(keys, 2); got != nil {
+		t.Fatalf("expected no stale updates, got %v", got)
+	}
+}

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -675,7 +675,7 @@ loop:
 			if err := provider.Purge(p.home, p.app.Name, p.app.Stage); err != nil {
 				return err
 			}
-		} else if p.app.State == nil || p.app.State.Retention == nil {
+		} else {
 			if err := provider.Cleanup(p.home, p.app.Name, p.app.Stage); err != nil {
 				return err
 			}

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -650,7 +650,7 @@ loop:
 	defer outputsFile.Close()
 	json.NewEncoder(outputsFile).Encode(complete.Outputs)
 
-	if input.Command != "diff " {
+	if input.Command != "diff" {
 		update.TimeCompleted = time.Now().Format(time.RFC3339)
 		for _, err := range errors {
 			update.Errors = append(update.Errors, provider.SummaryError{
@@ -664,12 +664,18 @@ loop:
 		}
 	}
 
+	if input.Command != "diff" && p.app.State != nil && p.app.State.Retention != nil {
+		if err := provider.Prune(p.home, p.app.Name, p.app.Stage, *p.app.State.Retention); err != nil {
+			log.Warn("failed to prune state history", "err", err)
+		}
+	}
+
 	if input.Command == "remove" && len(complete.Resources) == 0 {
 		if p.app.State != nil && p.app.State.Purge {
 			if err := provider.Purge(p.home, p.app.Name, p.app.Stage); err != nil {
 				return err
 			}
-		} else {
+		} else if p.app.State == nil || p.app.State.Retention == nil {
 			if err := provider.Cleanup(p.home, p.app.Name, p.app.Stage); err != nil {
 				return err
 			}

--- a/pkg/project/state_test.go
+++ b/pkg/project/state_test.go
@@ -1,0 +1,34 @@
+package project
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateStateRetention(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []int{0, -1} {
+		value := value
+		if err := validateState(&State{Retention: &value}); err == nil {
+			t.Fatalf("expected retention %d to fail validation", value)
+		}
+	}
+
+	value := 30
+	if err := validateState(&State{Retention: &value}); err != nil {
+		t.Fatalf("expected positive retention to pass validation: %v", err)
+	}
+	if err := validateState(nil); err != nil {
+		t.Fatalf("expected omitted state to pass validation: %v", err)
+	}
+}
+
+func TestStateRetentionRejectsFractions(t *testing.T) {
+	t.Parallel()
+
+	var state State
+	if err := json.Unmarshal([]byte(`{"retention":1.5}`), &state); err == nil {
+		t.Fatal("expected fractional retention to fail decoding")
+	}
+}

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -373,12 +373,12 @@ export interface App {
      * event logs, update records, and summaries. The current state, secrets, and
      * passphrase are not removed.
      *
+     * :::tip
+     * Use this property if your state bucket is growing very large.
+     * :::
+     *
      * Retention is based on the number of completed updates, not their age. An
      * inactive stage therefore keeps its retained history indefinitely.
-     *
-     * On AWS, the retained snapshots become the recovery history. SST permanently
-     * removes pruned history and noncurrent versions of the mutable current-state
-     * object, which include intermediate checkpoints.
      *
      * @default All completed state snapshots are kept.
      *

--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -366,6 +366,35 @@ export interface App {
      * ```
      */
     compress?: boolean;
+    /**
+     * The number of completed state snapshots to keep for each stage.
+     *
+     * After an update completes, SST removes older snapshots and their matching
+     * event logs, update records, and summaries. The current state, secrets, and
+     * passphrase are not removed.
+     *
+     * Retention is based on the number of completed updates, not their age. An
+     * inactive stage therefore keeps its retained history indefinitely.
+     *
+     * On AWS, the retained snapshots become the recovery history. SST permanently
+     * removes pruned history and noncurrent versions of the mutable current-state
+     * object, which include intermediate checkpoints.
+     *
+     * @default All completed state snapshots are kept.
+     *
+     * @example
+     *
+     * Keep the latest 30 completed state snapshots.
+     *
+     * ```ts
+     * {
+     *   state: {
+     *     retention: 30
+     *   }
+     * }
+     * ```
+     */
+    retention?: number;
   };
 
   /**

--- a/www/src/content/docs/docs/state.mdx
+++ b/www/src/content/docs/docs/state.mdx
@@ -66,7 +66,7 @@ You can read more about the `home` provider in [Config](/docs/reference/config/)
 
 ---
 
-### History retention
+### Retention
 
 By default, SST keeps every completed state snapshot. You can limit the number of snapshots kept for each stage with `state.retention`.
 
@@ -79,7 +79,7 @@ By default, SST keeps every completed state snapshot. You can limit the number o
 }
 ```
 
-After an update completes, SST keeps the latest 30 snapshots and removes older snapshots with their matching event logs, update records, and summaries. The current state, secrets, and encryption passphrase are not removed. These snapshots are also preserved after `sst remove` unless `state.purge` is enabled.
+After an update completes, SST keeps the latest 30 snapshots and removes older snapshots with their matching event logs, update records, and summaries. The current state, secrets, and encryption passphrase are not removed.
 
 Retention counts completed updates instead of days. If a stage is inactive, its retained snapshots do not expire. Pruning runs the next time an update completes for that stage.
 

--- a/www/src/content/docs/docs/state.mdx
+++ b/www/src/content/docs/docs/state.mdx
@@ -66,6 +66,31 @@ You can read more about the `home` provider in [Config](/docs/reference/config/)
 
 ---
 
+### History retention
+
+By default, SST keeps every completed state snapshot. You can limit the number of snapshots kept for each stage with `state.retention`.
+
+```ts title="sst.config.ts"
+{
+  home: "aws",
+  state: {
+    retention: 30
+  }
+}
+```
+
+After an update completes, SST keeps the latest 30 snapshots and removes older snapshots with their matching event logs, update records, and summaries. The current state, secrets, and encryption passphrase are not removed. These snapshots are also preserved after `sst remove` unless `state.purge` is enabled.
+
+Retention counts completed updates instead of days. If a stage is inactive, its retained snapshots do not expire. Pruning runs the next time an update completes for that stage.
+
+:::caution
+Lowering `state.retention` permanently removes older state history. On AWS, SST also removes the underlying S3 object versions.
+:::
+
+On AWS, the retained snapshots become the recovery history. SST removes noncurrent versions of the mutable current-state object, including the intermediate checkpoints uploaded during an update.
+
+---
+
 ## Bootstrap
 
 As SST starts deploying the resources in your app, it creates some additional _bootstrap_ resources. If your app has a Lambda function or a Docker container, then SST will create the following in the same region as the given resource:


### PR DESCRIPTION
## Summary

- add `state.retention` to keep the latest completed state snapshots
- prune matching snapshot, event log, update, and summary history across AWS, Cloudflare, and local homes
- permanently remove pruned S3 versions while preserving current state, secrets, and retained snapshots

## Behavior

```ts
state: {
  retention: 30
}
```

Retention counts completed updates, not days. Omitted retention keeps all history. Pruning runs after an update and failures are non-fatal.

On AWS, retained snapshots become recovery history; noncurrent `app` checkpoints and stale lock versions are removed. On Cloudflare R2 and local homes, stale history objects are deleted explicitly.

## Tests

- `bun run test:cli`
- `go test ./pkg/project/...`
- `bun run typecheck`
- `bun run build:cli`
- `git diff --check`

`bun run build:platform` completed TypeScript bundling, but local Docker reported that its driver does not support multi-platform builds; command exited 0.

Supersedes #6669.