### PR TITLE
fix: reap exited function workers

### DIFF
--- a/cmd/sst/mosaic/aws/function.go
+++ b/cmd/sst/mosaic/aws/function.go
@@ -263,6 +263,7 @@ func function(ctx context.Context, input input) {
 		}
 		go func() {
 			logs := worker.Logs()
+			defer logs.Close()
 			scanner := bufio.NewScanner(logs)
 			for scanner.Scan() {
 				line := scanner.Text()

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -13,8 +14,16 @@ import (
 var (
 	lock     sync.Mutex
 	cmds     = []*exec.Cmd{}
+	managed  = map[*os.Process]*Managed{}
 	killWait = 5 * time.Second
 )
+
+// Managed owns the wait lifecycle for a started process.
+type Managed struct {
+	cmd  *exec.Cmd
+	done chan struct{}
+	stop sync.Mutex
+}
 
 func Command(name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(name, args...)
@@ -31,10 +40,72 @@ func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd 
 	return cmd
 }
 
+// Start starts cmd and immediately arranges for its process to be reaped.
+func Start(cmd *exec.Cmd) (*Managed, error) {
+	result := &Managed{
+		cmd:  cmd,
+		done: make(chan struct{}),
+	}
+	if cmd.Cancel != nil {
+		cmd.Cancel = func() error {
+			go result.Stop()
+			return nil
+		}
+	}
+
+	lock.Lock()
+	if err := cmd.Start(); err != nil {
+		untrackCommandLocked(cmd)
+		lock.Unlock()
+		return nil, err
+	}
+	managed[cmd.Process] = result
+	lock.Unlock()
+
+	go result.wait()
+	return result, nil
+}
+
+// Done is closed after the process has been reaped.
+func (m *Managed) Done() <-chan struct{} {
+	return m.done
+}
+
+// Stop terminates the process through its existing reaper.
+func (m *Managed) Stop() error {
+	if m == nil {
+		return nil
+	}
+
+	m.stop.Lock()
+	defer m.stop.Unlock()
+	select {
+	case <-m.done:
+		return nil
+	default:
+	}
+
+	slog.Info("killing process", "pid", m.cmd.Process.Pid)
+	return escalatingKill(m.cmd.Process, m.done)
+}
+
+func (m *Managed) wait() {
+	// The caller owns any pipe readers, so this is the sole wait for the command.
+	_ = m.cmd.Wait()
+	lock.Lock()
+	if owner, ok := managed[m.cmd.Process]; ok && owner == m {
+		delete(managed, m.cmd.Process)
+	}
+	untrackCommandLocked(m.cmd)
+	close(m.done)
+	lock.Unlock()
+}
+
 func reset() {
 	lock.Lock()
 	defer lock.Unlock()
 	cmds = []*exec.Cmd{}
+	managed = map[*os.Process]*Managed{}
 }
 
 func track(cmd *exec.Cmd) {
@@ -44,43 +115,64 @@ func track(cmd *exec.Cmd) {
 }
 
 func Cleanup() error {
+	type trackedProcess struct {
+		process *os.Process
+		managed *Managed
+	}
+
 	lock.Lock()
-	processes := make([]*exec.Cmd, len(cmds))
-	copy(processes, cmds)
-	lock.Unlock()
-
-	var wg sync.WaitGroup
-	errors := make(chan error, len(processes))
-
-	for _, cmd := range processes {
+	processes := make([]trackedProcess, 0, len(cmds))
+	for _, cmd := range cmds {
 		if cmd.Process == nil {
+			continue
+		}
+		owner := managed[cmd.Process]
+		if owner != nil {
+			processes = append(processes, trackedProcess{
+				process: cmd.Process,
+				managed: owner,
+			})
 			continue
 		}
 		if cmd.ProcessState != nil {
 			continue
 		}
+		processes = append(processes, trackedProcess{
+			process: cmd.Process,
+			managed: nil,
+		})
+	}
+	lock.Unlock()
 
+	var wg sync.WaitGroup
+	errorsCh := make(chan error, len(processes))
+
+	for _, item := range processes {
 		wg.Add(1)
-		go func(p *os.Process) {
+		go func(item trackedProcess) {
 			defer wg.Done()
-			if err := Kill(p); err != nil {
-				errors <- err
+			var err error
+			if item.managed != nil {
+				err = item.managed.Stop()
+			} else {
+				err = Kill(item.process)
 			}
-		}(cmd.Process)
+			if err != nil {
+				errorsCh <- err
+			}
+		}(item)
 	}
 
-	// Wait for all processes to be killed
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
-		close(errors)
+		close(errorsCh)
 	}()
 
 	select {
 	case <-done:
-		// Check for any errors
-		for err := range errors {
+		for err := range errorsCh {
 			if err != nil {
 				return err
 			}
@@ -95,8 +187,15 @@ func Kill(process *os.Process) error {
 	if process == nil {
 		return nil
 	}
-	slog.Info("killing process", "pid", process.Pid)
 
+	lock.Lock()
+	owner := managed[process]
+	lock.Unlock()
+	if owner != nil {
+		return owner.Stop()
+	}
+
+	slog.Info("killing process", "pid", process.Pid)
 	done := make(chan struct{})
 	go func() {
 		_, _ = process.Wait()
@@ -104,12 +203,20 @@ func Kill(process *os.Process) error {
 	}()
 
 	killErr := escalatingKill(process, done)
-	untrack(process.Pid)
+	untrackProcess(process)
 	return killErr
 }
 
 func escalatingKill(process *os.Process, done <-chan struct{}) error {
 	if err := sendTermSignal(process); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			select {
+			case <-done:
+				return nil
+			case <-time.After(killWait):
+				return os.ErrProcessDone
+			}
+		}
 		slog.Error("term signal failed, escalating", "pid", process.Pid, "err", err)
 		return forceKill(process, done)
 	}
@@ -125,6 +232,14 @@ func escalatingKill(process *os.Process, done <-chan struct{}) error {
 
 func forceKill(process *os.Process, done <-chan struct{}) error {
 	if err := sendKillSignal(process); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			select {
+			case <-done:
+				return nil
+			case <-time.After(killWait):
+				return os.ErrProcessDone
+			}
+		}
 		slog.Error("kill signal failed", "pid", process.Pid, "err", err)
 		return err
 	}
@@ -138,15 +253,25 @@ func forceKill(process *os.Process, done <-chan struct{}) error {
 	}
 }
 
-func untrack(pid int) {
+func untrackProcess(process *os.Process) {
 	lock.Lock()
 	defer lock.Unlock()
 	for i := len(cmds) - 1; i >= 0; i-- {
-		if cmds[i].Process != nil && cmds[i].Process.Pid == pid {
+		if cmds[i].Process == process {
 			cmds[i] = cmds[len(cmds)-1]
 			cmds = cmds[:len(cmds)-1]
 			return
 		}
 	}
-	slog.Info("process not found in tracked list", "pid", pid)
+	slog.Info("process not found in tracked list", "pid", process.Pid)
+}
+
+func untrackCommandLocked(cmd *exec.Cmd) {
+	for i := len(cmds) - 1; i >= 0; i-- {
+		if cmds[i] == cmd {
+			cmds[i] = cmds[len(cmds)-1]
+			cmds = cmds[:len(cmds)-1]
+			return
+		}
+	}
 }

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,7 +1,9 @@
 package process
 
 import (
+	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -97,6 +99,134 @@ func TestKillUntracksProcess(t *testing.T) {
 
 	if count != 0 {
 		t.Fatalf("expected 0 tracked commands after Kill, got %d", count)
+	}
+}
+
+func TestManagedNaturalExitIsReaped(t *testing.T) {
+	reset()
+	cmd := Command("true")
+	managed, err := Start(cmd)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	waitForDone(t, managed.Done())
+	if err := cmd.Process.Signal(os.Interrupt); err == nil {
+		t.Fatal("process still signalable after it was reaped")
+	}
+	assertTrackedCount(t, 0)
+}
+
+func TestManagedStopIsConcurrentAndIdempotent(t *testing.T) {
+	reset()
+	cmd := Command("sleep", "60")
+	managed, err := Start(cmd)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 10)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- managed.Stop()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Stop returned error: %v", err)
+		}
+	}
+	if err := managed.Stop(); err != nil {
+		t.Fatalf("repeated Stop returned error: %v", err)
+	}
+	waitForDone(t, managed.Done())
+	assertTrackedCount(t, 0)
+}
+
+func TestManagedStopRacesNaturalExit(t *testing.T) {
+	for range 20 {
+		reset()
+		cmd := Command("true")
+		managed, err := Start(cmd)
+		if err != nil {
+			t.Fatalf("failed to start: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		errs := make(chan error, 4)
+		for range 4 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- managed.Stop()
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("Stop returned error: %v", err)
+			}
+		}
+		waitForDone(t, managed.Done())
+	}
+}
+
+func TestCleanupStopsManagedProcess(t *testing.T) {
+	reset()
+	cmd := Command("sleep", "60")
+	managed, err := Start(cmd)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	if err := Cleanup(); err != nil {
+		t.Fatalf("Cleanup returned error: %v", err)
+	}
+	waitForDone(t, managed.Done())
+	assertTrackedCount(t, 0)
+}
+func TestManagedCommandContextCancellation(t *testing.T) {
+	reset()
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := CommandContext(ctx, "sleep", "60")
+	managed, err := Start(cmd)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-managed.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("managed command cancellation blocked on its own Wait")
+	}
+	assertTrackedCount(t, 0)
+}
+
+func waitForDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for process to be reaped")
+	}
+}
+
+func assertTrackedCount(t *testing.T, expected int) {
+	t.Helper()
+	lock.Lock()
+	defer lock.Unlock()
+	if len(cmds) != expected {
+		t.Fatalf("expected %d tracked commands, got %d", expected, len(cmds))
+	}
+	if len(managed) != expected {
+		t.Fatalf("expected %d managed commands, got %d", expected, len(managed))
 	}
 }
 

--- a/pkg/runtime/golang/golang.go
+++ b/pkg/runtime/golang/golang.go
@@ -3,10 +3,8 @@ package golang
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,38 +17,6 @@ import (
 type Runtime struct {
 	mut         sync.Mutex
 	directories map[string]string
-}
-
-type Worker struct {
-	stdout io.ReadCloser
-	stderr io.ReadCloser
-	cmd    *exec.Cmd
-}
-
-func (w *Worker) Stop() {
-	process.Kill(w.cmd.Process)
-}
-
-func (w *Worker) Logs() io.ReadCloser {
-	reader, writer := io.Pipe()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stdout)
-	}()
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stderr)
-	}()
-
-	go func() {
-		wg.Wait()
-		defer writer.Close()
-	}()
-
-	return reader
 }
 
 func New() *Runtime {
@@ -120,14 +86,7 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	cmd.Env = input.Env
 	cmd.Env = append(cmd.Env, "AWS_LAMBDA_RUNTIME_API="+input.Server)
 	cmd.Dir = input.Build.Out
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-	cmd.Start()
-	return &Worker{
-		stdout,
-		stderr,
-		cmd,
-	}, nil
+	return runtime.StartWorker(ctx, cmd)
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {

--- a/pkg/runtime/node/node.go
+++ b/pkg/runtime/node/node.go
@@ -3,10 +3,8 @@ package node
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -77,38 +75,6 @@ func New(version string) *Runtime {
 		version:     version,
 		concurrency: semaphore.NewWeighted(weight),
 	}
-}
-
-type Worker struct {
-	stdout io.ReadCloser
-	stderr io.ReadCloser
-	cmd    *exec.Cmd
-}
-
-func (w *Worker) Stop() {
-	process.Kill(w.cmd.Process)
-}
-
-func (w *Worker) Logs() io.ReadCloser {
-	reader, writer := io.Pipe()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stdout)
-	}()
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stderr)
-	}()
-
-	go func() {
-		wg.Wait()
-		defer writer.Close()
-	}()
-
-	return reader
 }
 
 type NodeProperties struct {
@@ -244,14 +210,7 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	cmd.Env = append(cmd.Env, "AWS_LAMBDA_RUNTIME_API="+input.Server)
 	slog.Info("starting worker", "server", input.Server)
 	cmd.Dir = input.Build.Out
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-	cmd.Start()
-	return &Worker{
-		stdout,
-		stderr,
-		cmd,
-	}, nil
+	return runtime.StartWorker(ctx, cmd)
 }
 
 func (r *Runtime) Match(runtime string) bool {

--- a/pkg/runtime/process.go
+++ b/pkg/runtime/process.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/sst/sst/v3/pkg/process"
+)
+
+const workerLogDrainIdle = time.Second
+
+type workerLogs struct {
+	*os.File
+	activity chan struct{}
+	done     chan struct{}
+	drained  sync.Once
+	closed   sync.Once
+	closeErr error
+}
+
+func newWorkerLogs(file *os.File) *workerLogs {
+	return &workerLogs{
+		File:     file,
+		activity: make(chan struct{}, 1),
+		done:     make(chan struct{}),
+	}
+}
+
+func (l *workerLogs) Read(p []byte) (int, error) {
+	n, err := l.File.Read(p)
+	if n > 0 {
+		select {
+		case l.activity <- struct{}{}:
+		default:
+		}
+	}
+	if err != nil {
+		l.markDrained()
+	}
+	return n, err
+}
+
+func (l *workerLogs) Close() error {
+	l.closed.Do(func() {
+		l.closeErr = l.File.Close()
+		l.markDrained()
+	})
+	return l.closeErr
+}
+
+func (l *workerLogs) drain() {
+	timer := time.NewTimer(workerLogDrainIdle)
+	defer timer.Stop()
+	for {
+		select {
+		case <-l.done:
+			_ = l.Close()
+			return
+		case <-l.activity:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(workerLogDrainIdle)
+		case <-timer.C:
+			_ = l.Close()
+			return
+		}
+	}
+}
+
+func (l *workerLogs) markDrained() {
+	l.drained.Do(func() {
+		close(l.done)
+	})
+}
+
+type processWorker struct {
+	logs    *workerLogs
+	managed *process.Managed
+}
+
+// StartWorker starts cmd and returns a worker whose process is always reaped.
+func StartWorker(ctx context.Context, cmd *exec.Cmd) (Worker, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	logs := newWorkerLogs(reader)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+
+	managed, err := process.Start(cmd)
+	_ = writer.Close()
+	if err != nil {
+		_ = logs.Close()
+		return nil, err
+	}
+
+	w := &processWorker{
+		logs:    logs,
+		managed: managed,
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = managed.Stop()
+			<-managed.Done()
+		case <-managed.Done():
+		}
+		logs.drain()
+	}()
+
+	return w, nil
+}
+
+func (w *processWorker) Stop() {
+	_ = w.managed.Stop()
+}
+
+func (w *processWorker) Logs() io.ReadCloser {
+	return w.logs
+}

--- a/pkg/runtime/process_test.go
+++ b/pkg/runtime/process_test.go
@@ -1,0 +1,167 @@
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sst/sst/v3/pkg/process"
+)
+
+func TestProcessWorkerNaturalExitDrainsLogs(t *testing.T) {
+	worker, err := StartWorker(context.Background(), processWorkerTestCommand("output"))
+	if err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	output, err := io.ReadAll(worker.Logs())
+	if err != nil {
+		t.Fatalf("failed to read logs: %v", err)
+	}
+	for _, expected := range []string{"stdout line", "stderr line"} {
+		if !strings.Contains(string(output), expected) {
+			t.Errorf("missing %q in logs %q", expected, output)
+		}
+	}
+
+	worker.Stop()
+	worker.Stop()
+}
+
+func TestProcessWorkerStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	worker, err := StartWorker(ctx, processWorkerTestCommand("block"))
+	if err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	cancel()
+	managed := worker.(*processWorker).managed
+	select {
+	case <-managed.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker was not reaped after context cancellation")
+	}
+	worker.Stop()
+}
+
+func TestProcessWorkerStopsWithoutLogConsumer(t *testing.T) {
+	worker, err := StartWorker(context.Background(), processWorkerTestCommand("flood"))
+	if err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		worker.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop blocked without a log consumer")
+	}
+	_ = worker.Logs().Close()
+}
+func TestProcessWorkerClosesLogsHeldByDescendant(t *testing.T) {
+	worker, err := StartWorker(context.Background(), processWorkerTestCommand("inherit"))
+	if err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	logs := worker.Logs()
+	defer logs.Close()
+	reader := bufio.NewReader(logs)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read descendant pid: %v", err)
+	}
+	var pid int
+	if _, err := fmt.Sscanf(line, "%d", &pid); err != nil {
+		t.Fatalf("failed to parse descendant pid from %q: %v", line, err)
+	}
+	descendant, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatalf("failed to find descendant: %v", err)
+	}
+	defer descendant.Kill()
+
+	drained := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, reader)
+		drained <- err
+	}()
+	select {
+	case <-drained:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker logs remained open after the worker exited")
+	}
+}
+
+func TestProcessWorkerConcurrentStop(t *testing.T) {
+	worker, err := StartWorker(context.Background(), processWorkerTestCommand("block"))
+	if err != nil {
+		t.Fatalf("failed to start worker: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker.Stop()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Stop calls blocked")
+	}
+}
+
+func TestProcessWorkerHelper(t *testing.T) {
+	if os.Getenv("SST_PROCESS_WORKER_DESCENDANT") == "1" {
+		time.Sleep(time.Minute)
+		return
+	}
+
+	switch os.Getenv("SST_PROCESS_WORKER_HELPER") {
+	case "output":
+		fmt.Fprintln(os.Stdout, "stdout line")
+		fmt.Fprintln(os.Stderr, "stderr line")
+	case "flood":
+		line := strings.Repeat("x", 256<<10)
+		fmt.Fprintln(os.Stdout, line)
+		fmt.Fprintln(os.Stderr, line)
+	case "block":
+		time.Sleep(time.Minute)
+	case "inherit":
+		cmd := exec.Command(os.Args[0], "-test.run=^TestProcessWorkerHelper$")
+		cmd.Env = append(os.Environ(), "SST_PROCESS_WORKER_DESCENDANT=1")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start descendant: %v", err)
+		}
+		fmt.Fprintln(os.Stdout, cmd.Process.Pid)
+	}
+}
+
+func processWorkerTestCommand(mode string) *exec.Cmd {
+	cmd := process.Command(os.Args[0], "-test.run=^TestProcessWorkerHelper$")
+	cmd.Env = append(os.Environ(), "SST_PROCESS_WORKER_HELPER="+mode)
+	return cmd
+}

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -29,36 +28,6 @@ var (
 	// Clear .deps/ once per SST run so workspace package changes are picked up
 	globalDepsCacheClearOnce sync.Once
 )
-
-type worker struct {
-	stdout io.ReadCloser
-	stderr io.ReadCloser
-	cmd    *exec.Cmd
-}
-
-func (w *worker) Stop() {
-	// Terminate the whole process group
-	process.Kill(w.cmd.Process)
-}
-
-func (w *worker) Logs() io.ReadCloser {
-	reader, writer := io.Pipe()
-
-	go func() {
-		defer writer.Close()
-		var wg sync.WaitGroup
-		for _, src := range []io.Reader{w.stdout, w.stderr} {
-			wg.Add(1)
-			go func(src io.Reader) {
-				defer wg.Done()
-				io.Copy(writer, src)
-			}(src)
-		}
-		wg.Wait()
-	}()
-
-	return reader
-}
 
 type PythonRuntime struct {
 	// concurrency limits total parallel builds across all functions.
@@ -167,8 +136,7 @@ func (r *PythonRuntime) Run(ctx context.Context, input *runtime.RunInput) (runti
 		workingDir = projectRoot
 	}
 
-	cmd := process.CommandContext(
-		ctx,
+	cmd := process.Command(
 		"uv",
 		"run",
 		lambdaBridgePath,
@@ -197,24 +165,11 @@ func (r *PythonRuntime) Run(ctx context.Context, input *runtime.RunInput) (runti
 
 	cmd.Env = env
 	cmd.Dir = workingDir
-	stdout, err := cmd.StdoutPipe()
+	worker, err := runtime.StartWorker(ctx, cmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create stdout pipe: %v", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stderr pipe: %v", err)
-	}
-
-	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start worker process: %v", err)
 	}
-
-	return &worker{
-		stdout,
-		stderr,
-		cmd,
-	}, nil
+	return worker, nil
 
 }
 

--- a/pkg/runtime/rust/rust.go
+++ b/pkg/runtime/rust/rust.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -21,38 +20,6 @@ import (
 type Runtime struct {
 	mut         sync.Mutex
 	directories map[string]string
-}
-
-type Worker struct {
-	stdout io.ReadCloser
-	stderr io.ReadCloser
-	cmd    *exec.Cmd
-}
-
-func (w *Worker) Stop() {
-	process.Kill(w.cmd.Process)
-}
-
-func (w *Worker) Logs() io.ReadCloser {
-	reader, writer := io.Pipe()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stdout)
-	}()
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(writer, w.stderr)
-	}()
-
-	go func() {
-		wg.Wait()
-		defer writer.Close()
-	}()
-
-	return reader
 }
 
 func New() *Runtime {
@@ -184,14 +151,7 @@ func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Wor
 	cmd.Env = append(cmd.Env, "AWS_LAMBDA_RUNTIME_API=http://"+input.Server)
 	cmd.Env = append(cmd.Env, "AWS_LAMBDA_FUNCTION_MEMORY_SIZE=1024")
 	cmd.Dir = input.Build.Out
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-	cmd.Start()
-	return &Worker{
-		stdout,
-		stderr,
-		cmd,
-	}, nil
+	return runtime.StartWorker(ctx, cmd)
 }
 
 func (r *Runtime) ShouldRebuild(functionID string, file string) bool {


### PR DESCRIPTION
## Summary
- centralize runtime worker process ownership so every started worker is reaped exactly once
- make worker stop, cleanup, and context cancellation share the managed lifecycle
- close worker log pipes after a bounded idle drain when descendants inherit stdout or stderr

Closes #6971

## Verification
- `go test ./pkg/process ./pkg/runtime`
- `go test -race ./pkg/process ./pkg/runtime`
- `bun run build:platform`
- `bun run build:cli`
- `bun run test:cli`
