### PR TITLE
Fix unbounded memory growth in sst dev from retained esbuild contexts

### DIFF
--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -16,6 +16,13 @@ var SST_BUN_PATH = os.Getenv("SST_BUN_PATH")
 var SST_BUILD_CONCURRENCY = os.Getenv("SST_BUILD_CONCURRENCY")
 var SST_BUILD_CONCURRENCY_FUNCTION = os.Getenv("SST_BUILD_CONCURRENCY_FUNCTION")
 var SST_BUILD_CONCURRENCY_SITE = os.Getenv("SST_BUILD_CONCURRENCY_SITE")
+
+// SST_BUILD_CONTEXT_CACHE is the max number of esbuild build contexts kept
+// alive in dev mode for fast incremental rebuilds. 0 disables the cache.
+var SST_BUILD_CONTEXT_CACHE = os.Getenv("SST_BUILD_CONTEXT_CACHE")
+
+// SST_PPROF exposes Go pprof handlers on the dev server under /debug/pprof/
+var SST_PPROF = isTrue("SST_PPROF")
 var SST_SKIP_DEPENDENCY_CHECK = isTrue("SST_SKIP_DEPENDENCY_CHECK")
 var SST_TELEMETRY_DISABLED = isTrue("SST_TELEMETRY_DISABLED") || isTrue("DO_NOT_TRACK")
 var SST_BUN_VERSION = os.Getenv("SST_BUN_VERSION")

--- a/pkg/runtime/node/build.go
+++ b/pkg/runtime/node/build.go
@@ -198,13 +198,13 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	}
 
 	if input.Dev {
-		match, ok := r.contexts.Load(input.FunctionID)
-		if !ok {
-			match, _ = esbuild.Context(options)
-			r.contexts.Store(input.FunctionID, match)
+		buildContext, ctxErr := r.acquireContext(input.FunctionID, options)
+		if ctxErr != nil {
+			return nil, ctxErr
 		}
-		result = match.(esbuild.BuildContext).Rebuild()
-		r.results.Store(input.FunctionID, result)
+		result = buildContext.Rebuild()
+		r.releaseContext(input.FunctionID)
+		r.storeInputs(input.FunctionID, result.Metafile)
 	}
 	log.Info("esbuild finished")
 

--- a/pkg/runtime/node/build_dev_test.go
+++ b/pkg/runtime/node/build_dev_test.go
@@ -1,0 +1,94 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sst/sst/v3/pkg/runtime"
+)
+
+func devBuildInput(t *testing.T, dir string, name string) *runtime.BuildInput {
+	t.Helper()
+	file := filepath.Join(dir, name+".ts")
+	err := os.WriteFile(file, []byte("export const handler = async () => \""+name+"\";\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &runtime.BuildInput{
+		CfgPath:    filepath.Join(dir, "sst.config.ts"),
+		Dev:        true,
+		FunctionID: name,
+		Handler:    name + ".handler",
+		Runtime:    "nodejs20.x",
+		Properties: json.RawMessage(`{}`),
+	}
+}
+
+func TestDevBuildContextsAreBounded(t *testing.T) {
+	dir := t.TempDir()
+	r := New("dev")
+	r.contextCap = 2
+
+	for i := 0; i < 5; i++ {
+		input := devBuildInput(t, dir, fmt.Sprintf("fn%d", i))
+		output, err := r.Build(context.Background(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output.Errors) > 0 {
+			t.Fatal(output.Errors)
+		}
+	}
+
+	r.contextsLock.Lock()
+	got := len(r.contexts)
+	r.contextsLock.Unlock()
+	if got > 2 {
+		t.Errorf("live esbuild contexts = %d, want <= 2", got)
+	}
+}
+
+func TestDevBuildShouldRebuildTracksInputs(t *testing.T) {
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := New("dev")
+	r.contextCap = 1
+
+	first := devBuildInput(t, dir, "first")
+	second := devBuildInput(t, dir, "second")
+	for _, input := range []*runtime.BuildInput{first, second} {
+		output, err := r.Build(context.Background(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output.Errors) > 0 {
+			t.Fatal(output.Errors)
+		}
+	}
+
+	// dependency tracking must survive context eviction
+	if !r.ShouldRebuild("first", filepath.Join(dir, "first.ts")) {
+		t.Error("expected ShouldRebuild to be true for first.ts after eviction")
+	}
+	if !r.ShouldRebuild("second", filepath.Join(dir, "second.ts")) {
+		t.Error("expected ShouldRebuild to be true for second.ts")
+	}
+	if r.ShouldRebuild("first", filepath.Join(dir, "second.ts")) {
+		t.Error("expected ShouldRebuild to be false for unrelated file")
+	}
+
+	// rebuilding an evicted function must still work
+	output, buildErr := r.Build(context.Background(), first)
+	if buildErr != nil {
+		t.Fatal(buildErr)
+	}
+	if len(output.Errors) > 0 {
+		t.Fatal(output.Errors)
+	}
+}

--- a/pkg/runtime/node/node.go
+++ b/pkg/runtime/node/node.go
@@ -56,11 +56,26 @@ var LoaderToString = []string{
 	"tsx",
 }
 
+// DefaultContextCap is the default number of esbuild build contexts kept
+// alive in dev mode. Each context caches the parsed dependency graph of one
+// function, which can retain hundreds of MB for large graphs, so keeping one
+// per function grows memory without bound as functions are built.
+const DefaultContextCap = 4
+
+type buildContextEntry struct {
+	context  esbuild.BuildContext
+	lastUsed int64
+	building int
+}
+
 type Runtime struct {
-	version     string
-	contexts    sync.Map
-	results     sync.Map
-	concurrency *semaphore.Weighted
+	version      string
+	concurrency  *semaphore.Weighted
+	contextCap   int
+	contextsLock sync.Mutex
+	contexts     map[string]*buildContextEntry
+	contextClock int64
+	inputs       map[string]map[string]bool
 }
 
 func New(version string) *Runtime {
@@ -71,12 +86,114 @@ func New(version string) *Runtime {
 		weight, _ = strconv.ParseInt(flag.SST_BUILD_CONCURRENCY, 10, 64)
 	}
 
+	contextCap := DefaultContextCap
+	if flag.SST_BUILD_CONTEXT_CACHE != "" {
+		if parsed, err := strconv.Atoi(flag.SST_BUILD_CONTEXT_CACHE); err == nil && parsed >= 0 {
+			contextCap = parsed
+		}
+	}
+
 	return &Runtime{
-		contexts:    sync.Map{},
-		results:     sync.Map{},
 		version:     version,
 		concurrency: semaphore.NewWeighted(weight),
+		contextCap:  contextCap,
+		contexts:    map[string]*buildContextEntry{},
+		inputs:      map[string]map[string]bool{},
 	}
+}
+
+// acquireContext returns the cached build context for a function, creating
+// one if needed. The entry is pinned until releaseContext is called so it
+// cannot be evicted mid-build.
+func (r *Runtime) acquireContext(functionID string, options esbuild.BuildOptions) (esbuild.BuildContext, error) {
+	r.contextsLock.Lock()
+	if entry, ok := r.contexts[functionID]; ok {
+		entry.building++
+		r.contextClock++
+		entry.lastUsed = r.contextClock
+		r.contextsLock.Unlock()
+		return entry.context, nil
+	}
+	r.contextsLock.Unlock()
+
+	// create outside the lock; plugin setup can spawn subprocesses
+	created, ctxErr := esbuild.Context(options)
+	if ctxErr != nil {
+		return nil, ctxErr
+	}
+
+	r.contextsLock.Lock()
+	if entry, ok := r.contexts[functionID]; ok {
+		// lost a race with a concurrent build of the same function
+		entry.building++
+		r.contextClock++
+		entry.lastUsed = r.contextClock
+		r.contextsLock.Unlock()
+		created.Dispose()
+		return entry.context, nil
+	}
+	r.contextClock++
+	r.contexts[functionID] = &buildContextEntry{
+		context:  created,
+		lastUsed: r.contextClock,
+		building: 1,
+	}
+	r.contextsLock.Unlock()
+	return created, nil
+}
+
+// releaseContext unpins a function's build context and evicts the least
+// recently used contexts beyond the configured cap.
+func (r *Runtime) releaseContext(functionID string) {
+	var evicted []esbuild.BuildContext
+	r.contextsLock.Lock()
+	if entry, ok := r.contexts[functionID]; ok {
+		entry.building--
+	}
+	for len(r.contexts) > r.contextCap {
+		oldestID := ""
+		var oldest *buildContextEntry
+		for id, entry := range r.contexts {
+			if entry.building > 0 {
+				continue
+			}
+			if oldest == nil || entry.lastUsed < oldest.lastUsed {
+				oldestID = id
+				oldest = entry
+			}
+		}
+		if oldest == nil {
+			break
+		}
+		delete(r.contexts, oldestID)
+		evicted = append(evicted, oldest.context)
+	}
+	r.contextsLock.Unlock()
+	for _, context := range evicted {
+		context.Dispose()
+	}
+}
+
+// storeInputs records the absolute paths of a build's inputs so ShouldRebuild
+// can match changed files without retaining the full build result.
+func (r *Runtime) storeInputs(functionID string, metafile string) {
+	var meta struct {
+		Inputs map[string]json.RawMessage `json:"inputs"`
+	}
+	if err := json.Unmarshal([]byte(metafile), &meta); err != nil {
+		return
+	}
+	paths := make(map[string]bool, len(meta.Inputs))
+	for key := range meta.Inputs {
+		absPath, err := filepath.Abs(key)
+		if err != nil {
+			continue
+		}
+		paths[absPath] = true
+	}
+	r.contextsLock.Lock()
+	r.inputs[functionID] = paths
+	r.contextsLock.Unlock()
 }
 
 type Worker struct {
@@ -282,25 +399,11 @@ func (r *Runtime) getFile(input *runtime.BuildInput) (string, bool) {
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
-	result, ok := r.results.Load(functionID)
+	r.contextsLock.Lock()
+	defer r.contextsLock.Unlock()
+	paths, ok := r.inputs[functionID]
 	if !ok {
 		return false
 	}
-
-	var meta = map[string]interface{}{}
-	err := json.Unmarshal([]byte(result.(esbuild.BuildResult).Metafile), &meta)
-	if err != nil {
-		return false
-	}
-	for key := range meta["inputs"].(map[string]interface{}) {
-		absPath, err := filepath.Abs(key)
-		if err != nil {
-			continue
-		}
-		if absPath == file {
-			return true
-		}
-	}
-
-	return false
+	return paths[file]
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,12 +8,14 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/http/pprof"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"net/url"
 	"os"
 	"path/filepath"
 
+	"github.com/sst/sst/v3/pkg/flag"
 	"github.com/sst/sst/v3/pkg/global"
 	"github.com/sst/sst/v3/pkg/project"
 	"github.com/sst/sst/v3/pkg/server/aws"
@@ -48,6 +50,13 @@ func New() (*Server, error) {
 		slog.Info("rpc request", "method", r.Method, "url", r.URL.String())
 		result.Rpc.ServeCodec(jsonrpc.NewServerCodec(&HttpConn{Reader: r.Body, Writer: w}))
 	})
+	if flag.SST_PPROF {
+		result.Mux.HandleFunc("/debug/pprof/", pprof.Index)
+		result.Mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		result.Mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		result.Mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		result.Mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
## Problem

`sst dev` keeps one esbuild incremental build context per function, forever. Each context holds the parsed module graph of that function's bundle. For a handler that pulls in `@aws-sdk` plus a shared core package, that's 220-550 MB of live heap, and nothing ever disposes it.

Worse, the retained unit is effectively the build, not the function: rebuilding the same handler after a code change grows memory again each time. On our monorepo (311 handlers), RSS hit 12.4 GiB after building 28 of them, and a developer doing a normal edit-test loop routinely reaches 100+ GiB over a working session. `GOMEMLIMIT` can't contain it because the bytes are reachable, so the GC has no authority to drop them. The only reclaim today is restarting `sst dev`.

Measured on 4.17.1, editing one already-built handler 8 times with the distinct-handler count held constant: +1972 MB, about 219 MB per rebuild, monotonic. Repeat invocations without edits cost nothing, so the leak is entirely in the build path.

`ShouldRebuild` added to this: it kept the full `BuildResult` per function (metafile JSON included) and re-parsed that JSON on every file-change event.

## Fix

Build contexts now live in an LRU cache capped at 4 entries by default. Evicted contexts get `Dispose()`d, which frees the module graph. A context is pinned while a build is running on it, so it can't be evicted mid-build; concurrent builds of the same function that race on context creation dispose the loser.

The cap is tunable with `SST_BUILD_CONTEXT_CACHE`. Setting it to 0 disables context caching entirely.

`ShouldRebuild` now works off a plain set of absolute input paths, extracted from the metafile once per build, instead of retaining and re-parsing the whole build result. This also means dependency tracking keeps working for functions whose context was evicted.

The trade-off: if you're actively editing more than 4 functions in rotation, the coldest one loses its incremental-build state and pays a full rebuild on the next change. That's the same cost as the function's first dev build, in exchange for a bounded memory ceiling.

Separately, `SST_PPROF=1` now mounts the standard `net/http/pprof` handlers on the dev server under `/debug/pprof/`. Pinning this leak down required sampling `/proc/<pid>/mem` by hand because no heap profile was reachable from a running `sst dev`; next time it should be one `go tool pprof` invocation.

## Testing

`go test ./pkg/runtime/node/` passes. Two new tests:

- `TestDevBuildContextsAreBounded`: builds 5 functions with the cap set to 2 and asserts no more than 2 live contexts remain.
- `TestDevBuildShouldRebuildTracksInputs`: with the cap set to 1, verifies `ShouldRebuild` still matches input files for an evicted function, rejects unrelated files, and that rebuilding an evicted function works.
