### PR TITLE
docs(aws): clarify Vite preview environment

### DIFF
--- a/platform/src/components/aws/react.ts
+++ b/platform/src/components/aws/react.ts
@@ -124,6 +124,12 @@ export interface ReactArgs extends SsrSiteArgs {
    * 1. In `react-router build`, they are loaded into `process.env`.
    * 2. Locally while running `react-router dev` through `sst dev`.
    *
+   * Commands started by the build command inherit these variables. A standalone
+   * `vite preview` command runs outside SST; use
+   * `sst shell --target MyWeb -- vite preview` to expose them to the preview
+   * process. Client values in `import.meta.env` remain the values embedded by
+   * the build.
+   *
    * :::tip
    * You can also `link` resources to your React app and access them in a type-safe way with the [SDK](/docs/reference/sdk/). We recommend linking since it's more secure.
    * :::

--- a/platform/src/components/aws/tan-stack-start.ts
+++ b/platform/src/components/aws/tan-stack-start.ts
@@ -123,6 +123,12 @@ export interface TanStackStartArgs extends SsrSiteArgs {
    * 1. In `vite build`, they are loaded into `process.env`.
    * 2. Locally while running `sst dev`.
    *
+   * Commands started by the build command inherit these variables. A standalone
+   * `vite preview` command runs outside SST; use
+   * `sst shell --target MyWeb -- vite preview` to expose them to the preview
+   * process. Client values in `import.meta.env` remain the values embedded by
+   * the build.
+   *
    * :::tip
    * You can also `link` resources to your TanStack Start app and access them in a type-safe way with the [SDK](/docs/reference/sdk/). We recommend linking since it's more secure.
    * :::


### PR DESCRIPTION
## Summary

- clarify that commands spawned by the component build inherit its environment
- document how to run a separately started Vite preview with the component environment
- distinguish preview process variables from `import.meta.env` values embedded at build time

Closes #6877

## Verification

- `go test ./pkg/project -run '^TestEnvFor'`
- `bun run typecheck:platform`
- `bun run build:platform`
- `bun run docs:generate`

## Local environment note

`bun run --cwd platform test` is blocked by the current dependency/runtime environment: Vite cannot resolve `@types/node`, followed by Pulumi `ERR_TRACE_EVENTS_UNAVAILABLE` errors.