### PR TITLE
Fix Python container builds for workspace members above the workspace root

### DIFF
--- a/pkg/runtime/python/build.go
+++ b/pkg/runtime/python/build.go
@@ -655,6 +655,14 @@ func installDependenciesForLambda(ctx context.Context, input *runtime.BuildInput
 
 // copyWorkspacePackagesForContainer copies workspace package directories into the artifact
 // so the Dockerfile's `uv pip install -r requirements.txt` can resolve relative paths.
+//
+// Members that live above the workspace root (e.g. "../../lib") cannot be
+// referenced by their original relative path: copying them there would escape
+// the docker build context, and inside the image uv would resolve the path
+// against the requirements.txt location (/var/task) and fail. Such members are
+// re-homed inside the build context by stripping the leading "../" segments
+// (e.g. "../../lib" -> "./lib"), and the requirements.txt line is rewritten to
+// match.
 func copyWorkspacePackagesForContainer(input *runtime.BuildInput, projectInfo *projectInfo) error {
 	workspaceRoot := findWorkspaceRoot(projectInfo)
 
@@ -665,8 +673,10 @@ func copyWorkspacePackagesForContainer(input *runtime.BuildInput, projectInfo *p
 	}
 
 	lines := strings.Split(string(content), "\n")
+	rewritten := false
+	rehomed := map[string]string{}
 
-	for _, line := range lines {
+	for i, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
 			continue
@@ -691,8 +701,26 @@ func copyWorkspacePackagesForContainer(input *runtime.BuildInput, projectInfo *p
 			continue
 		}
 
-		// Copy to artifact at the same relative path
-		destPath := filepath.Join(input.Out(), pkgPath)
+		// Re-home members that live above the workspace root inside the build
+		// context, and rewrite their requirements.txt line to the new path.
+		contextPath := pkgPath
+		if strings.HasPrefix(pkgPath, "../") {
+			trimmed := pkgPath
+			for strings.HasPrefix(trimmed, "../") {
+				trimmed = strings.TrimPrefix(trimmed, "../")
+			}
+			if trimmed == "" || trimmed == "." {
+				slog.Warn("cannot re-home workspace package inside build context", "line", line)
+				continue
+			}
+			contextPath = "./" + trimmed
+			lines[i] = contextPath + strings.TrimPrefix(line, pkgPath)
+			rewritten = true
+			rehomed[pkgPath] = contextPath
+		}
+
+		// Copy to artifact at the in-context relative path
+		destPath := filepath.Join(input.Out(), contextPath)
 		if _, err := os.Stat(destPath); err == nil {
 			// Already exists — just ensure pyproject.toml is present for uv pip install
 			srcPyproject := filepath.Join(fullPath, "pyproject.toml")
@@ -722,7 +750,60 @@ func copyWorkspacePackagesForContainer(input *runtime.BuildInput, projectInfo *p
 
 	}
 
+	if rewritten {
+		if err := os.WriteFile(requirementsPath, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+			return fmt.Errorf("failed to rewrite requirements.txt for workspace packages: %w", err)
+		}
+	}
+
+	if len(rehomed) > 0 {
+		if err := rewritePyprojectWorkspacePaths(input, projectInfo, rehomed); err != nil {
+			return fmt.Errorf("failed to rewrite pyproject.toml workspace paths: %w", err)
+		}
+	}
+
 	return nil
+}
+
+// rewritePyprojectWorkspacePaths updates workspace member paths in the artifact's
+// pyproject.toml after their packages were re-homed inside the build context.
+// uv validates [tool.uv.workspace] members when it builds the project inside the
+// image, so a member path like "../../lib" fails with "Workspace member
+// `/var/task/../../lib` is missing a `pyproject.toml`" even after the package
+// itself was copied into the context. Replaces the exact quoted paths only, so
+// the rest of the file (comments, formatting) is untouched.
+func rewritePyprojectWorkspacePaths(input *runtime.BuildInput, projectInfo *projectInfo, rehomed map[string]string) error {
+	outPyproject := filepath.Join(input.Out(), "pyproject.toml")
+	if _, err := os.Stat(outPyproject); err != nil {
+		// Not copied yet (ensureDockerfile runs later in the build). Copy it
+		// now so the rewrite lands in the artifact, not the source tree.
+		if projectInfo.PyprojectPath == "" {
+			return nil
+		}
+		if _, err := os.Stat(projectInfo.PyprojectPath); err != nil {
+			return nil
+		}
+		if err := copyFile(projectInfo.PyprojectPath, outPyproject); err != nil {
+			return err
+		}
+	}
+
+	content, err := os.ReadFile(outPyproject)
+	if err != nil {
+		return err
+	}
+
+	updated := string(content)
+	for oldPath, newPath := range rehomed {
+		for _, quote := range []string{`"`, `'`} {
+			updated = strings.ReplaceAll(updated, quote+oldPath+quote, quote+newPath+quote)
+		}
+	}
+
+	if updated == string(content) {
+		return nil
+	}
+	return os.WriteFile(outPyproject, []byte(updated), 0644)
 }
 
 // copySourceFilesSimple copies handler source files to the build output.

--- a/pkg/runtime/python/build_test.go
+++ b/pkg/runtime/python/build_test.go
@@ -303,3 +303,163 @@ func TestHasBuildConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyWorkspacePackagesForContainer(t *testing.T) {
+	// Builds a workspace where the member lives above the workspace root:
+	//
+	//   repo/
+	//     lib/                  <- workspace member ("../../lib" from app)
+	//     projects/app/         <- workspace root (has [tool.uv.workspace])
+	//
+	// and a build output dir seeded with the given requirements.txt.
+	setup := func(t *testing.T, requirements string) (*runtime.BuildInput, *projectInfo, string) {
+		tmp := t.TempDir()
+		appDir := filepath.Join(tmp, "repo", "projects", "app")
+		libDir := filepath.Join(tmp, "repo", "lib")
+
+		if err := os.MkdirAll(filepath.Join(libDir, "src", "shared"), 0755); err != nil {
+			t.Fatalf("failed to create lib dir: %v", err)
+		}
+		if err := os.MkdirAll(appDir, 0755); err != nil {
+			t.Fatalf("failed to create app dir: %v", err)
+		}
+		files := map[string]string{
+			filepath.Join(appDir, "pyproject.toml"):               "[project]\nname = \"app\"\n\n[tool.uv.workspace]\nmembers = [\"../../lib\"]\n",
+			filepath.Join(libDir, "pyproject.toml"):               "[project]\nname = \"shared\"\n",
+			filepath.Join(libDir, "src", "shared", "__init__.py"): "",
+		}
+		for path, content := range files {
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatalf("failed to write %s: %v", path, err)
+			}
+		}
+
+		input := &runtime.BuildInput{
+			CfgPath:     filepath.Join(tmp, "sst.config.ts"),
+			FunctionID:  "testfn",
+			IsContainer: true,
+		}
+		outDir := input.Out()
+		if err := os.MkdirAll(outDir, 0755); err != nil {
+			t.Fatalf("failed to create output dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(outDir, "requirements.txt"), []byte(requirements), 0644); err != nil {
+			t.Fatalf("failed to write requirements.txt: %v", err)
+		}
+
+		info := &projectInfo{
+			ProjectRoot:   tmp,
+			SourceRoot:    appDir,
+			PyprojectPath: filepath.Join(appDir, "pyproject.toml"),
+		}
+		return input, info, outDir
+	}
+
+	readRequirements := func(t *testing.T, outDir string) string {
+		content, err := os.ReadFile(filepath.Join(outDir, "requirements.txt"))
+		if err != nil {
+			t.Fatalf("failed to read requirements.txt: %v", err)
+		}
+		return string(content)
+	}
+
+	t.Run("member above workspace root is re-homed and requirements rewritten", func(t *testing.T) {
+		input, info, outDir := setup(t, "# generated\n.\n../../lib\nboto3==1.34.0\n")
+
+		if err := copyWorkspacePackagesForContainer(input, info); err != nil {
+			t.Fatalf("copyWorkspacePackagesForContainer failed: %v", err)
+		}
+
+		got := readRequirements(t, outDir)
+		want := "# generated\n.\n./lib\nboto3==1.34.0\n"
+		if got != want {
+			t.Errorf("requirements.txt = %q, want %q", got, want)
+		}
+
+		// Package copied inside the build context, not above it
+		if _, err := os.Stat(filepath.Join(outDir, "lib", "pyproject.toml")); err != nil {
+			t.Error("lib/pyproject.toml should have been copied into the build context")
+		}
+		if _, err := os.Stat(filepath.Join(outDir, "lib", "src", "shared", "__init__.py")); err != nil {
+			t.Error("lib package source should have been copied into the build context")
+		}
+		if _, err := os.Stat(filepath.Join(filepath.Dir(filepath.Dir(outDir)), "lib")); err == nil {
+			t.Error("lib should not have been copied outside the build context")
+		}
+
+		// The artifact's pyproject.toml must point at the re-homed member, or
+		// uv's workspace validation fails when building the project in-image.
+		pyproject, err := os.ReadFile(filepath.Join(outDir, "pyproject.toml"))
+		if err != nil {
+			t.Fatalf("artifact pyproject.toml should exist: %v", err)
+		}
+		if !strings.Contains(string(pyproject), "\"./lib\"") {
+			t.Errorf("artifact pyproject.toml should reference \"./lib\", got: %s", pyproject)
+		}
+		if strings.Contains(string(pyproject), "../../lib") {
+			t.Errorf("artifact pyproject.toml still references \"../../lib\": %s", pyproject)
+		}
+
+		// The source tree's pyproject.toml must be untouched
+		srcPyproject, err := os.ReadFile(info.PyprojectPath)
+		if err != nil {
+			t.Fatalf("failed to read source pyproject.toml: %v", err)
+		}
+		if !strings.Contains(string(srcPyproject), "../../lib") {
+			t.Error("source pyproject.toml should not have been modified")
+		}
+	})
+
+	t.Run("extras and markers are preserved on rewritten lines", func(t *testing.T) {
+		input, info, outDir := setup(t, "../../lib[crypto] ; python_version >= \"3.11\"\n")
+
+		if err := copyWorkspacePackagesForContainer(input, info); err != nil {
+			t.Fatalf("copyWorkspacePackagesForContainer failed: %v", err)
+		}
+
+		got := readRequirements(t, outDir)
+		want := "./lib[crypto] ; python_version >= \"3.11\"\n"
+		if got != want {
+			t.Errorf("requirements.txt = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("member inside workspace root is unchanged", func(t *testing.T) {
+		input, info, outDir := setup(t, "./core\nboto3==1.34.0\n")
+
+		coreDir := filepath.Join(filepath.Dir(info.PyprojectPath), "core")
+		if err := os.MkdirAll(coreDir, 0755); err != nil {
+			t.Fatalf("failed to create core dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(coreDir, "pyproject.toml"), []byte("[project]\nname = \"core\"\n"), 0644); err != nil {
+			t.Fatalf("failed to write core pyproject: %v", err)
+		}
+
+		if err := copyWorkspacePackagesForContainer(input, info); err != nil {
+			t.Fatalf("copyWorkspacePackagesForContainer failed: %v", err)
+		}
+
+		got := readRequirements(t, outDir)
+		want := "./core\nboto3==1.34.0\n"
+		if got != want {
+			t.Errorf("requirements.txt = %q, want %q", got, want)
+		}
+		if _, err := os.Stat(filepath.Join(outDir, "core", "pyproject.toml")); err != nil {
+			t.Error("core package should have been copied into the build context")
+		}
+	})
+
+	t.Run("missing member directory leaves requirements unchanged", func(t *testing.T) {
+		input, info, outDir := setup(t, "../../missing\nboto3==1.34.0\n")
+
+		if err := copyWorkspacePackagesForContainer(input, info); err != nil {
+			t.Fatalf("copyWorkspacePackagesForContainer failed: %v", err)
+		}
+
+		got := readRequirements(t, outDir)
+		want := "../../missing\nboto3==1.34.0\n"
+		if got != want {
+			t.Errorf("requirements.txt = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Python container builds fail when a uv workspace member is referenced with a parent path (e.g. `members = ["../../lib"]`). This PR copies such members into the docker build context and rewrites the requirements.txt lines and pyproject.toml member paths so uv can resolve them inside the image.

Fixes #6928

## Problem

`uv export` writes path members into requirements.txt as-is. A member above the workspace root produces a line like `../../lib`, which breaks container builds three ways:

1. `copyWorkspacePackagesForContainer` copies the member to `filepath.Join(artifactDir, "../../lib")`. That path is outside the docker build context, so the package never reaches the image.
2. Inside the image, uv resolves `../../lib` against the requirements.txt location (`/var/task`) and fails.
3. Even with 1 and 2 fixed, the artifact's pyproject.toml still declares `members = ["../../lib"]`, and uv's workspace validation fails when building the project in-image: `Workspace member '/var/task/../../lib' is missing a 'pyproject.toml'`

Members inside the workspace root (`./core`) are unaffected.

## Solution

In `copyWorkspacePackagesForContainer`:

- Members that resolve above the workspace root are re-homed inside the build context by stripping the leading `../` segments (`../../lib` becomes `./lib`).
- Their requirements.txt lines are rewritten to the new path. Extras and markers are preserved.
- The matching member paths in the artifact's pyproject.toml are rewritten the same way, via exact quoted-string replacement so the rest of the file is untouched. The source tree is never modified.

Compatibility:

- Members inside the workspace root keep identical behavior.
- Zip builds do not run this code path.
- Every configuration this touches fails unconditionally today, so no working setup can regress.

Known limitation: literal member paths only. Parent-path globs (`members = ["../../packages/*"]`) are not rewritten in pyproject.toml.

## Testing

- New `TestCopyWorkspacePackagesForContainer`: re-homing with requirements and pyproject rewrites, extras and markers preserved, `./` members unchanged, missing member directories left alone, source pyproject untouched.
- `go test ./pkg/runtime/python/` passes, gofmt and go vet clean.
- Validated end to end on a real monorepo: a container Lambda whose deploy failed with this error builds, deploys, and processes SQS jobs with the patch.
