### PR TITLE
fix(config): inject provider globals safely

### DIFF
--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -59,6 +59,33 @@ func Build(input EvalOptions) (esbuild.BuildResult, error) {
 		outfile = filepath.Join(input.Dir, ".sst", "platform", fmt.Sprintf("sst.config.%v.mjs", time.Now().UnixMilli()))
 	}
 	slog.Info("esbuild building", "out", outfile)
+	inject := append([]string{}, input.Inject...)
+	plugins := []esbuild.Plugin{}
+	if input.Globals != "" {
+		const globalsPath = "sst:globals"
+		globals := input.Globals
+		inject = append(inject, globalsPath)
+		plugins = append(plugins, esbuild.Plugin{
+			Name: "InjectGlobals",
+			Setup: func(build esbuild.PluginBuild) {
+				build.OnResolve(esbuild.OnResolveOptions{Filter: "^" + globalsPath + "$"},
+					func(args esbuild.OnResolveArgs) (esbuild.OnResolveResult, error) {
+						return esbuild.OnResolveResult{
+							Path:      globalsPath,
+							Namespace: globalsPath,
+						}, nil
+					})
+				build.OnLoad(esbuild.OnLoadOptions{Filter: ".*", Namespace: globalsPath},
+					func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
+						return esbuild.OnLoadResult{
+							Contents:   &globals,
+							ResolveDir: input.Dir,
+							Loader:     esbuild.LoaderJS,
+						}, nil
+					})
+			},
+		})
+	}
 	var err error
 	result := esbuild.Build(esbuild.BuildOptions{
 		Banner: map[string]string{
@@ -83,43 +110,18 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 		NodePaths: []string{
 			filepath.Join(input.Dir, ".sst", "platform", "node_modules"),
 		},
-		Plugins: []esbuild.Plugin{
-			{
-				Name: "DisallowImports",
-				Setup: func(build esbuild.PluginBuild) {
-					build.OnResolve(esbuild.OnResolveOptions{Filter: ".*"}, func(args esbuild.OnResolveArgs) (esbuild.OnResolveResult, error) {
-						if input.Globals == "" && filepath.Base(args.Importer) == "sst.config.ts" && args.Kind == esbuild.ResolveJSImportStatement {
-							err = ErrTopLevelImport
-							return esbuild.OnResolveResult{}, ErrTopLevelImport
-						}
-						return esbuild.OnResolveResult{}, nil
-					})
-				},
+		Plugins: append(plugins, esbuild.Plugin{
+			Name: "DisallowImports",
+			Setup: func(build esbuild.PluginBuild) {
+				build.OnResolve(esbuild.OnResolveOptions{Filter: ".*"}, func(args esbuild.OnResolveArgs) (esbuild.OnResolveResult, error) {
+					if input.Globals == "" && filepath.Base(args.Importer) == "sst.config.ts" && args.Kind == esbuild.ResolveJSImportStatement {
+						err = ErrTopLevelImport
+						return esbuild.OnResolveResult{}, ErrTopLevelImport
+					}
+					return esbuild.OnResolveResult{}, nil
+				})
 			},
-			{
-				Name: "InjectGlobals",
-				Setup: func(build esbuild.PluginBuild) {
-					build.OnLoad(esbuild.OnLoadOptions{Filter: `\.(js|ts|jsx|tsx)$`},
-						func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
-							if filepath.HasPrefix(args.Path, filepath.Join(input.Dir, ".sst")) {
-								return esbuild.OnLoadResult{}, nil
-							}
-							contents, err := os.ReadFile(args.Path)
-							if err != nil {
-								return esbuild.OnLoadResult{}, err
-							}
-							newContents := string(contents)
-							if !strings.Contains(args.Path, ".sst") {
-								newContents = input.Globals + "\n" + newContents
-							}
-							return esbuild.OnLoadResult{
-								Contents: &newContents,
-								Loader:   esbuild.LoaderDefault,
-							}, nil
-						})
-				},
-			},
-		},
+		}),
 		External: []string{
 			"@pulumi/*",
 			"undici",
@@ -132,7 +134,7 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 			"vite", // The remix component uses vite to resolve the user's vite config file. We don't want to bundle it.
 		},
 		Define:   input.Define,
-		Inject:   input.Inject,
+		Inject:   inject,
 		Outfile:  outfile,
 		Write:    true,
 		Bundle:   true,

--- a/pkg/js/js_test.go
+++ b/pkg/js/js_test.go
@@ -1,11 +1,15 @@
 package js_test
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	esbuild "github.com/evanw/esbuild/pkg/api"
 	"github.com/sst/sst/v3/pkg/js"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatError(t *testing.T) {
@@ -33,4 +37,46 @@ func TestFormatError(t *testing.T) {
 		}
 		assert.Equal(t, "err1\nb.ts:2:3: err2", js.FormatError(msgs))
 	})
+}
+
+func TestBuildGlobalsDoNotCollideWithDependencyBindings(t *testing.T) {
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, ".sst", "platform")
+	providerDir := filepath.Join(dir, "node_modules", "provider")
+	dependencyDir := filepath.Join(dir, "node_modules", "collision")
+	require.NoError(t, os.MkdirAll(outDir, 0755))
+	for _, packageDir := range []string{providerDir, dependencyDir} {
+		require.NoError(t, os.MkdirAll(packageDir, 0755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(packageDir, "package.json"),
+			[]byte(`{"type":"module"}`),
+			0644,
+		))
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(providerDir, "index.js"),
+		[]byte(`export const name = "provider";`),
+		0644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dependencyDir, "index.js"),
+		[]byte(`
+export const postgresql = "dependency";
+export default postgresql;
+`),
+		0644,
+	))
+
+	outfile := filepath.Join(outDir, "config.mjs")
+	_, err := js.Build(js.EvalOptions{
+		Dir:     dir,
+		Outfile: outfile,
+		Code:    `import value from "collision"; console.log(postgresql.name, value);`,
+		Globals: `export * as postgresql from "provider";`,
+	})
+	require.NoError(t, err)
+
+	output, err := exec.Command("node", outfile).CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.Equal(t, "provider dependency\n", string(output))
 }

--- a/pkg/project/run.go
+++ b/pkg/project/run.go
@@ -158,9 +158,9 @@ func (p *Project) Run(ctx context.Context, input *StackInput) error {
 
 	providerShim := []string{}
 	for _, entry := range p.lock {
-		providerShim = append(providerShim, fmt.Sprintf("import * as %s from \"%s\";", entry.Alias, entry.Package))
+		providerShim = append(providerShim, fmt.Sprintf("export * as %s from \"%s\";", entry.Alias, entry.Package))
 	}
-	providerShim = append(providerShim, fmt.Sprintf("import * as sst from \"%s\";", path.Join(filepath.ToSlash(p.PathPlatformDir()), "src/components")))
+	providerShim = append(providerShim, fmt.Sprintf("export * as sst from \"%s\";", path.Join(filepath.ToSlash(p.PathPlatformDir()), "src/components")))
 
 	buildResult, err := js.Build(js.EvalOptions{
 		Dir:     p.PathRoot(),


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/anomalyco/sst/issues/6979

## In a Nutshell
- Inject provider globals through esbuild
- Prevent dependency binding collisions

## Description
Provider and SST globals now come from a virtual esbuild inject module instead of source text prepended to every bundled module. This preserves global access in `sst.config.ts` while allowing dependencies to declare matching top-level names, with a regression test covering the collision.

## Must
- [x] Tests
- [x] Documentation (not applicable)