### PR TITLE
fix(aws/router): build the S3 key from the baseless uri

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2755,7 +2755,7 @@ async function routeSite(kvNamespace, metadata) {
       : ["", ".html", "/index.html"];
     const v = await Promise.any(postfixes.map(p => cf.kvs().get(kvNamespace + ":" + u + p).then(v => p)));
     // files are stored in a subdirectory, add it to the request uri
-    event.request.uri = metadata.s3.dir + event.request.uri + v;
+    event.request.uri = metadata.s3.dir + baselessUri + v;
     setS3Origin(metadata.s3.domain);
     return;
   } catch (e) {}
@@ -2765,7 +2765,7 @@ async function routeSite(kvNamespace, metadata) {
     for (var i=0, l=metadata.s3.routes.length; i<l; i++) {
       const route = metadata.s3.routes[i];
       if (baselessUri.startsWith(route)) {
-        event.request.uri = metadata.s3.dir + event.request.uri;
+        event.request.uri = metadata.s3.dir + baselessUri;
         // uri ends with /, ie. /usage/ -> /usage/index.html
         if (event.request.uri.endsWith("/")) {
           event.request.uri += "index.html";

--- a/platform/test/components/cloudfront.test.ts
+++ b/platform/test/components/cloudfront.test.ts
@@ -127,12 +127,7 @@ function createContext(input: CreateContextInput) {
   return { context, event };
 }
 
-function loadRouteSite(input: {
-  uri: string;
-  headers: Record<string, CloudFrontField>;
-  cookies?: Record<string, CloudFrontField>;
-  querystring?: Record<string, unknown>;
-}) {
+function loadRouteSite(input: CreateContextInput) {
   const { context, event } = createContext(input);
 
   new vm.Script(
@@ -463,6 +458,117 @@ describe("CloudFront router", () => {
       expect(response.statusCode).toBe(431);
       expect(response.statusDescription).toBe("Request Header Fields Too Large");
       expect(response.body.data).toContain("Reduce cookie size");
+    });
+  });
+
+  describe("base path", () => {
+    const S3_DOMAIN = "assets.s3.us-east-1.amazonaws.com";
+
+    function siteMetadata(overrides: Record<string, any> = {}) {
+      return {
+        base: "/admin/board",
+        s3: { domain: S3_DOMAIN, dir: "/_assets", routes: ["/_next/static"] },
+        servers: [["server.lambda-url.us-east-1.on.aws", 0, 0]],
+        ...overrides,
+      };
+    }
+
+    it("keys an S3 route without the base", async () => {
+      // The regression. The route is matched against the baseless uri, so the
+      // key has to be built from it too. Building it from the full uri asks S3
+      // for /_assets/admin/board/_next/... while the deploy uploaded
+      // /_assets/_next/..., so every asset 404s. S3 reports that as 403 when
+      // the caller cannot list, which sends people hunting for a permissions
+      // problem that is not there.
+      const { event, routeSite } = loadRouteSite({
+        uri: "/admin/board/_next/static/css/abc123.css",
+        headers: { host: { value: "example.com" } },
+      });
+
+      await routeSite("test", siteMetadata());
+
+      expect(event.request.uri).toBe("/_assets/_next/static/css/abc123.css");
+    });
+
+    it("does not leave the base anywhere in the key", async () => {
+      const { event, routeSite } = loadRouteSite({
+        uri: "/admin/board/_next/static/chunk.js",
+        headers: { host: { value: "example.com" } },
+      });
+
+      await routeSite("test", siteMetadata());
+
+      expect(event.request.uri).not.toContain("/admin/board");
+    });
+
+    it("sends it to the S3 origin", async () => {
+      let origin: any;
+      const { routeSite } = loadRouteSite({
+        uri: "/admin/board/_next/static/chunk.js",
+        headers: { host: { value: "example.com" } },
+        updateRequestOrigin: (o) => (origin = o),
+      });
+
+      await routeSite("test", siteMetadata());
+
+      expect(origin.domainName).toBe(S3_DOMAIN);
+    });
+
+    it("is unchanged for a site with no base", async () => {
+      const { event, routeSite } = loadRouteSite({
+        uri: "/_next/static/css/abc123.css",
+        headers: { host: { value: "example.com" } },
+      });
+
+      await routeSite("test", siteMetadata({ base: undefined }));
+
+      expect(event.request.uri).toBe("/_assets/_next/static/css/abc123.css");
+    });
+
+    it("keys a file found in the KV store without the base", async () => {
+      // The other branch that matches baseless and then keyed with the full
+      // uri. Its own comment says files are stored in the root.
+      const { event, routeSite } = loadRouteSite({
+        uri: "/admin/board/about",
+        headers: { host: { value: "example.com" } },
+        kvGet: async (key: string) => {
+          if (key === "test:/about.html") return "";
+          throw new Error("missing");
+        },
+      });
+
+      await routeSite("test", siteMetadata());
+
+      expect(event.request.uri).toBe("/_assets/about.html");
+    });
+
+    it("still appends index.html under a base", async () => {
+      const { event, routeSite } = loadRouteSite({
+        uri: "/admin/board/docs/guide",
+        headers: { host: { value: "example.com" } },
+      });
+
+      await routeSite(
+        "test",
+        siteMetadata({
+          s3: { domain: S3_DOMAIN, dir: "/_assets", routes: ["/docs"] },
+        }),
+      );
+
+      expect(event.request.uri).toBe("/_assets/docs/guide/index.html");
+    });
+
+    it("leaves a path the S3 routes do not match to the server", async () => {
+      let origin: any;
+      const { routeSite } = loadRouteSite({
+        uri: "/admin/board/b/123",
+        headers: { host: { value: "example.com" } },
+        updateRequestOrigin: (o) => (origin = o),
+      });
+
+      await routeSite("test", siteMetadata());
+
+      expect(origin.domainName).toBe("server.lambda-url.us-east-1.on.aws");
     });
   });
 });


### PR DESCRIPTION
## The problem

A site deployed with `sst.aws.Nextjs` whose `next.config.ts` sets a `basePath`
serves its HTML fine and then fails to load a single stylesheet or script. The
page renders as unstyled markup. Every request under `<base>/_next/static/*`
comes back as:

```
HTTP/1.1 403 Forbidden
Server: AmazonS3
Via: 1.1 ...cloudfront.net (CloudFront)

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
```

The 403 is misleading and cost me a while: it is a missing key, not a
permissions problem. The OAC principal has `s3:GetObject` but not
`s3:ListBucket`, so S3 answers 403 rather than 404.

## Cause

Both S3 branches of the router function match against the *baseless* uri and
then build the S3 key from the *full* one, so the base path ends up in the key.
The assets are uploaded without it.

`platform/src/components/aws/router.ts`, inside `CF_ROUTER_INJECTION`:

```js
const baselessUri = metadata.base
  ? event.request.uri.replace(metadata.base, "")
  : event.request.uri;

// Route to S3 files
try {
  // check using baselessUri b/c files are stored in the root      <-- intent
  const u = decodeURIComponent(baselessUri);
  ...
  event.request.uri = metadata.s3.dir + event.request.uri + v;     <-- full uri
```

```js
// Route to S3 routes
    if (baselessUri.startsWith(route)) {                           // baseless
      event.request.uri = metadata.s3.dir + event.request.uri;     // full uri
```

The comment on the first branch already states the intent: files are stored in
the root. `sst.aws.Nextjs` uploads them accordingly, with no base awareness:

```ts
// platform/src/components/aws/nextjs.ts
assets: [
  { from: ".open-next/assets", to: "_assets", cached: true, versionedSubDir: "_next", ... }
],
```

So for a site based at `/admin/board`, CloudFront asks S3 for

```
/_assets/admin/board/_next/static/css/<hash>.css
```

while the deploy uploaded

```
/_assets/_next/static/css/<hash>.css
```

## The change

Two lines: build the key from `baselessUri` in both branches, which is what the
existing comment says should happen.

## Tests

Seven cases in `platform/test/components/cloudfront.test.ts`. Four of them fail
on the parent commit with the base left in the key:

```
expected '/_assets/admin/board/_next/static/css…' to be '/_assets/_next/static/css/abc123.css'
expected '/_assets/admin/board/_next/static/chu…' not to contain '/admin/board'
expected '/_assets/admin/board/about.html'       to be '/_assets/about.html'
expected '/_assets/admin/board/docs/guide/index…' to be '/_assets/docs/guide/index.html'
```

The other three pass either way on purpose. They are guards rather than
reproductions, so that a later change to the key building cannot quietly break
what already worked: a site with no base at all, the S3 origin actually being
selected, and a path the S3 routes do not match still reaching the server.

`loadRouteSite` now takes the same input type as `createContext`. It was
declaring a narrower one, so a test could not stub the KV store or observe
which origin was chosen, and the KVS-matched case needs both.

## Two things I did not touch

- The `custom404` branch goes the other way and adds the base explicitly
  (`metadata.s3.dir + (metadata.base ? metadata.base : "") + metadata.custom404`).
  If files really are stored in the root then that looks wrong too, but I have
  not exercised that path and did not want to change behaviour I could not
  test.
- The "route unmatched to S3" branch has the same shape. It only runs for a
  site with no servers, where it exists to trigger `customErrorResponses`, so I
  left it alone for the same reason.

Happy to fold either in if you would prefer them consistent.

## Notes

- `CF_ROUTER_INJECTION` is size-sensitive against the 10KB CloudFront Functions
  limit. This reuses the existing `baselessUri` variable, so the injected code
  gets slightly smaller.
- Found on 4.17.0 against a live deployment, and the code is identical on
  4.17.1 and `dev`.
