### PR TITLE
fix: inject globals from paths containing .sst

### DIFF
--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -101,17 +101,14 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 				Setup: func(build esbuild.PluginBuild) {
 					build.OnLoad(esbuild.OnLoadOptions{Filter: `\.(js|ts|jsx|tsx)$`},
 						func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
-							if filepath.HasPrefix(args.Path, filepath.Join(input.Dir, ".sst")) {
+							if isWithinDir(args.Path, filepath.Join(input.Dir, ".sst")) {
 								return esbuild.OnLoadResult{}, nil
 							}
 							contents, err := os.ReadFile(args.Path)
 							if err != nil {
 								return esbuild.OnLoadResult{}, err
 							}
-							newContents := string(contents)
-							if !strings.Contains(args.Path, ".sst") {
-								newContents = input.Globals + "\n" + newContents
-							}
+							newContents := input.Globals + "\n" + string(contents)
 							return esbuild.OnLoadResult{
 								Contents: &newContents,
 								Loader:   esbuild.LoaderDefault,
@@ -155,6 +152,11 @@ const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 	os.WriteFile(filepath.Join(input.Dir, ".sst", "esbuild.json"), []byte(analysis), 0644)
 
 	return result, nil
+}
+
+func isWithinDir(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func FormatError(input []esbuild.Message) string {

--- a/pkg/js/js_test.go
+++ b/pkg/js/js_test.go
@@ -1,21 +1,21 @@
-package js_test
+package js
 
 import (
+	"path/filepath"
 	"testing"
 
 	esbuild "github.com/evanw/esbuild/pkg/api"
-	"github.com/sst/sst/v3/pkg/js"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatError(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
-		assert.Equal(t, "", js.FormatError([]esbuild.Message{}))
+		assert.Equal(t, "", FormatError([]esbuild.Message{}))
 	})
 
 	t.Run("no location", func(t *testing.T) {
 		msgs := []esbuild.Message{{Text: "something broke"}}
-		assert.Equal(t, "something broke", js.FormatError(msgs))
+		assert.Equal(t, "something broke", FormatError(msgs))
 	})
 
 	t.Run("with location", func(t *testing.T) {
@@ -23,7 +23,7 @@ func TestFormatError(t *testing.T) {
 			Text:     "unexpected token",
 			Location: &esbuild.Location{File: "app.ts", Line: 10, Column: 5},
 		}}
-		assert.Equal(t, "app.ts:10:5: unexpected token", js.FormatError(msgs))
+		assert.Equal(t, "app.ts:10:5: unexpected token", FormatError(msgs))
 	})
 
 	t.Run("multiple errors", func(t *testing.T) {
@@ -31,6 +31,43 @@ func TestFormatError(t *testing.T) {
 			{Text: "err1"},
 			{Text: "err2", Location: &esbuild.Location{File: "b.ts", Line: 2, Column: 3}},
 		}
-		assert.Equal(t, "err1\nb.ts:2:3: err2", js.FormatError(msgs))
+		assert.Equal(t, "err1\nb.ts:2:3: err2", FormatError(msgs))
 	})
+}
+
+func TestIsWithinDir(t *testing.T) {
+	root := t.TempDir()
+	sstDir := filepath.Join(root, "app.sst-branch", ".sst")
+
+	tests := map[string]struct {
+		path string
+		want bool
+	}{
+		"generated file": {
+			path: filepath.Join(sstDir, "platform", "config.ts"),
+			want: true,
+		},
+		"generated directory": {
+			path: sstDir,
+			want: true,
+		},
+		"project path containing sst": {
+			path: filepath.Join(root, "app.sst-branch", "src", "index.ts"),
+			want: false,
+		},
+		"similarly named directory": {
+			path: filepath.Join(root, "app.sst-branch", ".sst-other", "index.ts"),
+			want: false,
+		},
+		"parent directory": {
+			path: filepath.Join(root, "app.sst-branch"),
+			want: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isWithinDir(tt.path, sstDir))
+		})
+	}
 }

--- a/pkg/js/js_test.go
+++ b/pkg/js/js_test.go
@@ -1,21 +1,23 @@
-package js
+package js_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	esbuild "github.com/evanw/esbuild/pkg/api"
+	"github.com/sst/sst/v3/pkg/js"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatError(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
-		assert.Equal(t, "", FormatError([]esbuild.Message{}))
+		assert.Equal(t, "", js.FormatError([]esbuild.Message{}))
 	})
 
 	t.Run("no location", func(t *testing.T) {
 		msgs := []esbuild.Message{{Text: "something broke"}}
-		assert.Equal(t, "something broke", FormatError(msgs))
+		assert.Equal(t, "something broke", js.FormatError(msgs))
 	})
 
 	t.Run("with location", func(t *testing.T) {
@@ -23,7 +25,7 @@ func TestFormatError(t *testing.T) {
 			Text:     "unexpected token",
 			Location: &esbuild.Location{File: "app.ts", Line: 10, Column: 5},
 		}}
-		assert.Equal(t, "app.ts:10:5: unexpected token", FormatError(msgs))
+		assert.Equal(t, "app.ts:10:5: unexpected token", js.FormatError(msgs))
 	})
 
 	t.Run("multiple errors", func(t *testing.T) {
@@ -31,43 +33,26 @@ func TestFormatError(t *testing.T) {
 			{Text: "err1"},
 			{Text: "err2", Location: &esbuild.Location{File: "b.ts", Line: 2, Column: 3}},
 		}
-		assert.Equal(t, "err1\nb.ts:2:3: err2", FormatError(msgs))
+		assert.Equal(t, "err1\nb.ts:2:3: err2", js.FormatError(msgs))
 	})
 }
 
-func TestIsWithinDir(t *testing.T) {
-	root := t.TempDir()
-	sstDir := filepath.Join(root, "app.sst-branch", ".sst")
+func TestBuildInjectsGlobalsForProjectPathContainingSST(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "app.sst-branch")
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, ".sst"), 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "source.ts"), []byte(`if (!injected) throw new Error("missing globals")`), 0644))
 
-	tests := map[string]struct {
-		path string
-		want bool
-	}{
-		"generated file": {
-			path: filepath.Join(sstDir, "platform", "config.ts"),
-			want: true,
-		},
-		"generated directory": {
-			path: sstDir,
-			want: true,
-		},
-		"project path containing sst": {
-			path: filepath.Join(root, "app.sst-branch", "src", "index.ts"),
-			want: false,
-		},
-		"similarly named directory": {
-			path: filepath.Join(root, "app.sst-branch", ".sst-other", "index.ts"),
-			want: false,
-		},
-		"parent directory": {
-			path: filepath.Join(root, "app.sst-branch"),
-			want: false,
-		},
-	}
+	outfile := filepath.Join(dir, ".sst", "platform", "config.mjs")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(outfile), 0755))
+	_, err := js.Build(js.EvalOptions{
+		Dir:     dir,
+		Outfile: outfile,
+		Code:    `import "./source"`,
+		Globals: `const injected = true`,
+	})
+	assert.NoError(t, err)
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isWithinDir(tt.path, sstDir))
-		})
-	}
+	contents, err := os.ReadFile(outfile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(contents), "injected = true")
 }


### PR DESCRIPTION
## Summary
- detect the generated `.sst` directory by path segments instead of string prefixes
- inject globals for source files when a project ancestor contains `.sst`
- add a behavioral build regression for the reported worktree path

## Verification
- `go test ./pkg/js`
- `bun run test:cli`
- `bun run build:platform`
- `bun run build:cli`

Closes #6937