### PR TITLE
docs: remove duplicate Azure QuickStart ACR Geo Replication entry

### DIFF
--- a/www/src/content/docs/docs/all-providers.mdx
+++ b/www/src/content/docs/docs/all-providers.mdx
@@ -129,7 +129,6 @@ If you want SST to support a Terraform provider or update a version, you can **s
 | [Azure Justrun](https://www.pulumi.com/registry/packages/azure-justrun) | `pulumi-azure-justrun` |
 | [Azure Native](https://www.pulumi.com/registry/packages/azure-native) | `azure-native` |
 | [Azure Quickstart ACR Geo Replication](https://www.pulumi.com/registry/packages/azure-quickstart-acr-geo-replication) | `azure-quickstart-acr-geo-replication` |
-| [Azure QuickStart ACR Geo Replication](https://www.pulumi.com/registry/packages/azure-quickstart-acr-geo-replication/) | `azure-quickstart-acr-geo-replication` |
 | [Azure Static Website](https://www.pulumi.com/registry/packages/azure-static-website) | `azure-static-website` |
 | [AzureDevOps](https://www.pulumi.com/registry/packages/azuredevops) | `azuredevops` |
 | [Buildkite](https://www.pulumi.com/registry/packages/buildkite) | `@pulumiverse/buildkite` |


### PR DESCRIPTION
Removed duplicate entry for Azure QuickStart ACR Geo Replication.

The provider directory table on /docs/all-providers lists Azure Quickstart ACR Geo Replication twice (same package azure-quickstart-acr-geo-replication, only capitalization differs). This removes the duplicate row.
<img width="1328" height="181" alt="image" src="https://github.com/user-attachments/assets/ceac1401-4e3e-4f3a-933f-51f583c15f4e" />
