### PR TITLE
Support existing Cloudflare workers for queue and cron

### DIFF
--- a/platform/src/components/cloudflare/cron.ts
+++ b/platform/src/components/cloudflare/cron.ts
@@ -2,7 +2,7 @@ import { all, ComponentResourceOptions, Output } from "@pulumi/pulumi";
 import * as cf from "@pulumi/cloudflare";
 import * as cloudflare from "@pulumi/cloudflare";
 import { Component, Transform, transform } from "../component";
-import { WorkerArgs } from "./worker";
+import { Worker, WorkerArgs } from "./worker";
 import { DEFAULT_ACCOUNT_ID } from "./account-id.js";
 import { Input } from "../input.js";
 import { WorkerBuilder, workerBuilder } from "./helpers/worker-builder";
@@ -10,31 +10,12 @@ import { VisibleError } from "../error";
 
 export interface CronArgs {
   /**
-   * The worker that'll be executed when the cron job runs.
+   * The worker that's executed when the cron job runs.
    * @deprecated Use `worker` instead.
-   *
-   * @example
-   *
-   * ```ts
-   * {
-   *   job: "src/cron.ts"
-   * }
-   * ```
-   *
-   * You can pass in the full worker props.
-   *
-   * ```ts
-   * {
-   *   job: {
-   *     handler: "src/cron.ts",
-   *     link: [bucket]
-   *   }
-   * }
-   * ```
    */
-  job?: Input<string | WorkerArgs>;
+  job?: Input<string | WorkerArgs> | Worker;
   /**
-   * The worker that'll be executed when the cron job runs.
+   * The worker that's executed when the cron job runs.
    *
    * @example
    *
@@ -44,7 +25,7 @@ export interface CronArgs {
    * }
    * ```
    *
-   * You can pass in the full worker props.
+   * Pass full worker props.
    *
    * ```ts
    * {
@@ -54,8 +35,16 @@ export interface CronArgs {
    *   }
    * }
    * ```
+   *
+   * Or pass an existing worker.
+   *
+   * ```ts
+   * {
+   *   worker
+   * }
+   * ```
    */
-  worker?: Input<string | WorkerArgs>;
+  worker?: Input<string | WorkerArgs> | Worker;
   /**
    * The schedule for the cron job.
    *
@@ -115,7 +104,7 @@ export interface CronArgs {
  * };
  * ```
  *
- * Pass in a `schedules` and a `worker` that'll be executed.
+ * Pass `schedules` and a `worker`.
  *
  * ```ts title="sst.config.ts"
  * new sst.cloudflare.Cron("MyCronJob", {
@@ -124,15 +113,28 @@ export interface CronArgs {
  * });
  * ```
  *
- * #### Customize the worker
+ * #### Pass full worker props
  *
- * ```js title="sst.config.ts"
+ * ```ts title="sst.config.ts"
  * new sst.cloudflare.Cron("MyCronJob", {
  *   schedules: ["* * * * *"],
  *   worker: {
  *     handler: "cron.ts",
  *     link: [bucket]
  *   }
+ * });
+ * ```
+ *
+ * #### Use an existing worker
+ *
+ * ```ts title="sst.config.ts"
+ * const worker = new sst.cloudflare.Worker("MyWorker", {
+ *   handler: "worker.ts"
+ * });
+ *
+ * new sst.cloudflare.Cron("MyCronJob", {
+ *   schedules: ["* * * * *"],
+ *   worker
  * });
  * ```
  */
@@ -164,7 +166,19 @@ export class Cron extends Component {
         throw new VisibleError(
           `You must provide a "worker" for the "${name}" Cron component.`,
         );
-      return workerBuilder(`${name}Handler`, workerArgs, undefined, undefined, args.accountId);
+      if (workerArgs instanceof Worker)
+        return all([workerArgs.nodes.worker]).apply(([script]) => ({
+          getWorker: () => workerArgs,
+          script,
+        }));
+
+      return workerBuilder(
+        `${name}Handler`,
+        workerArgs as Input<string | WorkerArgs>,
+        undefined,
+        undefined,
+        args.accountId,
+      );
     }
 
     function createTrigger() {

--- a/platform/src/components/cloudflare/queue-worker-subscriber.ts
+++ b/platform/src/components/cloudflare/queue-worker-subscriber.ts
@@ -7,8 +7,9 @@ import {
   toMilliseconds,
 } from "../duration";
 import { WorkerBuilder, workerBuilder } from "./helpers/worker-builder";
-import { WorkerArgs } from "./worker";
+import { Worker, WorkerArgs } from "./worker";
 import { DEFAULT_ACCOUNT_ID } from "./account-id";
+import { VisibleError } from "../error";
 
 export interface QueueWorkerSubscriberArgs {
   /**
@@ -21,9 +22,10 @@ export interface QueueWorkerSubscriberArgs {
     id: Input<string>;
   }>;
   /**
-   * The subscriber worker.
+   * The subscriber worker. Accepts a handler path, full worker props, or an
+   * existing Cloudflare Worker.
    */
-  subscriber: Input<string | WorkerArgs>;
+  subscriber: Input<string | WorkerArgs> | Worker;
   /**
    * The Cloudflare account ID to use for this subscriber and its consumer.
    * Overrides the default account ID set via `CLOUDFLARE_DEFAULT_ACCOUNT_ID`.
@@ -133,9 +135,21 @@ export class QueueWorkerSubscriber extends Component {
     this.consumer = consumer;
 
     function createWorker() {
+      if (args.subscriber instanceof Worker) {
+        if (args.transform?.worker)
+          throw new VisibleError(
+            `Cannot transform the "${name}" Worker because it is already created.`,
+          );
+
+        return output({
+          getWorker: () => args.subscriber as Worker,
+          script: args.subscriber.nodes.worker,
+        });
+      }
+
       return workerBuilder(
         `${name}Function`,
-        args.subscriber,
+        args.subscriber as Input<string | WorkerArgs>,
         args.transform?.worker,
         { parent: self },
         accountId,

--- a/platform/src/components/cloudflare/queue.ts
+++ b/platform/src/components/cloudflare/queue.ts
@@ -4,7 +4,7 @@ import { Component, Transform, transform } from "../component";
 import { Link } from "../link";
 import { binding } from "./binding";
 import { DEFAULT_ACCOUNT_ID } from "./account-id";
-import { WorkerArgs } from "./worker";
+import { Worker, WorkerArgs } from "./worker";
 import { VisibleError } from "../error";
 import { QueueWorkerSubscriber } from "./queue-worker-subscriber";
 import { DurationMinutes, DurationSeconds } from "../duration";
@@ -168,6 +168,17 @@ export interface QueueSubscribeArgs {
  *   link: [bucket],
  * });
  * ```
+ *
+ * #### Subscribe with an existing worker
+ *
+ * ```ts title="sst.config.ts"
+ * const worker = new sst.cloudflare.Worker("MyWorker", {
+ *   handler: "worker.ts",
+ *   link: [queue],
+ * });
+ *
+ * queue.subscribe(worker);
+ * ```
  */
 export class Queue extends Component implements Link.Linkable {
   private queue: cloudflare.Queue;
@@ -204,7 +215,7 @@ export class Queue extends Component implements Link.Linkable {
   }
 
   /**
-   * Subscribe to the queue with a worker.
+   * Subscribe with a worker.
    *
    * @param subscriber The worker that'll process messages from the queue.
    * @param args Configure the subscription.
@@ -218,7 +229,7 @@ export class Queue extends Component implements Link.Linkable {
    * queue.subscribe("consumer.ts");
    * ```
    *
-   * Pass in full worker props.
+   * Pass full worker props.
    *
    * ```ts title="sst.config.ts"
    * const bucket = new sst.cloudflare.Bucket("MyBucket");
@@ -227,6 +238,17 @@ export class Queue extends Component implements Link.Linkable {
    *   handler: "consumer.ts",
    *   link: [bucket],
    * });
+   * ```
+   *
+   * Pass an existing worker.
+   *
+   * ```ts title="sst.config.ts"
+   * const worker = new sst.cloudflare.Worker("MyWorker", {
+   *   handler: "worker.ts",
+   *   link: [queue],
+   * });
+   *
+   * queue.subscribe(worker);
    * ```
    *
    * Configure batch settings.
@@ -241,7 +263,7 @@ export class Queue extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: Input<string | WorkerArgs>,
+    subscriber: Input<string | WorkerArgs> | Worker,
     args?: QueueSubscribeArgs,
     opts?: ComponentResourceOptions,
   ) {

--- a/platform/test/components/cloudflare-existing-worker.test.ts
+++ b/platform/test/components/cloudflare-existing-worker.test.ts
@@ -1,0 +1,102 @@
+import * as pulumi from "@pulumi/pulumi";
+import type * as cloudflare from "@pulumi/cloudflare";
+import { describe, expect, it } from "vitest";
+import type { Worker } from "../../src/components/cloudflare/worker";
+
+// @ts-ignore
+global.$app = {
+  name: "app",
+  stage: "test",
+  providers: {},
+};
+
+pulumi.runtime.setMocks(
+  {
+    newResource: function (args: pulumi.runtime.MockResourceArgs): {
+      id: string;
+      state: any;
+    } {
+      return {
+        id: args.name + "_id",
+        state: args.inputs,
+      };
+    },
+    call: function (args: pulumi.runtime.MockCallArgs) {
+      return args.inputs;
+    },
+  },
+  "project",
+  "stack",
+  false,
+);
+
+async function resolveOutput<T>(value: pulumi.Output<T>) {
+  return await new Promise<T>((resolve) => {
+    value.apply((resolved) => {
+      resolve(resolved);
+      return resolved;
+    });
+  });
+}
+
+function createMockWorker() {
+  const script = {
+    scriptName: pulumi.output("existing-worker"),
+  } as cloudflare.WorkerScript;
+  return import("../../src/components/cloudflare/worker").then(({ Worker }) => {
+    const worker = Object.create(Worker.prototype) as Worker;
+    Object.defineProperty(worker, "nodes", { value: { worker: script } });
+    return worker;
+  });
+}
+
+describe("Cloudflare existing Worker targets", () => {
+  it("attaches a queue consumer to an existing Worker", async () => {
+    const { QueueWorkerSubscriber } = await import(
+      "../../src/components/cloudflare/queue-worker-subscriber"
+    );
+    const worker = await createMockWorker();
+
+    const subscriber = new QueueWorkerSubscriber("Subscriber", {
+      queue: { id: "queue-id" },
+      subscriber: worker,
+    });
+
+    const scriptName = await resolveOutput(subscriber.nodes.consumer.scriptName);
+
+    expect(scriptName).toBe("existing-worker");
+  });
+
+  it("rejects worker transforms when subscribing an existing Worker", async () => {
+    const { QueueWorkerSubscriber } = await import(
+      "../../src/components/cloudflare/queue-worker-subscriber"
+    );
+    const worker = await createMockWorker();
+
+    expect(
+      () =>
+        new QueueWorkerSubscriber("SubscriberWithTransform", {
+          queue: { id: "queue-id" },
+          subscriber: worker,
+          transform: {
+            worker: () => undefined,
+          },
+        }),
+    ).toThrow(/already created/);
+  });
+
+  it("attaches a cron trigger to an existing Worker", async () => {
+    const { Cron } = await import("../../src/components/cloudflare/cron");
+    const worker = await createMockWorker();
+
+    const cron = new Cron("Cron", {
+      worker,
+      schedules: ["*/5 * * * *"],
+    });
+
+    const trigger = await resolveOutput(cron.nodes.trigger);
+    const scriptName = await resolveOutput(trigger.scriptName);
+
+    expect(scriptName).toBe("existing-worker");
+  });
+});

--- a/platform/test/components/cloudflare-worker-api-types.ts
+++ b/platform/test/components/cloudflare-worker-api-types.ts
@@ -1,0 +1,20 @@
+import { Cron } from "../../src/components/cloudflare/cron";
+import { Queue } from "../../src/components/cloudflare/queue";
+import { Worker } from "../../src/components/cloudflare/worker";
+
+// This file is a compile-time fixture covered by `bun run typecheck:platform`.
+declare const queue: Queue;
+declare const worker: Worker;
+declare const bucket: unknown;
+
+queue.subscribe(worker);
+queue.subscribe("consumer.ts");
+queue.subscribe({ handler: "consumer.ts", link: [bucket] });
+
+new Cron("CronWorker", { worker, schedules: ["*/5 * * * *"] });
+new Cron("CronJobWorker", { job: worker, schedules: ["*/5 * * * *"] });
+new Cron("CronString", { worker: "cron.ts", schedules: ["* * * * *"] });
+new Cron("CronArgs", {
+  worker: { handler: "cron.ts", link: [bucket] },
+  schedules: ["* * * * *"],
+});


### PR DESCRIPTION
## Summary

Allow Cloudflare Queue consumers and Cron triggers to attach to an existing `sst.cloudflare.Worker`.

```ts
const queue = new sst.cloudflare.Queue("Queue");

const worker = new sst.cloudflare.Worker("ServerWorker", {
  handler: "worker.ts",
  link: [queue],
});

queue.subscribe(worker);

new sst.cloudflare.Cron("Cron", {
  worker,
  schedules: ["*/5 * * * *"],
});
```

Existing behavior is unchanged:

- `queue.subscribe("consumer.ts")` still creates a consumer Worker.
- `queue.subscribe({ handler: "consumer.ts" })` still creates a consumer Worker.
- `new sst.cloudflare.Cron(..., { worker: "cron.ts" })` still creates a Worker.
- Deprecated `job` remains supported as before.

## Why

Cloudflare Workers can handle `fetch`, `queue`, and `scheduled` events from the same script. Cloudflare Queue producer bindings and consumer attachments are separate: producers bind a queue to send messages, while a consumer points at a Worker `scriptName`. Cron triggers also point at a Worker script.

SST already supports the default separated-worker flow by accepting a handler or `WorkerArgs` and creating a Worker for `Queue.subscribe()` and `Cron`. That remains the default.

However, SST previously had no way to attach a Queue consumer or Cron trigger to a Worker created earlier in the same app. Users wanting one Worker to serve HTTP traffic, publish messages, process queue batches, and handle schedules had to create raw `cloudflare.QueueConsumer` and `cloudflare.WorkersCronTrigger` resources themselves.

## Design

This is intentionally scoped to direct `sst.cloudflare.Worker` instances.

- `QueueWorkerSubscriber` uses the existing Worker's `nodes.worker` for the consumer `scriptName`.
- `Cron` uses the existing Worker's `nodes.worker` for the trigger `scriptName`.
- Handler strings and `WorkerArgs` still use the existing `workerBuilder` path.
- `workerBuilder` remains responsible only for creating Workers from source definitions.
- `transform.worker` is rejected for an existing Queue subscriber Worker because no new Worker exists to transform.

This PR does not add raw `scriptName` support, `Worker.get()`, public `QueueConsumer`/`CronTrigger` components, or new deprecations.

## Testing

Passed:

- `bun run --cwd platform test test/components/cloudflare-existing-worker.test.ts`
- `bun run typecheck:platform`
- `bun run build:platform`

`bun run --cwd platform test` still has unrelated existing/environment failures resolving `@types/node` in the ALB/Bucket/Service tests, plus `ERR_TRACE_EVENTS_UNAVAILABLE` unhandled errors from Router WAF tests. The new Cloudflare existing Worker test passes in that full run.
