### PR TITLE
fix: resolve custom bundle paths in dev

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -118,6 +118,9 @@ func (c *Collection) Build(ctx context.Context, input *BuildInput) (*BuildOutput
 
 	if input.Bundle != "" {
 		out = input.Bundle
+		if !filepath.IsAbs(out) {
+			out = filepath.Join(path.ResolveRootDir(input.CfgPath), out)
+		}
 		result = &BuildOutput{
 			Handler: input.Handler,
 			Errors:  []string{},

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -55,6 +55,43 @@ func TestBuildInputOut(t *testing.T) {
 	})
 }
 
+func TestCollectionBuildCustomBundle(t *testing.T) {
+	projectDir := t.TempDir()
+	absoluteBundle := filepath.Join(t.TempDir(), "dist")
+	tests := []struct {
+		name   string
+		bundle string
+		want   string
+	}{
+		{
+			name:   "relative path",
+			bundle: "./dist",
+			want:   filepath.Join(projectDir, "dist"),
+		},
+		{
+			name:   "absolute path",
+			bundle: absoluteBundle,
+			want:   absoluteBundle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &runtime.BuildInput{
+				CfgPath: filepath.Join(projectDir, "sst.config.ts"),
+				Bundle:  tt.bundle,
+				Handler: "lambda.handler",
+			}
+
+			result, err := runtime.NewCollection(input.CfgPath).Build(context.Background(), input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.Out)
+			assert.True(t, filepath.IsAbs(result.Out))
+			assert.Equal(t, filepath.Join(tt.want, "lambda.handler"), filepath.Join(result.Out, result.Handler))
+		})
+	}
+}
+
 func TestCollectionRuntime(t *testing.T) {
 	t.Run("matching runtime found", func(t *testing.T) {
 		mr := &mockRuntime{matchFn: func(r string) bool { return r == "nodejs" }}


### PR DESCRIPTION
## Related Issues

Fixes #6253

## In a Nutshell

- Resolve custom bundles from the project root
- Cover relative and absolute bundle paths

## Description

Custom bundle paths remained relative during dev builds, while the Node runtime used the same path as both its working directory and part of the handler path. Resolve relative bundles against the SST config directory so dev handler loading matches deploy behavior, while preserving absolute bundle paths.

## Must

- [x] Tests
- [ ] Documentation (not applicable)

## Verification

- `go test ./pkg/runtime`
- `bun run test:cli`
- `bun run build:platform`
- `bun run build:cli`