### PR TITLE
fix(step-functions): serialize task timeout correctly

### DIFF
--- a/platform/src/components/aws/step-functions/task.ts
+++ b/platform/src/components/aws/step-functions/task.ts
@@ -324,7 +324,7 @@ export class Task extends State implements Nextable, Failable {
       Credentials: this.args.role && {
         RoleArn: this.args.role,
       },
-      Timeout: this.args.timeout
+      TimeoutSeconds: this.args.timeout
         ? output(this.args.timeout).apply((t) =>
             isJSONata(t) ? t : toSeconds(t as Duration),
           )

--- a/platform/test/components/step-functions-task.test.ts
+++ b/platform/test/components/step-functions-task.test.ts
@@ -1,0 +1,40 @@
+import * as pulumi from "@pulumi/pulumi";
+import { describe, expect, it } from "vitest";
+import { Task } from "../../src/components/aws/step-functions/task";
+
+async function resolveOutputs<T extends readonly unknown[]>(values: T) {
+  return await new Promise<T>((resolve, reject) => {
+    pulumi.all(values as unknown as pulumi.Input<unknown>[]).apply((result) => {
+      try {
+        resolve(result as unknown as T);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+describe("Step Functions Task", () => {
+  it("serializes duration and JSONata timeouts as TimeoutSeconds", async () => {
+    const duration = new Task({
+      name: "Duration",
+      resource: "arn:aws:states:::lambda:invoke",
+      timeout: "2 minutes",
+    }).serialize().Duration;
+    const jsonata = new Task({
+      name: "JSONata",
+      resource: "arn:aws:states:::lambda:invoke",
+      timeout: "{% $states.input.timeout %}",
+    }).serialize().JSONata;
+
+    const [durationTimeout, jsonataTimeout] = await resolveOutputs([
+      duration.TimeoutSeconds,
+      jsonata.TimeoutSeconds,
+    ] as const);
+
+    expect(durationTimeout).toBe(120);
+    expect(jsonataTimeout).toBe("{% $states.input.timeout %}");
+    expect(duration).not.toHaveProperty("Timeout");
+    expect(jsonata).not.toHaveProperty("Timeout");
+  });
+});


### PR DESCRIPTION
## Related Issues
Fixes #6747

## In a Nutshell
- Emit the valid ASL task timeout field
- Cover duration and JSONata timeout serialization

## Description
Task states currently serialize `timeout` as unsupported `Timeout`, causing AWS to reject the state machine definition. Serialize it as `TimeoutSeconds` while preserving duration conversion and JSONata expressions.

## Must
- [x] Tests
- [ ] Documentation (not applicable)