### PR TITLE
docs(secret): drop VideoAside linking a private video

### DIFF
--- a/platform/src/components/secret.ts
+++ b/platform/src/components/secret.ts
@@ -15,7 +15,6 @@ export class SecretMissingError extends VisibleError {
 /**
  * The `Secret` component lets you create secrets in your app.
  *
- * <VideoAside title="Watch a video on how secrets work" href="https://youtu.be/7tW2L3P6LKw" />
  *
  * Secrets are encrypted and stored in an S3 Bucket in your AWS account. If used in
  * your app config, they'll be encrypted in your state file as well. If used in


### PR DESCRIPTION
Closes #6975

The VideoAside in the Secret component docs links
https://youtu.be/7tW2L3P6LKw, which is now private
("This is a private video"). Remove the aside until a
replacement exists.

Heads up while checking: the four other VideoAside embeds in
www/src/content/docs/docs/basics.mdx (linking resources, dev
mode, protect prod, preview environments) also resolve to
login-required players as of today. If those are intentionally
members-only, feel free to close this note; happy to strip or
swap them in a follow-up if wanted.