### PR TITLE
fix(step-functions): serialize Task timeout as TimeoutSeconds, not Timeout

### DIFF
--- a/platform/src/components/aws/step-functions/task.ts
+++ b/platform/src/components/aws/step-functions/task.ts
@@ -324,7 +324,7 @@ export class Task extends State implements Nextable, Failable {
       Credentials: this.args.role && {
         RoleArn: this.args.role,
       },
-      Timeout: this.args.timeout
+      TimeoutSeconds: this.args.timeout
         ? output(this.args.timeout).apply((t) =>
             isJSONata(t) ? t : toSeconds(t as Duration),
           )


### PR DESCRIPTION
The `Task` state's `toJSON()` serializes the `timeout` arg under the ASL key `Timeout`, which is not a valid Amazon States Language field name in either JSONPath or JSONata query language mode. Per the [AWS Step Functions Task state docs](https://docs.aws.amazon.com/step-functions/latest/dg/state-task.html#task-state-fields), the correct field is `TimeoutSeconds` (with `TimeoutSecondsPath` as the JSONPath-only dynamic variant).

**Repro (before fix):**
```ts
const task = sst.aws.StepFunctions.lambdaInvoke({
  name: "MyTask",
  function: { handler: "src/handler.main" },
  timeout: "10 seconds",
});
new sst.aws.StepFunctions("Repro", { definition: task });
```
`sst deploy` fails with:
```
ERROR (SCHEMA_VALIDATION_FAILED): Field 'Timeout' is not supported: provider=aws@7.20.0
```

**Fix:** rename the serialized key from `Timeout` to `TimeoutSeconds`.

**Verified:** deployed a state machine with a 3s Task timeout racing a 6s Lambda sleep. Before the fix, deploy fails as above. After the fix, deploy succeeds and the execution correctly fails with `States.Timeout` at runtime, confirmed via `describe-execution`.