### PR TITLE
Fix [timeout] restart for credential-less dev processes

### DIFF
--- a/cmd/sst/mosaic.go
+++ b/cmd/sst/mosaic.go
@@ -71,7 +71,7 @@ func CmdMosaic(c *cli.Cli) error {
 		var cmd *exec.Cmd
 		var last *dev.EnvResponse
 		processExited := make(chan bool)
-		timeout := time.Minute * 50
+		timeout := time.Hour * 24
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
 
@@ -102,8 +102,15 @@ func CmdMosaic(c *cli.Cli) error {
 				if err != nil {
 					return err
 				}
-				if _, ok := nextEnv.Env["AWS_ACCESS_KEY_ID"]; ok {
+				if _, ok := nextEnv.Env["AWS_ACCESS_KEY_ID"]; ok && timeout != time.Minute*45 {
 					timeout = time.Minute * 45
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					timer.Reset(timeout)
 				}
 				if last == nil || diff(last.Env, nextEnv.Env) || last.Command != nextEnv.Command {
 					if cmd != nil && cmd.Process != nil {


### PR DESCRIPTION
Static sites get reloaded with a `[timeout]` every ~50 minutes in `sst dev`, even though they have no expiring credentials to refresh. 

Basically, restore the original `24h` default (from `edec0e64a`) and actually reset the timer to 45m when AWS credentials appear, so only credentialed processes get periodically restarted.

Related: https://github.com/anomalyco/sst/issues/4264