### PR TITLE
fix: guard live function descriptions

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -2686,7 +2686,7 @@ export class Function extends Component implements Link.Linkable {
                 ? {
                     description: transformed[1].description
                       ? output(transformed[1].description).apply(
-                          (v) => `${v.substring(0, 240)} (live)`,
+                          (v) => (v ? `${v.substring(0, 240)} (live)` : "live"),
                         )
                       : "live",
                     runtime: resolveDevRuntime(),


### PR DESCRIPTION
## Summary
- guard optional resolved Lambda descriptions before truncating them in live mode
- keep undefined and empty descriptions consistent with the existing `live` fallback
- make the shipped platform source clean under `strictNullChecks` for this path

## Verification
- `bun x tsc --noEmit -p platform/tsconfig.json --strictNullChecks`
- `bun run typecheck:platform`
- `bun x vitest run platform/test/components/function-builder.test.ts`
- `bun run build:platform`

Closes #6915