### PR TITLE
fix(aws): clarify Router origin timeout behavior

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -407,6 +407,10 @@ export interface RouterUrlRouteArgs extends RouteArgs {
    * When compared to the `connectionTimeout`, this is the total time for the
    * request.
    *
+   * The Router applies this timeout dynamically to matching requests through
+   * its CloudFront Function. It does not change the distribution's static
+   * origin configuration.
+   *
    * @default `"20 seconds"`
    * @example
    * ```js
@@ -420,6 +424,11 @@ export interface RouterUrlRouteArgs extends RouteArgs {
    * The number of seconds that CloudFront should try to maintain the connection
    * to the destination after receiving the last packet of the response. Must be
    * between 1 and 60 seconds
+   *
+   * The Router applies this timeout dynamically to matching requests through
+   * its CloudFront Function. It does not change the distribution's static
+   * origin configuration.
+   *
    * @default `"5 seconds"`
    * @example
    * ```js

--- a/platform/test/components/cloudfront.test.ts
+++ b/platform/test/components/cloudfront.test.ts
@@ -336,6 +336,49 @@ describe("CloudFront router", () => {
     });
   });
 
+  it("sets URL route origin timeouts dynamically", async () => {
+    const { event, handler } = loadHandler({
+      uri: "/",
+      headers: {
+        host: { value: "example.com" },
+      },
+      routes: ["url,route0,,/"],
+      metadata: {
+        route0: {
+          host: "gateway-origin.example.com",
+          origin: {
+            connectionAttempts: 2,
+            timeouts: {
+              connectionTimeout: 3,
+              readTimeout: 60,
+              keepAliveTimeout: 60,
+            },
+          },
+        },
+      },
+    });
+
+    await handler(event);
+
+    expect(event.request.origin).toEqual({
+      domainName: "gateway-origin.example.com",
+      customOriginConfig: {
+        port: 443,
+        protocol: "https",
+        sslProtocols: ["TLSv1.2"],
+      },
+      originAccessControlConfig: {
+        enabled: false,
+      },
+      connectionAttempts: 2,
+      timeouts: {
+        connectionTimeout: 3,
+        readTimeout: 60,
+        keepAliveTimeout: 60,
+      },
+    });
+  });
+
   describe("header sizing", () => {
     it("counts request headers and cookies", async () => {
       const { getRequestHeaderSize, routeSite } = loadRouteSite({


### PR DESCRIPTION
## Summary

- clarify that Router URL route timeouts are applied dynamically by the CloudFront Function
- document why static distribution origin configuration keeps its defaults
- cover request-scoped origin timeout overrides through the generated router handler

## Verification

- `bun run --cwd platform test test/components/cloudfront.test.ts`
- `bun run build:platform`

Closes #6900