### PR TITLE
Fix intermittent Lambda 409 when adding Function URL permissions

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1717,6 +1717,7 @@ export class Function extends Component implements Link.Linkable {
   private role: iam.Role;
   private logGroup: Output<cloudwatch.LogGroup | undefined>;
   private urlEndpoint: Output<string | undefined>;
+  private urlResource: Output<lambda.FunctionUrl | undefined>;
   private eventInvokeConfig?: lambda.FunctionEventInvokeConfig;
 
   private static readonly encryptionKey = lazy(
@@ -1787,7 +1788,7 @@ export class Function extends Component implements Link.Linkable {
     const logGroup = createLogGroup();
     const zipAsset = createZipAsset();
     const fn = createFunction();
-    const urlEndpoint = createUrl();
+    const { endpoint: urlEndpoint, resource: urlResource } = createUrl();
     createProvisioned();
     const eventInvokeConfig = createEventInvokeConfig();
 
@@ -1797,6 +1798,7 @@ export class Function extends Component implements Link.Linkable {
     this.role = role;
     this.logGroup = logGroup;
     this.urlEndpoint = urlEndpoint;
+    this.urlResource = urlResource;
     this.eventInvokeConfig = eventInvokeConfig;
 
     const buildInput = output({
@@ -2708,9 +2710,13 @@ export class Function extends Component implements Link.Linkable {
       );
     }
 
-    function createUrl() {
-      return url.apply((url) => {
-        if (url === undefined) return output(undefined);
+    function createUrl(): {
+      endpoint: Output<string | undefined>;
+      resource: Output<lambda.FunctionUrl | undefined>;
+    } {
+      const result = url.apply((url) => {
+        if (url === undefined)
+          return { endpoint: output(undefined), resource: undefined };
 
         const authorization = output(url.authorization ?? "none");
         const isOac = output(url.route?.routerProtection).apply(
@@ -2761,7 +2767,7 @@ export class Function extends Component implements Link.Linkable {
                 principal: "*",
                 functionUrlAuthType: "NONE",
               },
-              { parent },
+              { parent, dependsOn: [fnUrl] },
             );
             new lambda.Permission(
               `${name}InvokeFunction`,
@@ -2771,10 +2777,10 @@ export class Function extends Component implements Link.Linkable {
                 principal: "*",
                 invokedViaFunctionUrl: true,
               },
-              { parent },
+              { parent, dependsOn: [fnUrl] },
             );
           });
-          return fnUrl.functionUrl;
+          return { endpoint: fnUrl.functionUrl, resource: fnUrl };
         }
 
         // Create permissions based on Router protection mode
@@ -2789,7 +2795,7 @@ export class Function extends Component implements Link.Linkable {
                   principal: "cloudfront.amazonaws.com",
                   sourceArn: distributionArn,
                 },
-                { parent },
+                { parent, dependsOn: [fnUrl] },
               );
               new lambda.Permission(
                 `${name}CloudFrontInvokeFunction`,
@@ -2800,7 +2806,7 @@ export class Function extends Component implements Link.Linkable {
                   sourceArn: distributionArn,
                   invokedViaFunctionUrl: true,
                 },
-                { parent },
+                { parent, dependsOn: [fnUrl] },
               );
             } else if (authorization === "none") {
               new lambda.Permission(
@@ -2811,7 +2817,7 @@ export class Function extends Component implements Link.Linkable {
                   principal: "*",
                   functionUrlAuthType: "NONE",
                 },
-                { parent },
+                { parent, dependsOn: [fnUrl] },
               );
               new lambda.Permission(
                 `${name}PublicInvokeFunction`,
@@ -2821,7 +2827,7 @@ export class Function extends Component implements Link.Linkable {
                   principal: "*",
                   invokedViaFunctionUrl: true,
                 },
-                { parent },
+                { parent, dependsOn: [fnUrl] },
               );
             }
           },
@@ -2890,8 +2896,12 @@ export class Function extends Component implements Link.Linkable {
           },
           { parent },
         );
-        return url.route.routerUrl;
+        return { endpoint: url.route.routerUrl, resource: fnUrl };
       });
+      return {
+        endpoint: result.apply((r) => r.endpoint),
+        resource: result.apply((r) => r.resource),
+      };
     }
 
     function createProvisioned() {
@@ -2960,6 +2970,10 @@ export class Function extends Component implements Link.Linkable {
        * The Function Event Invoke Config resource if retries are configured.
        */
       eventInvokeConfig: this.eventInvokeConfig,
+      /**
+       * The Lambda Function URL resource if `url` is enabled.
+       */
+      url: this.urlResource,
     };
   }
 

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -1074,6 +1074,7 @@ async function handler(event) {
         // Server functions
         servers.forEach(({ region, server }) => {
           const provider = useProvider(region);
+          const urlDependsOn = server.nodes.url.apply((u) => (u ? [u] : []));
 
           if (protection.mode === "none") {
             new lambda.Permission(
@@ -1084,7 +1085,7 @@ async function handler(event) {
                 principal: "*",
                 functionUrlAuthType: "NONE",
               },
-              { provider, parent: self },
+              { provider, parent: self, dependsOn: urlDependsOn },
             );
           } else if (
             protection.mode === "oac" ||
@@ -1098,7 +1099,7 @@ async function handler(event) {
                 principal: "cloudfront.amazonaws.com",
                 sourceArn: distributionArn,
               },
-              { provider, parent: self },
+              { provider, parent: self, dependsOn: urlDependsOn },
             );
             new lambda.Permission(
               `${name}CloudFrontInvokeFunction${logicalName(region)}`,
@@ -1109,13 +1110,16 @@ async function handler(event) {
                 sourceArn: distributionArn,
                 invokedViaFunctionUrl: true,
               },
-              { provider, parent: self },
+              { provider, parent: self, dependsOn: urlDependsOn },
             );
           }
         });
 
         // Image optimizer
         if (imgOptimizer) {
+          const urlDependsOn = imgOptimizer.nodes.url.apply((u) =>
+            u ? [u] : [],
+          );
           if (protection.mode === "none") {
             new lambda.Permission(
               `${name}ImageOptimizerPublicFunctionUrlAccess`,
@@ -1125,7 +1129,7 @@ async function handler(event) {
                 principal: "*",
                 functionUrlAuthType: "NONE",
               },
-              { parent: self },
+              { parent: self, dependsOn: urlDependsOn },
             );
           } else if (
             protection.mode === "oac" ||
@@ -1139,7 +1143,7 @@ async function handler(event) {
                 principal: "cloudfront.amazonaws.com",
                 sourceArn: distributionArn,
               },
-              { parent: self },
+              { parent: self, dependsOn: urlDependsOn },
             );
             new lambda.Permission(
               `${name}ImageOptimizerCloudFrontInvokeFunction`,
@@ -1150,7 +1154,7 @@ async function handler(event) {
                 sourceArn: distributionArn,
                 invokedViaFunctionUrl: true,
               },
-              { parent: self },
+              { parent: self, dependsOn: urlDependsOn },
             );
           }
         }


### PR DESCRIPTION
# Fix intermittent Lambda 409 when adding Function URL permissions

## Problem

Deploying an SSR site (`Nextjs`, `Astro`, `SolidStart`, …) intermittently fails with:

```
operation error Lambda: AddPermission, https response error StatusCode: 409,
ResourceConflictException: The function could not be updated due to a concurrent
update operation.
```

It's non-deterministic and hits fresh/ephemeral stacks (e.g. per-PR preview
environments) far more often than re-deploys. Retrying the deploy succeeds.

## Cause

AWS Lambda serialises mutating control-plane operations per function: after any
update the function is briefly `LastUpdateStatus: InProgress`, and a second
mutating call in that window is rejected with a 409.

During a deploy two resources mutate the same function and, with no ordering
between them, Pulumi runs them concurrently:

- `aws.lambda.FunctionUrl` — created in `Function.createUrl()`
  (`CreateFunctionUrlConfig`), and
- `aws.lambda.Permission` with `action: "lambda:InvokeFunctionUrl"`.

For the OAC path the permission is created in `SsrSite` and depends only on the
function — not on the function URL. It can't depend on the URL because the
`FunctionUrl` resource isn't exposed on `Function.nodes` (only `role`,
`function`, `logGroup`, `eventInvokeConfig`). So `AddPermission` races
`CreateFunctionUrlConfig` and lands mid-update. Fresh stacks hit it more often
because the function and its URL are created together in a single run.

## Fix

Serialise the permission after the function URL:

- expose the `FunctionUrl` resource on `Function.nodes.url`, and
- add `dependsOn` on it to every `lambda.Permission` that grants URL access —
  both the ones created inside `Function.createUrl()` (public + router modes)
  and the OAC/CloudFront ones created in `SsrSite` (server functions and the
  image optimizer).

`dependsOn` only changes the Pulumi dependency graph, so existing permission
resources are updated in place — no replacement, no downtime.

## Testing

- `tsc --noEmit` passes.
- `platform` test suite: all component tests pass (the only failures are a
  pre-existing Node-version incompatibility in unrelated suites — `alb`,
  `bucket`, `service-alb` — that error on `@types/node` resolution /
  `ERR_TRACE_EVENTS_UNAVAILABLE`, unaffected by this change).
- Recommended before merge: a deploy of an SSR site in `oac` /
  `oac-with-edge-signing` and `none` protection modes (and a multi-region
  deploy) to confirm the 409 no longer occurs and that no permission resources
  are replaced on an in-place update.

## Notes / possible follow-ups

The same class of concurrent-mutation race can in principle affect other
per-function operations that run alongside URL/permission creation (e.g.
provisioned-concurrency config, or an environment update). Those are out of
scope here; happy to look at them separately if maintainers think it's worth it.
