### PR TITLE
fix commonjs require of unenv aliases in cloudflare worker bundling

### DIFF
--- a/pkg/runtime/worker/worker.go
+++ b/pkg/runtime/worker/worker.go
@@ -8,6 +8,8 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -103,6 +105,7 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 		build.ESBuild.External,
 	)
 	alias := stripAliasedExternals(unenv.Alias, external)
+	platformDir := path.ResolvePlatformDir(input.CfgPath)
 	options := esbuild.BuildOptions{
 		Platform: esbuild.PlatformNode,
 		Stdin: &esbuild.StdinOptions{
@@ -116,9 +119,10 @@ func (w *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 			Loader:     esbuild.LoaderTS,
 		},
 		NodePaths: append([]string{
-			filepath.Join(path.ResolvePlatformDir(input.CfgPath), "node_modules"),
+			filepath.Join(platformDir, "node_modules"),
 		}, build.ESBuild.NodePaths...),
 		Alias:             alias,
+		Plugins:           []esbuild.Plugin{unenvAliasInteropPlugin(alias, platformDir)},
 		Inject:            unenv.Polyfill,
 		External:          external,
 		Conditions:        build.ESBuild.ResolveConditions([]string{"workerd", "worker", "browser"}),
@@ -232,6 +236,40 @@ func stripAliasedExternals(alias map[string]string, external []string) map[strin
 		delete(result, item)
 	}
 	return result
+}
+
+func unenvAliasInteropPlugin(alias map[string]string, resolveDir string) esbuild.Plugin {
+	aliases := make([]string, 0, len(alias))
+	for name := range alias {
+		aliases = append(aliases, regexp.QuoteMeta(name))
+	}
+	slices.Sort(aliases)
+
+	const namespace = "sst-required-unenv-alias"
+	return esbuild.Plugin{
+		Name: "sst-unenv-alias-interop",
+		Setup: func(build esbuild.PluginBuild) {
+			build.OnResolve(esbuild.OnResolveOptions{Filter: "^(" + strings.Join(aliases, "|") + ")$"}, func(args esbuild.OnResolveArgs) (esbuild.OnResolveResult, error) {
+				target := alias[args.Path]
+				if args.Kind != esbuild.ResolveJSRequireCall || (!strings.HasPrefix(target, "unenv/npm/") && !strings.HasPrefix(target, "unenv/mock/")) {
+					return esbuild.OnResolveResult{}, nil
+				}
+				return esbuild.OnResolveResult{Path: args.Path, Namespace: namespace}, nil
+			})
+			build.OnLoad(esbuild.OnLoadOptions{Filter: ".*", Namespace: namespace}, func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
+				contents := fmt.Sprintf(`
+import * as esm from %q;
+module.exports = Object.entries(esm)
+  .filter(([k,]) => k !== "default")
+  .reduce((cjs, [k, value]) =>
+    Object.defineProperty(cjs, k, { value, enumerable: true }),
+    "default" in esm ? esm.default : {}
+  );
+`, alias[args.Path])
+				return esbuild.OnLoadResult{Contents: &contents, Loader: esbuild.LoaderJS, ResolveDir: resolveDir}, nil
+			})
+		},
+	}
 }
 
 func (w *Runtime) getUnenv(ctx context.Context, cfgPath string, compatibility compatibility) (*unenv, error) {

--- a/pkg/runtime/worker/worker_test.go
+++ b/pkg/runtime/worker/worker_test.go
@@ -1,7 +1,13 @@
 package worker
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
 )
 
 func TestStripAliasedExternals(t *testing.T) {
@@ -24,5 +30,51 @@ func TestStripAliasedExternals(t *testing.T) {
 	}
 	if original["http"] != "unenv/node/http" {
 		t.Fatalf("original alias map was mutated")
+	}
+}
+
+func TestUnenvAliasInteropPlugin(t *testing.T) {
+	dir := t.TempDir()
+	shimDir := filepath.Join(dir, "node_modules", "unenv", "npm")
+	if err := os.MkdirAll(shimDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shimDir, "inherits.js"), []byte(`
+export default function inherits() {}
+export const named = "named export"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "unenv", "package.json"), []byte(`{"type":"module","exports":{"./npm/inherits":"./npm/inherits.js"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	alias := map[string]string{"inherits": "unenv/npm/inherits"}
+	result := esbuild.Build(esbuild.BuildOptions{
+		Stdin: &esbuild.StdinOptions{
+			Contents: `
+import inheritsImport from "inherits"
+const inherits = require("inherits")
+if (typeof inheritsImport !== "function") throw new Error("ESM alias behavior changed")
+if (typeof inherits !== "function") throw new Error("default export was not a function")
+if (inherits.named !== "named export") throw new Error("named export was not copied")
+`,
+			ResolveDir: dir,
+		},
+		Alias:     alias,
+		Bundle:    true,
+		Format:    esbuild.FormatCommonJS,
+		NodePaths: []string{filepath.Join(dir, "node_modules")},
+		Plugins:   []esbuild.Plugin{unenvAliasInteropPlugin(alias, dir)},
+		Write:     false,
+	})
+	if len(result.Errors) > 0 {
+		t.Fatalf("bundle failed: %v", result.Errors)
+	}
+
+	cmd := exec.Command("node", "-")
+	cmd.Stdin = strings.NewReader(string(result.OutputFiles[0].Contents))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bundle execution failed: %v\n%s", err, output)
 	}
 }


### PR DESCRIPTION
the cloudflare worker bundler passes unenv aliases straight to esbuild. any commonjs dep that requires an aliased shim (`debug`, `inherits`, `node-fetch`, ...) gets the esm namespace object instead of the default export, which breaks at runtime and fails the upload with error 10021. one example: `hash.js` does `require("inherits")`, aliased to the esm-only `unenv/npm/inherits`, so `utils.inherits` is an object instead of a function.

this adds an esbuild plugin that routes require() resolutions of `unenv/npm/*` and `unenv/mock/*` aliases through a small cjs facade: default export when present, named exports copied over. esm imports keep the existing alias behavior. same approach wrangler ships since cloudflare/workers-sdk#6932.

verified with `go test ./pkg/runtime/worker`, the regression test bundles and executes default export, named export, and esm cases.