### PR TITLE
Improve oac-edge-signer performance

### DIFF
--- a/platform/functions/oac-edge-signer/index.ts
+++ b/platform/functions/oac-edge-signer/index.ts
@@ -1,15 +1,20 @@
 // Lambda@Edge function for automatic SHA256 header signing
-// This function adds the required x-amz-content-sha256 header for POST/PUT/PATCH requests
+// This function adds the required x-amz-content-sha256 header for POST/PUT/PATCH/QUERY requests
 // going to Lambda function URLs with Origin Access Control enabled.
 
-import { CloudFrontRequestHandler } from "aws-lambda";
-import crypto from "node:crypto";
+import type { CloudFrontRequestHandler } from "aws-lambda";
+import { createHash, hash } from "node:crypto";
+
+const EMPTY_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+const METHODS_WITH_BODY = ["POST", "PUT", "PATCH"];
 
 export const handler: CloudFrontRequestHandler = async (event) => {
   const request = event.Records[0].cf.request;
 
   // Only process requests that need SHA256 signing (methods with body)
-  if (!["POST", "PUT", "PATCH"].includes(request.method)) {
+  if (!METHODS_WITH_BODY.includes(request.method)) {
     return request;
   }
 
@@ -29,21 +34,17 @@ export const handler: CloudFrontRequestHandler = async (event) => {
   }
 
   try {
-    // Get the request body as raw bytes (never convert to UTF-8 string)
-    const bodyBuffer = request.body?.data
-      ? request.body.encoding === "base64"
-        ? Buffer.from(request.body.data, "base64")
-        : Buffer.from(request.body.data)
-      : Buffer.alloc(0);
+    const data = request.body?.data;
+    const digest = !data
+      ? EMPTY_SHA256
+      : request.body?.encoding === "base64"
+        ? createHash("sha256").update(data, "base64").digest("hex")
+        : hash("sha256", data, "hex");
 
-    // Compute SHA256 hash of the raw bytes
-    const hash = crypto.createHash("sha256").update(bodyBuffer).digest("hex");
-
-    // Add the x-amz-content-sha256 header in CloudFront format
     request.headers["x-amz-content-sha256"] = [
       {
         key: "x-amz-content-sha256",
-        value: hash,
+        value: digest,
       },
     ];
   } catch (error) {

--- a/platform/functions/oac-edge-signer/index.ts
+++ b/platform/functions/oac-edge-signer/index.ts
@@ -33,23 +33,19 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     };
   }
 
-  try {
-    const data = request.body?.data;
-    const digest = !data
-      ? EMPTY_SHA256
-      : request.body?.encoding === "base64"
-        ? createHash("sha256").update(data, "base64").digest("hex")
-        : hash("sha256", data, "hex");
+  const data = request.body?.data;
+  const digest = !data
+    ? EMPTY_SHA256
+    : request.body?.encoding === "base64"
+      ? createHash("sha256").update(data, "base64").digest("hex")
+      : hash("sha256", data, "hex");
 
-    request.headers["x-amz-content-sha256"] = [
-      {
-        key: "x-amz-content-sha256",
-        value: digest,
-      },
-    ];
-  } catch (error) {
-    console.error("Error computing SHA256 hash:", error);
-  }
+  request.headers["x-amz-content-sha256"] = [
+    {
+      key: "x-amz-content-sha256",
+      value: digest,
+    },
+  ];
 
   return request;
 };

--- a/platform/functions/oac-edge-signer/index.ts
+++ b/platform/functions/oac-edge-signer/index.ts
@@ -8,7 +8,7 @@ import { createHash, hash } from "node:crypto";
 const EMPTY_SHA256 =
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
-const METHODS_WITH_BODY = ["POST", "PUT", "PATCH"];
+const METHODS_WITH_BODY = ["POST", "PUT", "PATCH", "QUERY"];
 
 export const handler: CloudFrontRequestHandler = async (event) => {
   const request = event.Records[0].cf.request;

--- a/platform/functions/oac-edge-signer/index.ts
+++ b/platform/functions/oac-edge-signer/index.ts
@@ -34,12 +34,14 @@ export const handler: CloudFrontRequestHandler = async (event) => {
   }
 
   const data = request.body?.data;
+  // SHA256 hex digest of the body for x-amz-content-sha256 (required by Lambda URL OAC)
   const digest = !data
-    ? EMPTY_SHA256
+    ? EMPTY_SHA256 // empty body → precomputed SHA256 of zero bytes
     : request.body?.encoding === "base64"
-      ? createHash("sha256").update(data, "base64").digest("hex")
-      : hash("sha256", data, "hex");
+      ? createHash("sha256").update(data, "base64").digest("hex") // hash raw bytes from base64 without decoding to a string first
+      : hash("sha256", data, "hex"); // body already plain text; one-shot hex digest
 
+  // CloudFront header map: attach the digest so the origin request is OAC-signed
   request.headers["x-amz-content-sha256"] = [
     {
       key: "x-amz-content-sha256",

--- a/platform/scripts/build.mjs
+++ b/platform/scripts/build.mjs
@@ -11,12 +11,16 @@ await Promise.all(
       target: "esnext",
       format: "esm",
       entryPoints: [`./functions/${file}/index.ts`],
-      banner: {
-        js: [
-          `import { createRequire as topLevelCreateRequire } from 'module';`,
-          `const require = topLevelCreateRequire(import.meta.url);`,
-        ].join(""),
-      },
+      ...(file !== "oac-edge-signer"
+        ? {
+            banner: {
+              js: [
+                `import { createRequire as topLevelCreateRequire } from 'module';`,
+                `const require = topLevelCreateRequire(import.meta.url);`,
+              ].join(""),
+            },
+          }
+        : {}),
       outfile: `./dist/${file}/index.mjs`,
     }),
   ),


### PR DESCRIPTION
## Summary
- Improves `oac-edge-signer` performance and build packaging
- Adds query verb support for OAC edge signing
- Stops swallowing errors in the signer
- Removes the oac-edge-signer banner
- Documents oac-edge-signer digest/header branches with precise comments

This is landed as five commits that were developed as a local stack (GitHub native stacked PRs can't target upstream across forks without write access):

1. Improve oac edge signer performance
2. Add query verb support to oac edge
3. Stop oac-edge-signer swallowing errors
4. Remove banner from oac-edge-signer
5. Document oac-edge-signer digest branches

Fork stack (for reference): https://github.com/arjunyel/sst/pull/1 → #2 → #3 → #4 → #6

## Test plan
- [ ] Review diff in `platform/functions/oac-edge-signer/index.ts` and `platform/scripts/build.mjs`
- [ ] Confirm signer behavior for query verbs / error paths
- [ ] Build platform (`bun run build:platform`) if needed for the packaging change


Made with [Cursor](https://cursor.com)