### PR TITLE
fix(router): inherit OAC protection for URL routes

### DIFF
--- a/platform/src/components/aws/router-url-route.ts
+++ b/platform/src/components/aws/router-url-route.ts
@@ -21,9 +21,9 @@ export interface Args extends RouterBaseRouteArgs {
    */
   routeArgs?: Input<RouterUrlRouteArgs>;
   /**
-   * The protection mode to apply to this route.
+   * The protection configuration inherited from the Router.
    */
-  protection: Input<ProtectionConfig["mode"]>;
+  protection: Input<ProtectionConfig>;
 }
 
 /**
@@ -48,8 +48,9 @@ export class RouterUrlRoute extends Component {
         const host = u.host;
         const protocol = u.protocol.slice(0, -1);
         const useOac =
-          /^[^.]+\.lambda-url\.[^.]+\.on\.aws$/.test(u.hostname) &&
-          (protection === "oac" || protection === "oac-with-edge-signing");
+          /^[a-z0-9]{32}\.lambda-url\.[a-z0-9-]+\.on\.aws$/.test(u.hostname) &&
+          (protection.mode === "oac" ||
+            protection.mode === "oac-with-edge-signing");
 
         const patternData = parsePattern(pattern);
         const namespace = buildKvNamespace(name);
@@ -57,7 +58,7 @@ export class RouterUrlRoute extends Component {
           host,
           rewrite: routeArgs?.rewrite,
           origin: {
-            protocol: protocol === "https" ? undefined : protocol,
+            protocol: useOac || protocol === "https" ? undefined : protocol,
             connectionAttempts: routeArgs?.connectionAttempts,
             ...(useOac
               ? {

--- a/platform/src/components/aws/router-url-route.ts
+++ b/platform/src/components/aws/router-url-route.ts
@@ -1,13 +1,14 @@
-import { ComponentResourceOptions, Input, all } from "@pulumi/pulumi";
+import { all } from "@pulumi/pulumi";
+import type { ComponentResourceOptions, Input } from "@pulumi/pulumi";
 import { Component } from "../component";
 import {
   buildKvNamespace,
   createKvRouteData,
   parsePattern,
-  RouterBaseRouteArgs,
   updateKvRoutes,
 } from "./router-base-route";
-import { RouterUrlRouteArgs } from "./router";
+import type { RouterBaseRouteArgs } from "./router-base-route";
+import type { ProtectionConfig, RouterUrlRouteArgs } from "./router";
 import { toSeconds } from "../duration";
 
 export interface Args extends RouterBaseRouteArgs {
@@ -19,6 +20,10 @@ export interface Args extends RouterBaseRouteArgs {
    * Additional arguments for the route.
    */
   routeArgs?: Input<RouterUrlRouteArgs>;
+  /**
+   * The protection mode to apply to this route.
+   */
+  protection: Input<ProtectionConfig["mode"]>;
 }
 
 /**
@@ -37,11 +42,14 @@ export class RouterUrlRoute extends Component {
 
     const self = this;
 
-    all([args.url, args.pattern, args.routeArgs]).apply(
-      ([url, pattern, routeArgs]) => {
+    all([args.url, args.pattern, args.routeArgs, args.protection]).apply(
+      ([url, pattern, routeArgs, protection]) => {
         const u = new URL(url);
         const host = u.host;
         const protocol = u.protocol.slice(0, -1);
+        const useOac =
+          /^[^.]+\.lambda-url\.[^.]+\.on\.aws$/.test(u.hostname) &&
+          (protection === "oac" || protection === "oac-with-edge-signing");
 
         const patternData = parsePattern(pattern);
         const namespace = buildKvNamespace(name);
@@ -51,6 +59,16 @@ export class RouterUrlRoute extends Component {
           origin: {
             protocol: protocol === "https" ? undefined : protocol,
             connectionAttempts: routeArgs?.connectionAttempts,
+            ...(useOac
+              ? {
+                  originAccessControlConfig: {
+                    enabled: true,
+                    signingBehavior: "always",
+                    signingProtocol: "sigv4",
+                    originType: "lambda",
+                  },
+                }
+              : {}),
             timeouts: (() => {
               const timeouts = [
                 "connectionTimeout" as const,

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -2549,7 +2549,7 @@ async function handler(event) {
             pattern,
             url,
             routeArgs: args,
-            protection: protection.mode,
+            protection,
           },
           { provider: this.constructorOpts.provider },
         );

--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -1613,10 +1613,7 @@ export class Router extends Component implements Link.Linkable {
           return {
             include: (l.include ?? "all") as "all" | "blocked",
             retention: (l.retention ?? "1 month") as keyof typeof RETENTION,
-            redact:
-              redact === false
-                ? undefined
-                : redact ?? defaultRedact,
+            redact: redact === false ? undefined : redact ?? defaultRedact,
           };
         });
     }
@@ -2537,8 +2534,8 @@ async function handler(event) {
     url: Input<string>,
     args?: Input<RouterUrlRouteArgs>,
   ) {
-    all([pattern, args, this.hasInlineRoutes]).apply(
-      ([pattern, args, hasInlineRoutes]) => {
+    all([pattern, args, this.hasInlineRoutes, this._protectionMode]).apply(
+      ([pattern, args, hasInlineRoutes, protection]) => {
         if (hasInlineRoutes)
           throw new VisibleError(
             "Cannot use both `routes` and `.route()` function to add routes.",
@@ -2552,6 +2549,7 @@ async function handler(event) {
             pattern,
             url,
             routeArgs: args,
+            protection: protection.mode,
           },
           { provider: this.constructorOpts.provider },
         );

--- a/platform/test/components/router-url-route.test.ts
+++ b/platform/test/components/router-url-route.test.ts
@@ -51,7 +51,7 @@ async function settle() {
   }
 }
 
-function getOriginAccessControlConfig(host: string): unknown {
+function getOrigin(host: string): Record<string, unknown> {
   for (const metadata of captured.routeMetadata) {
     const parsed = metadata;
 
@@ -66,9 +66,7 @@ function getOriginAccessControlConfig(host: string): unknown {
     )
       continue;
 
-    return "originAccessControlConfig" in parsed.origin
-      ? parsed.origin.originAccessControlConfig
-      : undefined;
+    return parsed.origin as Record<string, unknown>;
   }
 
   throw new Error(`Route metadata not found for ${host}`);
@@ -106,12 +104,13 @@ describe("Router URL route protection", () => {
     "applies %s protection to Lambda function URLs",
     async (protection) => {
       const router = createRouter(protection);
-      const host = "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws";
+      const host =
+        "abcdefghijklmnopqrstuvwxyz234567.lambda-url.us-east-1.on.aws";
 
       router.route("/api", `https://${host}`);
       await settle();
 
-      expect(getOriginAccessControlConfig(host)).toEqual({
+      expect(getOrigin(host).originAccessControlConfig).toEqual({
         enabled: true,
         signingBehavior: "always",
         signingProtocol: "sigv4",
@@ -120,14 +119,26 @@ describe("Router URL route protection", () => {
     },
   );
 
-  it("does not apply OAC when protection is disabled", async () => {
+  it("forces HTTPS for protected Lambda function URLs", async () => {
+    const router = createRouter("oac");
+    const host = "abcdefghijklmnopqrstuvwxyz234567.lambda-url.us-east-1.on.aws";
+
+    router.route("/api", `http://${host}`);
+    await settle();
+
+    const origin = getOrigin(host);
+    expect(origin.originAccessControlConfig).toBeDefined();
+    expect(origin.protocol).toBeUndefined();
+  });
+
+  it("does not apply OAC for the normalized default protection mode", async () => {
     const router = createRouter("none");
-    const host = "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws";
+    const host = "abcdefghijklmnopqrstuvwxyz234567.lambda-url.us-east-1.on.aws";
 
     router.route("/api", `https://${host}`);
     await settle();
 
-    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+    expect(getOrigin(host).originAccessControlConfig).toBeUndefined();
   });
 
   it("does not apply OAC to ordinary HTTPS origins", async () => {
@@ -137,17 +148,18 @@ describe("Router URL route protection", () => {
     router.route("/api", `https://${host}`);
     await settle();
 
-    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+    expect(getOrigin(host).originAccessControlConfig).toBeUndefined();
   });
 
-  it("does not apply OAC to spoofed Lambda URL hostnames", async () => {
+  it.each([
+    "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws",
+    "abcdefghijklmnopqrstuvwxyz234567.lambda-url.us-east-1.on.aws.example.com",
+  ])("does not apply OAC to spoofed Lambda URL hostname %s", async (host) => {
     const router = createRouter("oac");
-    const host =
-      "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws.example.com";
 
     router.route("/api", `https://${host}`);
     await settle();
 
-    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+    expect(getOrigin(host).originAccessControlConfig).toBeUndefined();
   });
 });

--- a/platform/test/components/router-url-route.test.ts
+++ b/platform/test/components/router-url-route.test.ts
@@ -1,0 +1,153 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as pulumi from "@pulumi/pulumi";
+import type { Router as RouterType } from "../../src/components/aws/router";
+
+const captured = vi.hoisted(() => ({ routeMetadata: [] as unknown[] }));
+
+vi.mock("../../src/components/aws/router-base-route", () => ({
+  buildKvNamespace: () => "route",
+  parsePattern: () => ({ host: "", path: "/api" }),
+  createKvRouteData: (
+    _name: unknown,
+    _args: unknown,
+    _parent: unknown,
+    _namespace: unknown,
+    metadata: unknown,
+  ) => {
+    captured.routeMetadata.push(metadata);
+  },
+  updateKvRoutes: () => undefined,
+}));
+
+// @ts-ignore
+global.$app = {
+  name: "app",
+  stage: "test",
+};
+global.$util = pulumi;
+
+pulumi.runtime.setMocks(
+  {
+    newResource(args: pulumi.runtime.MockResourceArgs) {
+      return {
+        id: `${args.name}_id`,
+        state: args.inputs,
+      };
+    },
+    call(args: pulumi.runtime.MockCallArgs) {
+      return args.inputs;
+    },
+  },
+  "project",
+  "stack",
+  false,
+);
+
+async function settle() {
+  for (let i = 0; i < 50; i++) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setImmediate(resolve);
+    await promise;
+  }
+}
+
+function getOriginAccessControlConfig(host: string): unknown {
+  for (const metadata of captured.routeMetadata) {
+    const parsed = metadata;
+
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !("host" in parsed) ||
+      parsed.host !== host ||
+      !("origin" in parsed) ||
+      !parsed.origin ||
+      typeof parsed.origin !== "object"
+    )
+      continue;
+
+    return "originAccessControlConfig" in parsed.origin
+      ? parsed.origin.originAccessControlConfig
+      : undefined;
+  }
+
+  throw new Error(`Route metadata not found for ${host}`);
+}
+
+describe("Router URL route protection", () => {
+  let Router: typeof RouterType;
+
+  beforeAll(async () => {
+    // Import after installing Pulumi globals and mocks used during module setup.
+    Router = (await import("../../src/components/aws/router")).Router;
+  });
+
+  function createRouter(protection: "none" | "oac" | "oac-with-edge-signing") {
+    // Bypass unrelated Router infrastructure so this exercises only route propagation.
+    const router = Object.create(Router.prototype) as RouterType;
+    Object.assign(router, {
+      constructorName: `Router-${protection}`,
+      constructorOpts: {},
+      kvStoreArn: pulumi.output(
+        "arn:aws:cloudfront::123456789012:key-value-store/test",
+      ),
+      kvNamespace: pulumi.output("router"),
+      hasInlineRoutes: pulumi.output(false),
+      _protectionMode: pulumi.output({ mode: protection }),
+    });
+    return router;
+  }
+
+  beforeEach(() => {
+    captured.routeMetadata.length = 0;
+  });
+
+  it.each(["oac", "oac-with-edge-signing"] as const)(
+    "applies %s protection to Lambda function URLs",
+    async (protection) => {
+      const router = createRouter(protection);
+      const host = "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws";
+
+      router.route("/api", `https://${host}`);
+      await settle();
+
+      expect(getOriginAccessControlConfig(host)).toEqual({
+        enabled: true,
+        signingBehavior: "always",
+        signingProtocol: "sigv4",
+        originType: "lambda",
+      });
+    },
+  );
+
+  it("does not apply OAC when protection is disabled", async () => {
+    const router = createRouter("none");
+    const host = "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws";
+
+    router.route("/api", `https://${host}`);
+    await settle();
+
+    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+  });
+
+  it("does not apply OAC to ordinary HTTPS origins", async () => {
+    const router = createRouter("oac");
+    const host = "api.example.com";
+
+    router.route("/api", `https://${host}`);
+    await settle();
+
+    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+  });
+
+  it("does not apply OAC to spoofed Lambda URL hostnames", async () => {
+    const router = createRouter("oac");
+    const host =
+      "abcdefghijklmnopqrstuvwxyz.lambda-url.us-east-1.on.aws.example.com";
+
+    router.route("/api", `https://${host}`);
+    await settle();
+
+    expect(getOriginAccessControlConfig(host)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- propagate the Router's normalized protection configuration to URL routes
- enable Lambda Origin Access Control only for genuine Lambda Function URL origins
- force HTTPS for signed Lambda origins and keep ordinary URL routes unchanged
- add focused regression coverage for protected, unprotected, and spoofed origins

## Verification
- `bun run --cwd platform test -- test/components/router-url-route.test.ts`
- `bun run typecheck:platform`
- `bun run build:platform`

Closes #6881