### PR TITLE
Disable VCS metadata in Go lambda and bridge task builds

### DIFF
--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -84,7 +84,7 @@ func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtim
 	args := []string{"build"}
 	env := os.Environ()
 	if !input.Dev {
-		args = append(args, "-ldflags", "-s -w")
+		args = append(args, "-ldflags", "-s -w", "-buildvcs=false")
 		env = append(env, "CGO_ENABLED=0")
 		env = append(env, "GOOS=linux")
 		env = append(env, "GOARCH=amd64")

--- a/platform/scripts/build
+++ b/platform/scripts/build
@@ -24,8 +24,8 @@ cp ./functions/docker/python.Dockerfile ./dist/dockerfiles/python.Dockerfile
 
 cd ./support/bridge-task
 mkdir -p build/amd64 build/arm64
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -mod=readonly -ldflags="-buildid=" -o build/amd64/main .
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -mod=readonly -ldflags="-buildid=" -o build/arm64/main .
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false -mod=readonly -ldflags="-buildid=" -o build/amd64/main .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -buildvcs=false -mod=readonly -ldflags="-buildid=" -o build/arm64/main .
 
 timestamp=$(date +%Y%m%d%H%M%S)
 docker buildx inspect >/dev/null 2>&1 || docker buildx create --name multi --driver docker-container --use


### PR DESCRIPTION
Follow-up to #6607
Go records `vcs.revision`/`vcs.time` into every main package, so a new commit alone changes the binary's bytes

- `pkg/runtime/golang/golang.go` — user Go lambdas
- `platform/scripts/build` — the bridge task

Verified: two builds at one commit are byte-identical, `-buildvcs=false` changes the bytes, `gofmt` clean, package compiles.