### PR TITLE
Fix sst remove failing on in-use ACM certificate by ordering load Balancer deletion first.

### DIFF
--- a/platform/src/components/aws/alb.ts
+++ b/platform/src/components/aws/alb.ts
@@ -269,7 +269,7 @@ export class Alb extends Component implements Link.Linkable {
     const { vpcId, subnets } = normalizeVpc();
     const domain = normalizeDomain();
     const securityGroup = createSecurityGroup();
-    const certificateArn = createSsl();
+    const { cert, arn: certificateArn } = createSsl();
     const loadBalancer = createLoadBalancer();
     createListeners();
     createDnsRecords();
@@ -347,11 +347,14 @@ export class Alb extends Component implements Link.Linkable {
       );
     }
 
-    function createSsl(): Output<string | undefined> {
-      if (!domain) return output(undefined);
-      if (domain.cert) return output(domain.cert);
+    function createSsl(): {
+      cert?: DnsValidatedCertificate;
+      arn: Output<string | undefined>;
+    } {
+      if (!domain) return { arn: output(undefined) };
+      if (domain.cert) return { arn: output(domain.cert) };
 
-      return new DnsValidatedCertificate(
+      const cert = new DnsValidatedCertificate(
         `${name}Ssl`,
         {
           domainName: domain.name,
@@ -359,7 +362,8 @@ export class Alb extends Component implements Link.Linkable {
           dns: domain.dns!,
         },
         { parent: self },
-      ).arn;
+      );
+      return { cert, arn: cert.arn };
     }
 
     function createLoadBalancer() {
@@ -375,7 +379,7 @@ export class Alb extends Component implements Link.Linkable {
             enableCrossZoneLoadBalancing: true,
 
           },
-          { parent: self },
+          { parent: self, dependsOn: cert ? [cert] : [] },
         ),
       );
     }

--- a/platform/src/components/aws/service-v1.ts
+++ b/platform/src/components/aws/service-v1.ts
@@ -117,7 +117,7 @@ export class Service extends Component implements Link.Linkable {
     const image = createImage();
     const logGroup = createLogGroup();
     const taskDefinition = createTaskDefinition();
-    const certificateArn = createSsl();
+    const { cert, arn: certificateArn } = createSsl();
     const { loadBalancer, targets } = createLoadBalancer();
     const service = createService();
     createAutoScaling();
@@ -414,7 +414,10 @@ export class Service extends Component implements Link.Linkable {
             securityGroups: [securityGroup.id],
             enableCrossZoneLoadBalancing: true,
           },
-          { parent: self },
+          {
+            parent: self,
+            dependsOn: cert.apply((cert) => (cert ? [cert] : [])),
+          },
         ),
       );
 
@@ -487,11 +490,15 @@ export class Service extends Component implements Link.Linkable {
     }
 
     function createSsl() {
-      if (!pub) return output(undefined);
+      if (!pub) {
+        return {
+          cert: output<DnsValidatedCertificate | undefined>(undefined),
+          arn: output<string | undefined>(undefined),
+        };
+      }
 
-      return pub.domain.apply((domain) => {
-        if (!domain) return output(undefined);
-        if (domain.cert) return output(domain.cert);
+      const cert = pub.domain.apply((domain) => {
+        if (!domain || domain.cert) return undefined;
 
         return new DnsValidatedCertificate(
           `${name}Ssl`,
@@ -500,8 +507,16 @@ export class Service extends Component implements Link.Linkable {
             dns: domain.dns!,
           },
           { parent: self },
-        ).arn;
+        );
       });
+      return {
+        cert,
+        arn: all([pub.domain, cert]).apply(([domain, cert]) => {
+          if (!domain) return undefined;
+          if (domain.cert) return domain.cert;
+          return cert!.arn;
+        }),
+      };
     }
 
     function createLogGroup() {

--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -1822,7 +1822,7 @@ export class Service extends Component implements Link.Linkable {
     let effectiveLbArn: Output<string> | undefined;
     let effectiveDomain: Output<string | undefined>;
     let effectiveDnsName: Output<string> | undefined;
-    const certificateArn = albAttachment ? output(undefined) : createSsl();
+    const { cert, arn: certificateArn } = createSsl();
     if (albAttachment) {
       all([albAttachment.instance._vpc, vpc.id]).apply(
         ([albVpcId, clusterVpcId]) => {
@@ -2155,7 +2155,10 @@ export class Service extends Component implements Link.Linkable {
             securityGroups: [securityGroup.id],
             enableCrossZoneLoadBalancing: true,
           },
-          { parent: self },
+          {
+            parent: self,
+            dependsOn: cert.apply((cert) => (cert ? [cert] : [])),
+          },
         ),
       );
     }
@@ -2344,11 +2347,15 @@ export class Service extends Component implements Link.Linkable {
     }
 
     function createSsl() {
-      if (!lbArgs) return output(undefined);
+      if (!lbArgs) {
+        return {
+          cert: output<DnsValidatedCertificate | undefined>(undefined),
+          arn: output<string | undefined>(undefined),
+        };
+      }
 
-      return lbArgs.domain.apply((domain) => {
-        if (!domain) return output(undefined);
-        if (domain.cert) return output(domain.cert);
+      const cert = lbArgs.domain.apply((domain) => {
+        if (!domain || domain.cert) return undefined;
 
         return new DnsValidatedCertificate(
           `${name}Ssl`,
@@ -2358,8 +2365,16 @@ export class Service extends Component implements Link.Linkable {
             dns: domain.dns!,
           },
           { parent: self },
-        ).arn;
+        );
       });
+      return {
+        cert,
+        arn: all([lbArgs.domain, cert]).apply(([domain, cert]) => {
+          if (!domain) return undefined;
+          if (domain.cert) return domain.cert;
+          return cert!.arn;
+        }),
+      };
     }
 
     function createCloudmapService() {


### PR DESCRIPTION
closes #6934

## Problem Summary
The load balancer's Elastic Network Interface (ENI) release sometimes delays, and when the ACM certificate delete fires while the ENIs still reference the certificate, you get `ResourceInUseException` and the removal aborts before it ever reaches the load balancer. 

This issue is not deterministic by nature, and most of the time we are at the mercy of AWS-side timings so it not as obvious.

## Fix
The way this PR fixes the problem is by explicitly making the ALB depend on the ACM Certificate. Here is the base config I used for testing:
```typescript
/// <reference path="./.sst/platform/config.d.ts" />

export default $config({
  app(input) {
    return { name: "test-lb-cert", home: "aws", removal: "remove" };
  },
  async run() {
    const vpc = new sst.aws.Vpc("Vpc");
    new sst.aws.Alb("Alb", {
      vpc,
      domain: "lb.sst-test.malekd5.com", // AWS hosted zone
      listeners: [{ port: 443, protocol: "https" }],
    });
  },
});
```

Here is the before and after `sst state export` after running deploy:

**Before**
<img width="1255" height="519" alt="Before Fix Image" src="https://github.com/user-attachments/assets/b69a76cb-ec3d-4f37-878e-73785da8bd3a" />

As you can notice, no ACM URNs in dependencies, which means your run's success is timing luck.

**After**
<img width="1426" height="307" alt="image" src="https://github.com/user-attachments/assets/ee311495-efb8-42ef-b57c-ca081e871c98" />

As you can notice, ACM URNS in dependency array ordered, which means LB delete must fully complete before ACM delete starts every run. And we are no longer under the mercy of AWS-side timing.