### PR TITLE
Document PlanetScale role successors

### DIFF
--- a/examples/aws-planetscale-drizzle-postgres/sst.config.ts
+++ b/examples/aws-planetscale-drizzle-postgres/sst.config.ts
@@ -43,6 +43,9 @@
  * bun run db:push
  * ```
  *
+ * The database role sets `successor` to `postgres` so PlanetScale can reassign
+ * owned schema objects before deleting a non-production branch role.
+ *
  * In the function we use [Drizzle ORM](https://orm.drizzle.team) with the
  * [`Resource`](/docs/reference/sdk/#resource) helper.
  *
@@ -103,6 +106,7 @@ export default $config({
         "pg_write_all_data",
         "postgres", // Only needed for pushing schema changes
       ],
+      successor: "postgres",
     });
 
     const database = new sst.Linkable("Database", {

--- a/examples/cloudflare-hyperdrive-planetscale/sst.config.ts
+++ b/examples/cloudflare-hyperdrive-planetscale/sst.config.ts
@@ -44,6 +44,7 @@ export default $config({
       inheritedRoles: ["pg_read_all_data", "pg_write_all_data"],
       name: `${$app.name}-${$app.stage}`,
       organization: db.organization,
+      successor: "postgres",
     });
 
     const hyperdrive = new sst.cloudflare.Hyperdrive("Database", {

--- a/www/src/content/docs/docs/planetscale.mdx
+++ b/www/src/content/docs/docs/planetscale.mdx
@@ -50,6 +50,31 @@ const db = planetscale.getDatabaseVitessOutput({
 This guide uses the Vitess resources. PlanetScale also supports Postgres with equivalent resources and functions: `PostgresBranch`, `PostgresBranchRole`, `getDatabasePostgresOutput`, and `getPostgresBranchOutput`.
 :::
 
+For branch-per-stage Postgres roles, set `successor` to another role that should
+receive ownership of database objects before PlanetScale deletes the role. This
+is especially important in preview and branch-per-stage workflows where
+non-production roles are removed automatically after they may have created or
+modified objects.
+
+```ts title="sst.config.ts"
+const role = new planetscale.PostgresBranchRole("DatabaseRole", {
+  database: db.name,
+  organization: db.organization,
+  branch: branch.name,
+  name: `${$app.name}-${$app.stage}`,
+  inheritedRoles: [
+    "pg_read_all_data",
+    "pg_write_all_data",
+    "postgres", // Only needed for pushing schema changes
+  ],
+  successor: "postgres",
+});
+```
+
+Runtime-only roles that never own database objects do not need a `successor`,
+but setting one makes branch cleanup robust if the role later creates or owns
+objects.
+
 ---
 
 ## Branch per stage


### PR DESCRIPTION
## Problem

PlanetScale Postgres branch roles can own database objects after an app or migration tool creates or changes schema objects. In branch-per-stage and preview workflows, SST removes non-production resources automatically. If a `PostgresBranchRole` owns objects and no successor is configured, PlanetScale can reject role deletion during preview cleanup because it does not know which role should receive ownership of those objects.

Representative cleanup failure from a preview stage:

```text
~  Remove
|  Deleted     <dependent resources>
|  Error       <role-resource> planetscale:index:PostgresBranchRole
failure to invoke API: unknown status code returned: Status 422
{"code":"unprocessable","message":"Role is still referenced and cannot be dropped."}

✕  Failed

<role-resource> planetscale:index:PostgresBranchRole
failure to invoke API: unknown status code returned: Status 422
{"code":"unprocessable","message":"Role is still referenced and cannot be dropped."}
```

## Fix

This updates the PlanetScale docs and Postgres examples to model `successor: "postgres"` on branch roles. The successor gives PlanetScale a role to reassign owned objects to before deleting a temporary branch role.

The docs now call out that runtime-only roles which never own objects do not require a successor, but setting one makes cleanup robust if the role later creates or owns objects.

## Changes

- Add `successor: "postgres"` to the AWS PlanetScale Drizzle Postgres example.
- Add `successor: "postgres"` to the Cloudflare Hyperdrive PlanetScale example.
- Document why branch-per-stage Postgres roles should configure a successor.

## Validation

- `git diff --check`
- `bun run typecheck` was attempted, but the current checkout fails on pre-existing platform AWS provider type errors before reaching these docs/example changes.
