### PR TITLE
feat: Adds .NET as an aws lambda runtime and SDK support for C#

### DIFF
--- a/examples/aws-dotnet-project-based-apigw/.gitignore
+++ b/examples/aws-dotnet-project-based-apigw/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+
+# sst
+.sst

--- a/examples/aws-dotnet-project-based-apigw/package.json
+++ b/examples/aws-dotnet-project-based-apigw/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "aws-dotnet-project-based-apigw",
+  "module": "index.ts",
+  "type": "module",
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.146",
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "sst": "file:../../sdk/js"
+  },
+  "scripts": {
+    "dev": "bun sst dev"
+  }
+}

--- a/examples/aws-dotnet-project-based-apigw/src/Api.csproj
+++ b/examples/aws-dotnet-project-based-apigw/src/Api.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- this will break when not in this repo. -->
+    <ProjectReference Include="../../../sdk/csharp/src/SST.Sdk.csproj" />
+    <!-- <PackageReference Include="SST.Sdk" Version="0.1.0" /> -->
+  </ItemGroup>
+
+</Project>

--- a/examples/aws-dotnet-project-based-apigw/src/Program.cs
+++ b/examples/aws-dotnet-project-based-apigw/src/Program.cs
@@ -1,0 +1,16 @@
+using SST;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// On Lambda this replaces Kestrel with the Lambda runtime and translates API
+// Gateway V2 events into HTTP requests. Locally, `dotnet run` serves on Kestrel.
+builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+
+var app = builder.Build();
+
+app.MapGet("/", () => Results.Json(new { message = "home page", app = Resource.App.Name, stage = Resource.App.Stage }));
+app.MapGet("/hello", () => Results.Json(new { message = "hello world" }));
+app.MapGet("/my-ping", () => Results.Json(new { message = "pong" }));
+app.MapFallback(() => Results.Json(new { message = "not found" }, statusCode: StatusCodes.Status404NotFound));
+
+app.Run();

--- a/examples/aws-dotnet-project-based-apigw/sst.config.ts
+++ b/examples/aws-dotnet-project-based-apigw/sst.config.ts
@@ -1,0 +1,56 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * ## AWS ApiGatewayV2 .NET
+ *
+ * Runs an ASP.NET Core Minimal API behind API Gateway V2 using
+ * [`Amazon.Lambda.AspNetCoreServer.Hosting`](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.AspNetCoreServer.Hosting).
+ *
+ * :::tip
+ * One line swaps Kestrel for the Lambda runtime when the app runs on Lambda. Locally,
+ * `dotnet run` still serves the same app on Kestrel.
+ * :::
+ *
+ * So you write your API as you normally would.
+ *
+ * ```csharp title="src/Program.cs" {3}
+ * var builder = WebApplication.CreateBuilder(args);
+ *
+ * builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+ *
+ * var app = builder.Build();
+ *
+ * app.MapGet("/hello", () => Results.Json(new { message = "hello world" }));
+ *
+ * app.Run();
+ * ```
+ *
+ * And point the function at the project. The Lambda handler is the assembly name.
+ *
+ * ```ts title="sst.config.ts" {3,4}
+ * api.route("$default", {
+ *   handler: "./src",
+ *   runtime: "dotnet10",
+ * });
+ * ```
+ *
+ * The project is a regular `Microsoft.NET.Sdk.Web` project, so `sst dev` can build
+ * and run it [_Live_](/docs/live) as well.
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "aws-dotnet-project-based-apigw",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const api = new sst.aws.ApiGatewayV2("DotnetApi");
+
+    api.route("$default", {
+      handler: "./src",
+      runtime: "dotnet10",
+    });
+  },
+});

--- a/examples/aws-dotnet-project-based-apigw/tsconfig.json
+++ b/examples/aws-dotnet-project-based-apigw/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/examples/aws-lambda-dotnet-file-based/.gitignore
+++ b/examples/aws-lambda-dotnet-file-based/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+artifacts/
+
+# sst
+.sst

--- a/examples/aws-lambda-dotnet-file-based/package.json
+++ b/examples/aws-lambda-dotnet-file-based/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "aws-lambda-dotnet-file-based",
+  "module": "index.ts",
+  "type": "module",
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.146",
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "sst": "file:../../sdk/js"
+  },
+  "scripts": {
+    "dev": "bun sst dev"
+  }
+}

--- a/examples/aws-lambda-dotnet-file-based/src/Api.cs
+++ b/examples/aws-lambda-dotnet-file-based/src/Api.cs
@@ -1,0 +1,154 @@
+#:property TargetFramework=net10.0
+#:property PublishAot=false
+#:package Amazon.Lambda.Core@3.3.0
+#:package Amazon.Lambda.RuntimeSupport@2.2.0
+#:package Amazon.Lambda.APIGatewayEvents@3.0.1
+#:package Amazon.Lambda.Serialization.SystemTextJson@3.0.1
+#:package AWSSDK.DynamoDBv2@4.0.103.7
+// this will break when not in this repo.
+#:project ../../../sdk/csharp/src/SST.Sdk.csproj
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using SST;
+
+// The table name comes from `link: [table]` in sst.config.ts. Reading it at startup
+// means a broken link fails the cold start instead of the first request.
+var tableName = Resource.Get<string>("DotnetTable", "name");
+var dynamo = new Lazy<IAmazonDynamoDB>(() => new AmazonDynamoDBClient());
+var json = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+// Function URLs use the same payload as API Gateway V2, so its request type fits.
+Func<APIGatewayHttpApiV2ProxyRequest, ILambdaContext, Task<APIGatewayHttpApiV2ProxyResponse>> handler =
+    async (request, context) =>
+    {
+        var method = request.RequestContext?.Http?.Method ?? "GET";
+        var query = request.QueryStringParameters ?? new Dictionary<string, string>();
+
+        try
+        {
+            return (method, request.RawPath) switch
+            {
+                ("GET", "/") => Json(HttpStatusCode.OK, new
+                {
+                    message = "notes api",
+                    app = Resource.App.Name,
+                    stage = Resource.App.Stage,
+                    table = tableName,
+                }),
+                ("POST", "/notes") => await CreateNote(Body(request)),
+                ("GET", "/notes") when query.ContainsKey("noteId") => await GetNote(query),
+                ("GET", "/notes") => await ListNotes(query),
+                ("DELETE", "/notes") => await DeleteNote(query),
+                _ => Json(HttpStatusCode.NotFound, new { message = "not found" }),
+            };
+        }
+        catch (ArgumentException e)
+        {
+            return Json(HttpStatusCode.BadRequest, new { message = e.Message });
+        }
+    };
+
+// Executable assemblies talk to the Lambda Runtime API themselves. That is what
+// lets `sst dev` run the same file locally.
+await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+    .Build()
+    .RunAsync();
+
+async Task<APIGatewayHttpApiV2ProxyResponse> CreateNote(string body)
+{
+    var input = JsonSerializer.Deserialize<NoteInput>(body, json);
+    if (string.IsNullOrWhiteSpace(input?.UserId) || string.IsNullOrWhiteSpace(input.Content))
+    {
+        throw new ArgumentException("userId and content are required");
+    }
+
+    var note = new Note(input.UserId, Guid.NewGuid().ToString("N"), input.Content, DateTimeOffset.UtcNow.ToString("O"));
+    await dynamo.Value.PutItemAsync(new PutItemRequest
+    {
+        TableName = tableName,
+        Item = new Dictionary<string, AttributeValue>
+        {
+            ["userId"] = new(note.UserId),
+            ["noteId"] = new(note.NoteId),
+            ["content"] = new(note.Content),
+            ["createdAt"] = new(note.CreatedAt),
+        },
+    });
+    return Json(HttpStatusCode.Created, note);
+}
+
+async Task<APIGatewayHttpApiV2ProxyResponse> ListNotes(IDictionary<string, string> query)
+{
+    var userId = Require(query, "userId");
+    var response = await dynamo.Value.QueryAsync(new QueryRequest
+    {
+        TableName = tableName,
+        KeyConditionExpression = "userId = :userId",
+        ExpressionAttributeValues = new Dictionary<string, AttributeValue> { [":userId"] = new(userId) },
+    });
+    var notes = (response.Items ?? []).Select(ToNote).ToList();
+    return Json(HttpStatusCode.OK, new { userId, count = notes.Count, notes });
+}
+
+async Task<APIGatewayHttpApiV2ProxyResponse> GetNote(IDictionary<string, string> query)
+{
+    var response = await dynamo.Value.GetItemAsync(new GetItemRequest
+    {
+        TableName = tableName,
+        Key = Key(query),
+    });
+    return response.Item is { Count: > 0 } item
+        ? Json(HttpStatusCode.OK, ToNote(item))
+        : Json(HttpStatusCode.NotFound, new { message = "note not found" });
+}
+
+async Task<APIGatewayHttpApiV2ProxyResponse> DeleteNote(IDictionary<string, string> query)
+{
+    await dynamo.Value.DeleteItemAsync(new DeleteItemRequest
+    {
+        TableName = tableName,
+        Key = Key(query),
+    });
+    return Json(HttpStatusCode.OK, new { message = "note deleted" });
+}
+
+Dictionary<string, AttributeValue> Key(IDictionary<string, string> query) => new()
+{
+    ["userId"] = new(Require(query, "userId")),
+    ["noteId"] = new(Require(query, "noteId")),
+};
+
+static string Require(IDictionary<string, string> query, string name) =>
+    query.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value)
+        ? value
+        : throw new ArgumentException($"{name} query parameter is required");
+
+static string Body(APIGatewayHttpApiV2ProxyRequest request) =>
+    request.Body is null ? ""
+    : request.IsBase64Encoded ? Encoding.UTF8.GetString(Convert.FromBase64String(request.Body))
+    : request.Body;
+
+static Note ToNote(Dictionary<string, AttributeValue> item) => new(
+    item["userId"].S,
+    item["noteId"].S,
+    item.GetValueOrDefault("content")?.S ?? "",
+    item.GetValueOrDefault("createdAt")?.S ?? "");
+
+APIGatewayHttpApiV2ProxyResponse Json(HttpStatusCode status, object body) => new()
+{
+    StatusCode = (int)status,
+    Headers = new Dictionary<string, string> { ["Content-Type"] = "application/json" },
+    Body = JsonSerializer.Serialize(body, json),
+};
+
+record NoteInput(string? UserId, string? Content);
+
+record Note(string UserId, string NoteId, string Content, string CreatedAt);

--- a/examples/aws-lambda-dotnet-file-based/sst.config.ts
+++ b/examples/aws-lambda-dotnet-file-based/sst.config.ts
@@ -1,0 +1,83 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * ## AWS Lambda .NET file-based app with DynamoDB
+ *
+ * A .NET Lambda function written as a single C# file, using
+ * [file-based apps](https://learn.microsoft.com/dotnet/core/sdk/file-based-apps)
+ * from the .NET 10 SDK, that stores notes in a linked DynamoDB table. There is no
+ * `.csproj`; packages and build settings are declared with `#:` directives at the
+ * top of the file.
+ *
+ * ```csharp title="src/Api.cs"
+ * #:property PublishAot=false
+ * #:package Amazon.Lambda.RuntimeSupport@2.2.0
+ * #:package AWSSDK.DynamoDBv2@4.0.103.7
+ * ```
+ *
+ * We link the table to the function and point the function at the file. The Lambda
+ * handler is the file name, `Api`.
+ *
+ * ```ts title="sst.config.ts" {2,4}
+ * new sst.aws.Function("DotnetFunction", {
+ *   handler: "./src/Api.cs",
+ *   runtime: "dotnet10",
+ *   link: [table],
+ *   url: true,
+ * });
+ * ```
+ *
+ * The function reads the table name from the link with the SST .NET SDK and uses it
+ * with the DynamoDB client. The link also grants the function permissions on the table.
+ *
+ * ```csharp title="src/Api.cs" {1}
+ * var tableName = Resource.Get<string>("DotnetTable", "name");
+ *
+ * await dynamo.PutItemAsync(new PutItemRequest { TableName = tableName, Item = ... });
+ * ```
+ *
+ * Once deployed, exercise it through the function URL.
+ *
+ * ```bash
+ * curl "$URL/"                                   # reports the linked table name
+ * curl -X POST "$URL/notes" -d '{"userId":"u1","content":"hello"}'
+ * curl "$URL/notes?userId=u1"                    # lists u1's notes
+ * curl "$URL/notes?userId=u1&noteId=<noteId>"    # reads one
+ * curl -X DELETE "$URL/notes?userId=u1&noteId=<noteId>"
+ * ```
+ *
+ * The app bootstraps itself with `Amazon.Lambda.RuntimeSupport`, so `sst dev` can run
+ * the same file locally and still talk to the real table.
+ *
+ * :::note
+ * File-based apps need the .NET 10 SDK or later on the machine running `sst deploy`
+ * or `sst dev`.
+ * :::
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "aws-lambda-dotnet-file-based",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const table = new sst.aws.Dynamo("DotnetTable", {
+      fields: {
+        userId: "string",
+        noteId: "string",
+      },
+      primaryIndex: { hashKey: "userId", rangeKey: "noteId" },
+    });
+
+    const fn = new sst.aws.Function("DotnetFunction", {
+      handler: "./src/Api.cs",
+      runtime: "dotnet10",
+      link: [table],
+      url: true,
+    });
+
+    return { url: fn.url };
+  },
+});

--- a/examples/aws-lambda-dotnet-file-based/tsconfig.json
+++ b/examples/aws-lambda-dotnet-file-based/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/examples/aws-lambda-dotnet/.gitignore
+++ b/examples/aws-lambda-dotnet/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+
+# sst
+.sst

--- a/examples/aws-lambda-dotnet/src/Function.cs
+++ b/examples/aws-lambda-dotnet/src/Function.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using SST;
+
+// The function receives the raw event and returns the name of the linked bucket.
+var handler = (JsonElement request, ILambdaContext context) =>
+{
+    context.Logger.LogInformation($"Handling request {context.AwsRequestId} in {Resource.App.Name}/{Resource.App.Stage}");
+    return Task.FromResult(Resource.Get<string>("MyBucket", "name"));
+};
+
+// Executable assemblies talk to the Lambda Runtime API themselves. That is what
+// lets `sst dev` run the same binary locally.
+await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+    .Build()
+    .RunAsync();

--- a/examples/aws-lambda-dotnet/src/MyFunction.csproj
+++ b/examples/aws-lambda-dotnet/src/MyFunction.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.3.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- this will break when not in this repo. -->
+    <ProjectReference Include="../../../sdk/csharp/src/SST.Sdk.csproj" />
+    <!-- <PackageReference Include="SST.Sdk" Version="0.1.0" /> -->
+  </ItemGroup>
+
+</Project>

--- a/examples/aws-lambda-dotnet/sst.config.ts
+++ b/examples/aws-lambda-dotnet/sst.config.ts
@@ -1,0 +1,63 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * ## AWS Lambda .NET
+ *
+ * This example shows how to use the [`dotnet8`](https://dotnet.microsoft.com/) runtime in
+ * your Lambda functions.
+ *
+ * Our .NET project is in the `src` directory and we point to it in our function.
+ *
+ * ```ts title="sst.config.ts" {5}
+ * new sst.aws.Function("MyFunction", {
+ *   url: true,
+ *   runtime: "dotnet8",
+ *   link: [bucket],
+ *   handler: "./src",
+ * });
+ * ```
+ *
+ * The project is an executable assembly that bootstraps itself with
+ * `Amazon.Lambda.RuntimeSupport`. This is what lets `sst dev` run it
+ * [_Live_](/docs/live).
+ *
+ * ```csharp title="src/Function.cs"
+ * await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+ *   .Build()
+ *   .RunAsync();
+ * ```
+ *
+ * We are also linking it to an S3 bucket. We can reference the bucket in our function
+ * with the SST .NET SDK.
+ *
+ * ```csharp title="src/Function.cs" {1}
+ * using SST;
+ *
+ * var bucket = Resource.Get<string>("MyBucket", "name");
+ * ```
+ *
+ * The SDK lives in `sdk/csharp` and the example references it as a project.
+ *
+ * ```xml title="src/MyFunction.csproj"
+ * <ProjectReference Include="../../../sdk/csharp/src/SST.Sdk.csproj" />
+ * ```
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "aws-lambda-dotnet",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const bucket = new sst.aws.Bucket("MyBucket");
+
+    new sst.aws.Function("MyFunction", {
+      url: true,
+      runtime: "dotnet8",
+      link: [bucket],
+      handler: "./src",
+    });
+  },
+});

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sst/sst/v3/pkg/process"
 	"github.com/sst/sst/v3/pkg/project/provider"
 	"github.com/sst/sst/v3/pkg/runtime"
+	"github.com/sst/sst/v3/pkg/runtime/csharp"
 	"github.com/sst/sst/v3/pkg/runtime/golang"
 	"github.com/sst/sst/v3/pkg/runtime/node"
 	"github.com/sst/sst/v3/pkg/runtime/python"
@@ -197,6 +198,7 @@ func New(input *ProjectConfig) (*Project, error) {
 		pythonRuntime,
 		golang.New(),
 		rust.New(),
+		csharp.New(),
 	)
 
 	_, err := os.Stat(tmp)

--- a/pkg/runtime/csharp/csharp.go
+++ b/pkg/runtime/csharp/csharp.go
@@ -1,0 +1,452 @@
+package csharp
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/sst/sst/v3/pkg/process"
+	"github.com/sst/sst/v3/pkg/runtime"
+)
+
+// Runtime builds and runs .NET Lambda functions.
+//
+// It targets the managed Lambda runtimes (`dotnet8`, `dotnet10`) and expects the
+// handler to point at a project directory, a `.csproj` file, or a single-file
+// app (`app.cs`, .NET 10 SDK and later). Two project styles are supported:
+//
+//   - Executable assemblies (OutputType Exe using Amazon.Lambda.RuntimeSupport).
+//     The handler is just the path, e.g. `./src` or `./src/Api.cs`, and the
+//     Lambda handler string becomes the assembly name.
+//   - Class libraries. The handler is `{path}::{Namespace.Class}::{Method}` and the
+//     Lambda handler string becomes `{Assembly}::{Namespace.Class}::{Method}`.
+//
+// Live dev (`sst dev`) is only available for executable assemblies since those
+// can be started directly and speak the Lambda Runtime API on their own.
+type Runtime struct {
+	mut         sync.Mutex
+	directories map[string]string
+}
+
+type Worker struct {
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+	cmd    *exec.Cmd
+}
+
+func (w *Worker) Stop() {
+	process.Kill(w.cmd.Process)
+}
+
+func (w *Worker) Logs() io.ReadCloser {
+	reader, writer := io.Pipe()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(writer, w.stdout)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(writer, w.stderr)
+	}()
+
+	go func() {
+		wg.Wait()
+		defer writer.Close()
+	}()
+
+	return reader
+}
+
+func New() *Runtime {
+	return &Runtime{
+		directories: map[string]string{},
+	}
+}
+
+func (r *Runtime) Match(runtime string) bool {
+	return strings.HasPrefix(runtime, "dotnet")
+}
+
+type Properties struct {
+	Architecture string `json:"architecture"`
+}
+
+// Handler is the parsed form of the `handler` string.
+type Handler struct {
+	// Path is the project directory, .csproj file or file-based .cs app the user pointed at.
+	Path string
+	// Type is the fully qualified class name for class library handlers.
+	Type string
+	// Method is the method name for class library handlers.
+	Method string
+}
+
+// IsExecutable reports whether the handler refers to an executable assembly
+// rather than a class library method.
+func (h Handler) IsExecutable() bool {
+	return h.Type == ""
+}
+
+// ParseHandler splits the handler into its path and optional `::Type::Method`
+// suffix.
+func ParseHandler(handler string) (Handler, error) {
+	parts := strings.Split(handler, "::")
+	switch len(parts) {
+	case 1:
+		return Handler{Path: parts[0]}, nil
+	case 3:
+		if parts[1] == "" || parts[2] == "" {
+			return Handler{}, fmt.Errorf("invalid .NET handler %q: expected {path}::{Namespace.Class}::{Method}", handler)
+		}
+		return Handler{Path: parts[0], Type: parts[1], Method: parts[2]}, nil
+	default:
+		return Handler{}, fmt.Errorf("invalid .NET handler %q: expected {path} or {path}::{Namespace.Class}::{Method}", handler)
+	}
+}
+
+// ResolveProject locates what `dotnet publish` should build for the handler
+// path. The path can be a `.csproj`, a single-file `.cs` app, or a directory
+// containing exactly one project file.
+func ResolveProject(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("handler path %q not found: %w", path, err)
+	}
+	if !info.IsDir() {
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".csproj", ".cs":
+			return path, nil
+		}
+		return "", fmt.Errorf("handler path %q must be a directory, a .csproj file or a file-based .cs app", path)
+	}
+	matches, err := filepath.Glob(filepath.Join(path, "*.csproj"))
+	if err != nil {
+		return "", err
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no .csproj found in %q", path)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("multiple .csproj files found in %q, point the handler at one of them", path)
+	}
+}
+
+// Project is the subset of build settings the runtime needs from a `.csproj`
+// or from the `#:` directives of a file-based app.
+type Project struct {
+	// FileBased is true for single-file apps built directly from a `.cs` file.
+	FileBased    bool
+	sdk          string
+	assemblyName string
+	outputType   string
+}
+
+type csproj struct {
+	Sdk  string `xml:"Sdk,attr"`
+	Sdks []struct {
+		Name string `xml:"Name,attr"`
+	} `xml:"Sdk"`
+	PropertyGroups []struct {
+		AssemblyName string `xml:"AssemblyName"`
+		OutputType   string `xml:"OutputType"`
+	} `xml:"PropertyGroup"`
+}
+
+// executableSdks build an executable unless <OutputType> says otherwise.
+var executableSdks = map[string]bool{
+	"microsoft.net.sdk.web":    true,
+	"microsoft.net.sdk.worker": true,
+}
+
+// ReadProject parses the parts of a project we care about.
+func ReadProject(path string) (*Project, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(filepath.Ext(path), ".cs") {
+		return readFileBasedApp(data), nil
+	}
+	var parsed csproj
+	if err := xml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	project := &Project{sdk: parsed.Sdk}
+	for _, sdk := range parsed.Sdks {
+		if project.sdk == "" {
+			project.sdk = sdk.Name
+		}
+	}
+	for _, group := range parsed.PropertyGroups {
+		if project.assemblyName == "" {
+			project.assemblyName = strings.TrimSpace(group.AssemblyName)
+		}
+		if project.outputType == "" {
+			project.outputType = strings.TrimSpace(group.OutputType)
+		}
+	}
+	return project, nil
+}
+
+// readFileBasedApp picks up `#:property Name=Value` directives. File-based apps
+// are always executables.
+func readFileBasedApp(data []byte) *Project {
+	project := &Project{FileBased: true}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#:property") {
+			continue
+		}
+		kv := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(line, "#:property")), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(kv[0]), "AssemblyName") {
+			project.assemblyName = strings.TrimSpace(kv[1])
+		}
+	}
+	return project
+}
+
+// AssemblyName returns the explicit AssemblyName or falls back to the project
+// or source file name, mirroring MSBuild's default.
+func (p *Project) AssemblyName(path string) string {
+	if p.assemblyName != "" {
+		return p.assemblyName
+	}
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}
+
+// IsExecutable reports whether the project builds an executable. MSBuild
+// defaults to a class library when <OutputType> is not set, except for the Web
+// and Worker SDKs which default to an executable.
+func (p *Project) IsExecutable() bool {
+	if p.FileBased {
+		return true
+	}
+	switch strings.ToLower(p.outputType) {
+	case "exe", "winexe":
+		return true
+	case "":
+		// The Sdk attribute may carry a version, e.g. "Microsoft.NET.Sdk.Web/1.0".
+		sdk, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(p.sdk)), "/")
+		return executableSdks[sdk]
+	}
+	return false
+}
+
+// PublishArgs builds the `dotnet publish` arguments. Dev builds are Debug builds
+// for the host machine. Deploy builds are framework-dependent Release builds for
+// the Lambda architecture so the managed runtime can load them. Native AOT is
+// switched off in both cases: the managed runtimes can't run AOT output, and
+// file-based apps enable it by default.
+func PublishArgs(project string, out string, dev bool, architecture string) []string {
+	args := []string{"publish", project, "--nologo", "-o", out, "-p:PublishAot=false"}
+	if dev {
+		return append(args, "-c", "Debug")
+	}
+	rid := "linux-x64"
+	if architecture == "arm64" {
+		rid = "linux-arm64"
+	}
+	return append(args,
+		"-c", "Release",
+		"-r", rid,
+		"--self-contained", "false",
+		"-p:GenerateRuntimeConfigurationFiles=true",
+		// The Lambda handler is the assembly name, so the native apphost is dead weight.
+		"-p:UseAppHost=false",
+	)
+}
+
+func (r *Runtime) Build(ctx context.Context, input *runtime.BuildInput) (*runtime.BuildOutput, error) {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	var properties Properties
+	json.Unmarshal(input.Properties, &properties)
+
+	handler, err := ParseHandler(input.Handler)
+	if err != nil {
+		return nil, err
+	}
+	projectPath, err := ResolveProject(handler.Path)
+	if err != nil {
+		return nil, err
+	}
+	// The handler is relative to the app root but publish runs from the project
+	// directory, so resolve it first.
+	projectPath, err = filepath.Abs(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	project, err := ReadProject(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	assembly := project.AssemblyName(projectPath)
+
+	if handler.IsExecutable() && !project.IsExecutable() {
+		return &runtime.BuildOutput{
+			Errors: []string{fmt.Sprintf(
+				"%s is a class library. Either set <OutputType>Exe</OutputType> and use Amazon.Lambda.RuntimeSupport, or point the handler at a method: \"%s::{Namespace.Class}::{Method}\"",
+				filepath.Base(projectPath), input.Handler,
+			)},
+		}, nil
+	}
+	if !handler.IsExecutable() && input.Dev {
+		return &runtime.BuildOutput{
+			Errors: []string{fmt.Sprintf(
+				"sst dev needs an executable assembly to run %s locally. Set <OutputType>Exe</OutputType>, bootstrap it with Amazon.Lambda.RuntimeSupport and set the handler to \"%s\"",
+				filepath.Base(projectPath), handler.Path,
+			)},
+		}, nil
+	}
+
+	root := filepath.Dir(projectPath)
+	dotnet, err := exec.LookPath("dotnet")
+	if err != nil {
+		return &runtime.BuildOutput{
+			Errors: []string{
+				"dotnet was not found on your PATH. Install the .NET SDK from https://dotnet.microsoft.com/download (10 or later for file-based apps) and restart sst.",
+			},
+		}, nil
+	}
+	if project.FileBased {
+		if major, version, err := sdkVersion(dotnet, root); err == nil && major < 10 {
+			return &runtime.BuildOutput{
+				Errors: []string{fmt.Sprintf(
+					"%s is a file-based app, which needs the .NET 10 SDK or later. `dotnet --version` reports %s.",
+					filepath.Base(projectPath), version,
+				)},
+			}, nil
+		}
+	}
+	cmd := process.Command(dotnet, PublishArgs(projectPath, input.Out(), input.Dev, properties.Architecture)...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"DOTNET_CLI_TELEMETRY_OPTOUT=1",
+		"DOTNET_NOLOGO=1",
+		"DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1",
+	)
+	slog.Info("running dotnet publish", "cmd", cmd.Args)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return &runtime.BuildOutput{
+			Errors: []string{message},
+		}, nil
+	}
+	r.directories[input.FunctionID], _ = filepath.Abs(root)
+
+	lambdaHandler := assembly
+	if !handler.IsExecutable() {
+		lambdaHandler = assembly + "::" + handler.Type + "::" + handler.Method
+	}
+	return &runtime.BuildOutput{
+		Handler:    lambdaHandler,
+		Sourcemaps: []string{},
+		Errors:     []string{},
+		Out:        root,
+	}, nil
+}
+
+// sdkVersion reports the SDK that `dotnet --version` resolves to from the given
+// directory, which honors any global.json on the way up.
+func sdkVersion(dotnet string, dir string) (int, string, error) {
+	cmd := process.Command(dotnet, "--version")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "DOTNET_CLI_TELEMETRY_OPTOUT=1", "DOTNET_NOLOGO=1")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, "", err
+	}
+	return parseMajor(strings.TrimSpace(string(output)))
+}
+
+// parseMajor extracts the major version from a version string like "10.0.401".
+func parseMajor(version string) (int, string, error) {
+	var major int
+	if _, err := fmt.Sscanf(version, "%d.", &major); err != nil {
+		return 0, version, fmt.Errorf("unexpected dotnet version %q", version)
+	}
+	return major, version, nil
+}
+
+func (r *Runtime) Run(ctx context.Context, input *runtime.RunInput) (runtime.Worker, error) {
+	if strings.Contains(input.Build.Handler, "::") {
+		return nil, fmt.Errorf("sst dev only supports executable .NET assemblies, got handler %q", input.Build.Handler)
+	}
+	cmd := process.Command(
+		"dotnet",
+		filepath.Join(input.Build.Out, input.Build.Handler+".dll"),
+	)
+	slog.Info("running dotnet", "server", input.Server, "cmd", cmd.Args)
+	cmd.Env = input.Env
+	// Amazon.Lambda.RuntimeSupport prepends http:// itself.
+	cmd.Env = append(cmd.Env, "AWS_LAMBDA_RUNTIME_API="+input.Server)
+	cmd.Env = append(cmd.Env, "DOTNET_CLI_TELEMETRY_OPTOUT=1")
+	cmd.Dir = input.Build.Out
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &Worker{
+		stdout,
+		stderr,
+		cmd,
+	}, nil
+}
+
+var rebuildExtensions = map[string]bool{
+	".cs":      true,
+	".csproj":  true,
+	".props":   true,
+	".targets": true,
+}
+
+func (r *Runtime) ShouldRebuild(functionID string, file string) bool {
+	if !rebuildExtensions[strings.ToLower(filepath.Ext(file))] {
+		return false
+	}
+	match, ok := r.directories[functionID]
+	if !ok {
+		return false
+	}
+	rel, err := filepath.Rel(match, file)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return false
+	}
+	// MSBuild writes generated .cs files and publish output under obj/ and bin/.
+	// Rebuilding on those would loop forever.
+	for _, segment := range strings.Split(filepath.ToSlash(rel), "/") {
+		if segment == "bin" || segment == "obj" {
+			return false
+		}
+	}
+	slog.Info("checking if file needs to be rebuilt", "file", file, "match", match)
+	return true
+}
+
+// ShouldRunEagerly returns true for .NET - workers restart immediately after
+// rebuild. Like Go and Rust, rebuilds are scoped to the project directory that
+// changed.
+func (r *Runtime) ShouldRunEagerly() bool {
+	return true
+}

--- a/pkg/runtime/csharp/csharp_test.go
+++ b/pkg/runtime/csharp/csharp_test.go
@@ -1,0 +1,656 @@
+package csharp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sst/sst/v3/pkg/runtime"
+)
+
+func TestMatch(t *testing.T) {
+	r := New()
+	for _, name := range []string{"dotnet8", "dotnet10"} {
+		if !r.Match(name) {
+			t.Errorf("expected %q to match", name)
+		}
+	}
+	for _, name := range []string{"nodejs24.x", "go", "rust", "python3.13", "provided.al2023"} {
+		if r.Match(name) {
+			t.Errorf("expected %q not to match", name)
+		}
+	}
+}
+
+func TestParseHandler(t *testing.T) {
+	h, err := ParseHandler("./src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Path != "./src" || !h.IsExecutable() {
+		t.Errorf("unexpected handler %+v", h)
+	}
+
+	h, err = ParseHandler("./src::My.Functions.Handler::Handle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Path != "./src" || h.Type != "My.Functions.Handler" || h.Method != "Handle" || h.IsExecutable() {
+		t.Errorf("unexpected handler %+v", h)
+	}
+
+	for _, bad := range []string{"./src::Type", "./src::Type::Method::Extra", "./src::::Method"} {
+		if _, err := ParseHandler(bad); err == nil {
+			t.Errorf("expected %q to fail", bad)
+		}
+	}
+}
+
+func writeProject(t *testing.T, dir string, name string, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolveProject(t *testing.T) {
+	root := t.TempDir()
+
+	single := filepath.Join(root, "single")
+	want := writeProject(t, single, "Api.csproj", "<Project/>")
+	got, err := ResolveProject(single)
+	if err != nil || got != want {
+		t.Errorf("ResolveProject(dir) = %q, %v; want %q", got, err, want)
+	}
+	got, err = ResolveProject(want)
+	if err != nil || got != want {
+		t.Errorf("ResolveProject(file) = %q, %v; want %q", got, err, want)
+	}
+
+	if _, err := ResolveProject(filepath.Join(root, "empty-"+t.Name())); err == nil {
+		t.Error("expected missing path to fail")
+	}
+	empty := filepath.Join(root, "empty")
+	os.MkdirAll(empty, 0755)
+	if _, err := ResolveProject(empty); err == nil {
+		t.Error("expected directory without csproj to fail")
+	}
+
+	multi := filepath.Join(root, "multi")
+	writeProject(t, multi, "A.csproj", "<Project/>")
+	writeProject(t, multi, "B.csproj", "<Project/>")
+	if _, err := ResolveProject(multi); err == nil {
+		t.Error("expected directory with two csproj files to fail")
+	}
+
+	app := writeProject(t, filepath.Join(root, "app"), "Api.cs", "Console.WriteLine();")
+	got, err = ResolveProject(app)
+	if err != nil || got != app {
+		t.Errorf("ResolveProject(file-based app) = %q, %v; want %q", got, err, app)
+	}
+
+	other := writeProject(t, filepath.Join(root, "other"), "README.md", "")
+	if _, err := ResolveProject(other); err == nil {
+		t.Error("expected non-project file to fail")
+	}
+}
+
+func TestReadProject(t *testing.T) {
+	root := t.TempDir()
+
+	exe := writeProject(t, root, "MyFunction.csproj", `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>`)
+	p, err := ReadProject(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsExecutable() {
+		t.Error("expected Exe project to be executable")
+	}
+	if got := p.AssemblyName(exe); got != "MyFunction" {
+		t.Errorf("AssemblyName = %q, want MyFunction", got)
+	}
+
+	lib := writeProject(t, root, "Lib.csproj", `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <AssemblyName>Custom.Assembly</AssemblyName>
+  </PropertyGroup>
+</Project>`)
+	p, err = ReadProject(lib)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.IsExecutable() {
+		t.Error("expected project without OutputType to be a class library")
+	}
+	if got := p.AssemblyName(lib); got != "Custom.Assembly" {
+		t.Errorf("AssemblyName = %q, want Custom.Assembly", got)
+	}
+
+	web := writeProject(t, root, "Web.csproj", `<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>`)
+	p, err = ReadProject(web)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsExecutable() {
+		t.Error("expected Web SDK project without OutputType to be executable")
+	}
+
+	webLib := writeProject(t, root, "WebLib.csproj", `<Project Sdk="Microsoft.NET.Sdk.Web/1.0">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+</Project>`)
+	p, err = ReadProject(webLib)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.IsExecutable() {
+		t.Error("expected explicit Library OutputType to win over the Web SDK default")
+	}
+
+	worker := writeProject(t, root, "Worker.csproj", `<Project>
+  <Sdk Name="Microsoft.NET.Sdk.Worker" />
+  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+</Project>`)
+	p, err = ReadProject(worker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsExecutable() {
+		t.Error("expected Worker SDK element project to be executable")
+	}
+
+	broken := writeProject(t, root, "Broken.csproj", "<Project><PropertyGroup>")
+	if _, err := ReadProject(broken); err == nil {
+		t.Error("expected malformed csproj to fail")
+	}
+
+	app := writeProject(t, root, "Api.cs", `#:property PublishAot=false
+#:package Amazon.Lambda.RuntimeSupport@2.2.0
+
+Console.WriteLine("hi");
+`)
+	p, err = ReadProject(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.FileBased || !p.IsExecutable() {
+		t.Error("expected file-based app to be an executable")
+	}
+	if got := p.AssemblyName(app); got != "Api" {
+		t.Errorf("AssemblyName = %q, want Api", got)
+	}
+
+	named := writeProject(t, root, "tool.cs", `#:property   AssemblyName = MyTool
+#:property TargetFramework=net10.0
+`)
+	p, err = ReadProject(named)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := p.AssemblyName(named); got != "MyTool" {
+		t.Errorf("AssemblyName = %q, want MyTool", got)
+	}
+}
+
+func TestPublishArgs(t *testing.T) {
+	dev := strings.Join(PublishArgs("a.csproj", "/out", true, "x86_64"), " ")
+	if !strings.Contains(dev, "-c Debug") || strings.Contains(dev, "-r ") || !strings.Contains(dev, "PublishAot=false") {
+		t.Errorf("unexpected dev args: %s", dev)
+	}
+
+	x64 := strings.Join(PublishArgs("a.csproj", "/out", false, "x86_64"), " ")
+	for _, want := range []string{"publish a.csproj", "-o /out", "-c Release", "-r linux-x64", "--self-contained false", "GenerateRuntimeConfigurationFiles=true", "UseAppHost=false", "PublishAot=false"} {
+		if !strings.Contains(x64, want) {
+			t.Errorf("expected %q in %s", want, x64)
+		}
+	}
+
+	arm := strings.Join(PublishArgs("a.csproj", "/out", false, "arm64"), " ")
+	if !strings.Contains(arm, "-r linux-arm64") {
+		t.Errorf("unexpected arm64 args: %s", arm)
+	}
+}
+
+func TestShouldRebuild(t *testing.T) {
+	r := New()
+	root := filepath.Join(t.TempDir(), "src")
+	r.directories["fn"] = root
+
+	yes := []string{
+		filepath.Join(root, "Function.cs"),
+		filepath.Join(root, "Nested", "Handler.cs"),
+		filepath.Join(root, "MyFunction.csproj"),
+		filepath.Join(root, "Directory.Build.props"),
+	}
+	for _, f := range yes {
+		if !r.ShouldRebuild("fn", f) {
+			t.Errorf("expected rebuild for %s", f)
+		}
+	}
+
+	no := []string{
+		filepath.Join(root, "obj", "Debug", "net8.0", "MyFunction.GlobalUsings.g.cs"),
+		filepath.Join(root, "obj", "MyFunction.csproj.nuget.g.props"),
+		filepath.Join(root, "bin", "Debug", "net8.0", "MyFunction.dll"),
+		filepath.Join(root, "README.md"),
+		filepath.Join(filepath.Dir(root), "other", "Function.cs"),
+	}
+	for _, f := range no {
+		if r.ShouldRebuild("fn", f) {
+			t.Errorf("expected no rebuild for %s", f)
+		}
+	}
+
+	if r.ShouldRebuild("unknown", filepath.Join(root, "Function.cs")) {
+		t.Error("expected no rebuild for unknown function")
+	}
+}
+
+func TestBuildRejectsClassLibraryWithoutMethod(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "src")
+	writeProject(t, dir, "Lib.csproj", `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>`)
+
+	out, err := New().Build(context.Background(), &runtime.BuildInput{
+		FunctionID: "fn",
+		Handler:    dir,
+		Runtime:    "dotnet8",
+		CfgPath:    filepath.Join(root, "sst.config.ts"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Errors) != 1 || !strings.Contains(out.Errors[0], "class library") {
+		t.Errorf("expected class library error, got %+v", out)
+	}
+}
+
+func TestBuildRejectsClassLibraryInDev(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "src")
+	writeProject(t, dir, "Lib.csproj", `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>`)
+
+	out, err := New().Build(context.Background(), &runtime.BuildInput{
+		FunctionID: "fn",
+		Handler:    dir + "::My.Ns.Function::Handler",
+		Runtime:    "dotnet8",
+		Dev:        true,
+		CfgPath:    filepath.Join(root, "sst.config.ts"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Errors) != 1 || !strings.Contains(out.Errors[0], "sst dev") {
+		t.Errorf("expected dev mode error, got %+v", out)
+	}
+}
+
+func TestBuildReportsMissingDotnet(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	root := t.TempDir()
+	dir := filepath.Join(root, "src")
+	writeProject(t, dir, "App.csproj", `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType></PropertyGroup></Project>`)
+
+	out, err := New().Build(context.Background(), &runtime.BuildInput{
+		FunctionID: "fn",
+		Handler:    dir,
+		Runtime:    "dotnet10",
+		CfgPath:    filepath.Join(root, "sst.config.ts"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Errors) != 1 || !strings.Contains(out.Errors[0], "dotnet was not found on your PATH") {
+		t.Errorf("expected missing dotnet error, got %+v", out)
+	}
+}
+
+func TestParseMajor(t *testing.T) {
+	for version, want := range map[string]int{"10.0.401": 10, "8.0.425": 8, "9.0.100-preview.1": 9} {
+		major, _, err := parseMajor(version)
+		if err != nil || major != want {
+			t.Errorf("parseMajor(%q) = %d, %v; want %d", version, major, err, want)
+		}
+	}
+	if _, _, err := parseMajor("garbage"); err == nil {
+		t.Error("expected garbage version to fail")
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skip("could not find repo root")
+		}
+		dir = parent
+	}
+}
+
+// requireDotnet skips the test unless a .NET SDK of at least the given major
+// version is installed.
+func requireDotnet(t *testing.T, major int) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("dotnet"); err != nil {
+		t.Skip("dotnet not installed")
+	}
+	out, err := exec.Command("dotnet", "--list-sdks").Output()
+	if err != nil {
+		t.Skipf("dotnet --list-sdks failed: %v", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		var found int
+		if _, err := fmt.Sscanf(line, "%d.", &found); err == nil && found >= major {
+			return
+		}
+	}
+	t.Skipf(".NET %d SDK not installed", major)
+}
+
+// invoke runs the built function in dev mode against a fake Lambda Runtime API,
+// feeds it one event and returns what the function posted back. Errors are
+// prefixed so assertions on the body fail with a useful message.
+func invoke(t *testing.T, r *Runtime, build *runtime.BuildOutput, event string, env []string) string {
+	t.Helper()
+	responses := make(chan string, 1)
+	done := make(chan struct{})
+	invoked := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/lambda/w1/2018-06-01/runtime/invocation/next", func(w http.ResponseWriter, req *http.Request) {
+		if invoked {
+			<-done
+			return
+		}
+		invoked = true
+		w.Header().Set("Lambda-Runtime-Aws-Request-Id", "req-1")
+		w.Header().Set("Lambda-Runtime-Deadline-Ms", "9999999999999")
+		w.Header().Set("Lambda-Runtime-Invoked-Function-Arn", "arn:aws:lambda:us-east-1:123456789012:function:test")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(event))
+	})
+	mux.HandleFunc("/lambda/w1/2018-06-01/runtime/invocation/req-1/response", func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		responses <- string(body)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/lambda/w1/2018-06-01/runtime/invocation/req-1/error", func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		responses <- "ERROR: " + string(body)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/lambda/w1/2018-06-01/runtime/init/error", func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		responses <- "INIT ERROR: " + string(body)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(done) })
+	_, port, _ := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+
+	worker, err := r.Run(context.Background(), &runtime.RunInput{
+		Runtime:    "dotnet",
+		Server:     "127.0.0.1:" + port + "/lambda/w1",
+		FunctionID: "fn",
+		WorkerID:   "w1",
+		Build:      build,
+		Env: append(append(os.Environ(),
+			`SST_RESOURCE_App={"name":"example","stage":"test"}`,
+			"AWS_LAMBDA_FUNCTION_NAME=example-test-fn",
+			"AWS_LAMBDA_FUNCTION_MEMORY_SIZE=1024",
+		), env...),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(worker.Stop)
+	var logs strings.Builder
+	go io.Copy(&logs, worker.Logs())
+
+	select {
+	case body := <-responses:
+		return body
+	case <-time.After(90 * time.Second):
+		t.Fatalf("timed out waiting for the function to respond, logs:\n%s", logs.String())
+		return ""
+	}
+}
+
+// devBuild builds an example in dev mode and returns the output with Out set,
+// the way the runtime collection would.
+func devBuild(t *testing.T, r *Runtime, cfg string, id string, handler string, rt string) *runtime.BuildOutput {
+	t.Helper()
+	out, err := r.Build(context.Background(), &runtime.BuildInput{
+		FunctionID: id,
+		Handler:    handler,
+		Runtime:    rt,
+		Dev:        true,
+		CfgPath:    cfg,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Errors) > 0 {
+		t.Fatalf("build errors: %s", strings.Join(out.Errors, "\n"))
+	}
+	out.Out = (&runtime.BuildInput{CfgPath: cfg, FunctionID: id, Dev: true}).Out()
+	return out
+}
+
+// TestExampleBuildAndRun publishes the example function with the real dotnet SDK,
+// runs it in dev mode against a fake Lambda Runtime API and checks the
+// invocation round trip. It also checks a deploy build produces the files the
+// managed Lambda runtime needs. Skipped when dotnet is not installed.
+func TestExampleBuildAndRun(t *testing.T) {
+	requireDotnet(t, 8)
+	example := filepath.Join(findRepoRoot(t), "examples", "aws-lambda-dotnet")
+	if _, err := os.Stat(example); err != nil {
+		t.Skipf("example not found: %v", err)
+	}
+	// Keep artifacts out of the example's .sst directory.
+	cfg := filepath.Join(t.TempDir(), "sst.config.ts")
+	// The CLI runs from the app root and handlers are relative to it.
+	t.Chdir(example)
+
+	r := New()
+
+	t.Run("deploy build", func(t *testing.T) {
+		out, err := r.Build(context.Background(), &runtime.BuildInput{
+			FunctionID: "deploy",
+			Handler:    "./src",
+			Runtime:    "dotnet8",
+			Properties: json.RawMessage(`{"architecture":"arm64"}`),
+			CfgPath:    cfg,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Errors) > 0 {
+			t.Fatalf("build errors: %s", strings.Join(out.Errors, "\n"))
+		}
+		if out.Handler != "MyFunction" {
+			t.Errorf("Handler = %q, want MyFunction", out.Handler)
+		}
+		dir := (&runtime.BuildInput{CfgPath: cfg, FunctionID: "deploy"}).Out()
+		for _, f := range []string{"MyFunction.dll", "MyFunction.deps.json", "MyFunction.runtimeconfig.json", "Amazon.Lambda.RuntimeSupport.dll", "SST.Sdk.dll"} {
+			if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+				t.Errorf("missing %s in publish output", f)
+			}
+		}
+	})
+
+	t.Run("dev build and run", func(t *testing.T) {
+		out := devBuild(t, r, cfg, "dev", "./src", "dotnet8")
+
+		if !r.ShouldRebuild("dev", filepath.Join(example, "src", "Function.cs")) {
+			t.Error("expected source change to trigger rebuild")
+		}
+		if r.ShouldRebuild("dev", filepath.Join(example, "src", "obj", "Debug", "net8.0", "MyFunction.GlobalUsings.g.cs")) {
+			t.Error("expected generated file not to trigger rebuild")
+		}
+
+		body := invoke(t, r, out, `{"hello":"world"}`, []string{
+			`SST_RESOURCE_MyBucket={"name":"my-test-bucket"}`,
+		})
+		if body != `"my-test-bucket"` {
+			t.Errorf("unexpected response body %s", body)
+		}
+	})
+}
+
+// TestDotnet10Examples builds the .NET 10 examples, a file-based app with a
+// function URL and an ASP.NET Core project behind API Gateway V2, runs them in
+// dev mode and sends one event through the fake Runtime API. Both payloads use
+// the HTTP API v2 shape. Needs the .NET 10 SDK.
+func TestDotnet10Examples(t *testing.T) {
+	requireDotnet(t, 10)
+	root := findRepoRoot(t)
+
+	event := func(path string) string {
+		return `{
+		"version": "2.0",
+		"routeKey": "$default",
+		"rawPath": "` + path + `",
+		"rawQueryString": "",
+		"headers": {"host": "example.com", "user-agent": "test"},
+		"requestContext": {
+			"accountId": "123456789012",
+			"apiId": "api",
+			"domainName": "example.com",
+			"http": {"method": "GET", "path": "` + path + `", "protocol": "HTTP/1.1", "sourceIp": "127.0.0.1", "userAgent": "test"},
+			"requestId": "req-1",
+			"routeKey": "$default",
+			"stage": "$default",
+			"time": "12/Sep/2026:00:00:00 +0000",
+			"timeEpoch": 1789000000000
+		},
+		"isBase64Encoded": false
+	}`
+	}
+
+	cases := []struct {
+		name     string
+		example  string
+		handler  string
+		assembly string
+		path     string
+		env      []string
+		want     string
+	}{
+		{
+			name:     "file-based app",
+			example:  "aws-lambda-dotnet-file-based",
+			handler:  "./src/Api.cs",
+			assembly: "Api",
+			path:     "/",
+			// The home route reports the linked table name without calling DynamoDB.
+			env:  []string{`SST_RESOURCE_DotnetTable={"name":"test-notes-table"}`, "AWS_REGION=us-east-1"},
+			want: `"table":"test-notes-table"`,
+		},
+		{
+			name:     "project",
+			example:  "aws-dotnet-project-based-apigw",
+			handler:  "./src",
+			assembly: "Api",
+			path:     "/hello",
+			want:     "hello world",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			example := filepath.Join(root, "examples", tc.example)
+			if _, err := os.Stat(example); err != nil {
+				t.Skipf("example not found: %v", err)
+			}
+			cfg := filepath.Join(t.TempDir(), "sst.config.ts")
+			t.Chdir(example)
+			r := New()
+
+			out := devBuild(t, r, cfg, "api", tc.handler, "dotnet10")
+			if out.Handler != tc.assembly {
+				t.Errorf("Handler = %q, want %q", out.Handler, tc.assembly)
+			}
+			if !r.ShouldRebuild("api", filepath.Join(example, "src", "anything.cs")) {
+				t.Error("expected source change to trigger rebuild")
+			}
+
+			body := invoke(t, r, out, event(tc.path), tc.env)
+			var response struct {
+				StatusCode int    `json:"statusCode"`
+				Body       string `json:"body"`
+			}
+			if err := json.Unmarshal([]byte(body), &response); err != nil {
+				t.Fatalf("response is not an HTTP API v2 response: %s", body)
+			}
+			if response.StatusCode != 200 || !strings.Contains(response.Body, tc.want) {
+				t.Errorf("unexpected response %s", body)
+			}
+
+			// A deploy build must produce a framework-dependent layout the
+			// managed dotnet10 runtime can load.
+			deploy, err := r.Build(context.Background(), &runtime.BuildInput{
+				FunctionID: "deploy",
+				Handler:    tc.handler,
+				Runtime:    "dotnet10",
+				Properties: json.RawMessage(`{"architecture":"x86_64"}`),
+				CfgPath:    cfg,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(deploy.Errors) > 0 {
+				t.Fatalf("deploy build errors: %s", strings.Join(deploy.Errors, "\n"))
+			}
+			dir := (&runtime.BuildInput{CfgPath: cfg, FunctionID: "deploy"}).Out()
+			for _, f := range []string{tc.assembly + ".dll", tc.assembly + ".deps.json", tc.assembly + ".runtimeconfig.json", "SST.Sdk.dll"} {
+				if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+					t.Errorf("missing %s in publish output", f)
+				}
+			}
+			for _, f := range []string{tc.assembly, "web.config"} {
+				if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+					t.Errorf("unexpected %s in publish output", f)
+				}
+			}
+		})
+	}
+}

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -348,7 +348,7 @@ export interface FunctionArgs {
   /**
    * The language runtime for the function.
    *
-   * Node.js and Golang are officially supported. While, Python and Rust are
+   * Node.js and Golang are officially supported. While, Python, Rust and .NET are
    * community supported. Support for other runtimes are on the roadmap.
    *
    * @default `"nodejs24.x"`
@@ -375,6 +375,8 @@ export interface FunctionArgs {
     | "python3.12"
     | "python3.13"
     | "python3.14"
+    | "dotnet8"
+    | "dotnet10"
   >;
   /**
    * Path to the source code directory for the function. By default, the handler is
@@ -406,6 +408,7 @@ export interface FunctionArgs {
    * - For Python this is also `{path}/{file}.{method}`.
    * - For Golang this is `{path}` to the Go module.
    * - For Rust this is `{path}` to the Rust crate.
+   * - For .NET this is `{path}` to the project. Class library handlers add `::{Namespace.Class}::{Method}`.
    *
    * @example
    *
@@ -507,6 +510,59 @@ export interface FunctionArgs {
    *
    * Where `crates/api` is the path to the Rust crate. This means there is a
    * `Cargo.toml` file in `crates/api`, and the main() function handles the lambda.
+   *
+   * ##### .NET
+   *
+   * For .NET, the handler points to the project (.csproj) or a single C# file in the case of a file-based app (.cs).
+   *
+   * ```js
+   * {
+   *   handler: "packages/functions/dotnet/api"
+   * }
+   * ```
+   *
+   * Where `packages/functions/dotnet/api` is a directory with a single `.csproj` in it.
+   * You can also point at the `.csproj` file directly. SST runs `dotnet publish` on it,
+   * so you need the [.NET SDK](https://dotnet.microsoft.com/download) installed.
+   *
+   * With the .NET 10 SDK you can also point at a single-file
+   * [file-based app](https://learn.microsoft.com/dotnet/core/sdk/file-based-apps),
+   * where packages are declared with `#:package` directives instead of a `.csproj`.
+   *
+   * ```js
+   * {
+   *   handler: "packages/functions/dotnet/api.cs"
+   * }
+   * ```
+   *
+   * The project should be an executable assembly that bootstraps itself with
+   * [`Amazon.Lambda.RuntimeSupport`](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.RuntimeSupport).
+   * The Lambda handler is set to the assembly name. This style is required for
+   * `sst dev`, since the function is started locally and talks to the Lambda
+   * Runtime API on its own.
+   *
+   * ```xml title="api.csproj"
+   * <OutputType>Exe</OutputType>
+   * ```
+   *
+   * ```csharp title="Function.cs"
+   * await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
+   *   .Build()
+   *   .RunAsync();
+   * ```
+   *
+   * Class library projects can be deployed by pointing the handler at the method.
+   *
+   * ```js
+   * {
+   *   handler: "packages/functions/dotnet/api::Api.Function::Handler"
+   * }
+   * ```
+   *
+   * Here `Api.Function` is the fully qualified class and `Handler` is the method. The
+   * assembly name is read from the `.csproj`. Class libraries can't be run with `sst dev`.
+   *
+   * You can refer to [this example of deploying a .NET function](/docs/examples/#aws-lambda-net).
    */
   handler: Input<string>;
   /**
@@ -1589,6 +1645,18 @@ export interface FunctionArgs {
  *
  *   [Learn more below](#handler).
  *   </TabItem>
+ *   <TabItem label=".NET">
+ *   Pass in the directory where your `.csproj` lives.
+ *
+ *   ```ts title="sst.config.ts"
+ *   new sst.aws.Function("MyFunction", {
+ *     runtime: "dotnet8",
+ *     handler: "./src"
+ *   });
+ *   ```
+ *
+ *   [Learn more below](#handler).
+ *   </TabItem>
  * </Tabs>
  *
  * #### Set additional config
@@ -1665,6 +1733,19 @@ export interface FunctionArgs {
  *
  *   let resource = Resource::init().unwrap();
  *   let Bucket { name } = resource.get("Bucket").unwrap();
+ *   ```
+ *   </TabItem>
+ *   <TabItem label=".NET">
+ *   ```csharp title="src/Function.cs"
+ *   using SST;
+ *
+ *   var bucket = Resource.Get<string>("MyBucket", "name");
+ *   ```
+ *
+ *   Where the SDK project in `sdk/csharp` is referenced from your `.csproj`.
+ *
+ *   ```xml title="src/MyFunction.csproj"
+ *   <ProjectReference Include="../../sdk/csharp/src/SST.Sdk.csproj" />
  *   ```
  *   </TabItem>
  * </Tabs>
@@ -1896,39 +1977,41 @@ export class Function extends Component implements Link.Linkable {
         Function.encryptionKey().base64,
         args.link,
         args.streaming,
-        dev.apply((dev) => dev ? Function.appsync() : undefined),
-      ]).apply(([environment, dev, bootstrap, key, link, streaming, appsync]) => {
-        const result = environment ?? {};
-        result.SST_RESOURCE_App = JSON.stringify({
-          name: $app.name,
-          stage: $app.stage,
-        });
-        for (const linkable of link || []) {
-          if (!Link.isLinkable(linkable)) continue;
-          const def = linkable.getSSTLink();
-          for (const item of def.include || []) {
-            if (item.type === "environment") Object.assign(result, item.env);
+        dev.apply((dev) => (dev ? Function.appsync() : undefined)),
+      ]).apply(
+        ([environment, dev, bootstrap, key, link, streaming, appsync]) => {
+          const result = environment ?? {};
+          result.SST_RESOURCE_App = JSON.stringify({
+            name: $app.name,
+            stage: $app.stage,
+          });
+          for (const linkable of link || []) {
+            if (!Link.isLinkable(linkable)) continue;
+            const def = linkable.getSSTLink();
+            for (const item of def.include || []) {
+              if (item.type === "environment") Object.assign(result, item.env);
+            }
           }
-        }
-        result.SST_KEY = key;
-        result.SST_KEY_FILE = "resource.enc";
-        if (dev) {
-          result.SST_REGION = process.env.SST_AWS_REGION!;
-          result.SST_APPSYNC_HTTP = appsync.http;
-          result.SST_APPSYNC_REALTIME = appsync.realtime;
-          result.SST_FUNCTION_ID = name;
-          result.SST_APP = $app.name;
-          result.SST_STAGE = $app.stage;
-          result.SST_ASSET_BUCKET = bootstrap.asset;
-          if (process.env.SST_FUNCTION_TIMEOUT) {
-            result.SST_FUNCTION_TIMEOUT = process.env.SST_FUNCTION_TIMEOUT;
+          result.SST_KEY = key;
+          result.SST_KEY_FILE = "resource.enc";
+          if (dev) {
+            result.SST_REGION = process.env.SST_AWS_REGION!;
+            result.SST_APPSYNC_HTTP = appsync.http;
+            result.SST_APPSYNC_REALTIME = appsync.realtime;
+            result.SST_FUNCTION_ID = name;
+            result.SST_APP = $app.name;
+            result.SST_STAGE = $app.stage;
+            result.SST_ASSET_BUCKET = bootstrap.asset;
+            if (process.env.SST_FUNCTION_TIMEOUT) {
+              result.SST_FUNCTION_TIMEOUT = process.env.SST_FUNCTION_TIMEOUT;
+            }
+            if (streaming) {
+              result.SST_FUNCTION_STREAMING = "true";
+            }
           }
-          if (streaming) {
-            result.SST_FUNCTION_STREAMING = "true";
-          }
-        }
-        return result;
-      });
+          return result;
+        },
+      );
     }
 
     function normalizeStreaming() {
@@ -2070,9 +2153,7 @@ export class Function extends Component implements Link.Linkable {
       if (!args.durable) return;
       const config = args.durable === true ? {} : args.durable;
       return {
-        timeout: output(config.timeout).apply((v) =>
-          toSeconds(v ?? "14 days"),
-        ),
+        timeout: output(config.timeout).apply((v) => toSeconds(v ?? "14 days")),
         retention: output(config.retention).apply((v) =>
           toDays(v ?? "30 days"),
         ),
@@ -2447,7 +2528,9 @@ export class Function extends Component implements Link.Linkable {
               $cli.paths.work,
               "artifacts",
               dev
-                ? `dev-bridge-${regionName}-${logicalName(path.basename(bundle))}`
+                ? `dev-bridge-${regionName}-${logicalName(
+                    path.basename(bundle),
+                  )}`
                 : name,
               "code.zip",
             );
@@ -2547,7 +2630,9 @@ export class Function extends Component implements Link.Linkable {
 
             return new s3.BucketObjectv2(
               dev
-                ? `DevBridgeCode${logicalName(regionName)}${logicalName(path.basename(bundle))}`
+                ? `DevBridgeCode${logicalName(regionName)}${logicalName(
+                    path.basename(bundle),
+                  )}`
                 : `${name}Code`,
               {
                 key: dev

--- a/sdk/csharp/.gitignore
+++ b/sdk/csharp/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+TestResults/

--- a/sdk/csharp/README.md
+++ b/sdk/csharp/README.md
@@ -1,0 +1,105 @@
+# SST .NET SDK
+
+The .NET SDK for [SST](https://sst.dev) lets you access linked resources, like buckets, tables and secrets, in your .NET Lambda functions and container applications.
+
+## Installation
+
+The package is not published to NuGet yet. Until it is, reference the project from this repo.
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="../../sdk/csharp/src/SST.Sdk.csproj" />
+</ItemGroup>
+```
+
+Once published it will be installed like any other package.
+
+```bash
+dotnet add package SST.Sdk
+```
+
+The SDK targets `net8.0`, has no dependencies, and works with the `dotnet8` and `dotnet10` Lambda runtimes and with Native AOT.
+
+## Usage
+
+Link resources to your function in `sst.config.ts`.
+
+```ts
+const bucket = new sst.aws.Bucket("MyBucket");
+const secret = new sst.Secret("StripeKey");
+
+new sst.aws.Function("MyFunction", {
+  runtime: "dotnet8",
+  handler: "./src",
+  link: [bucket, secret],
+});
+```
+
+Then read them with `Resource` in your code.
+
+```csharp
+using SST;
+
+// A property of a linked resource
+var bucketName = Resource.Get<string>("MyBucket", "name");
+
+// Secrets are resources with a `value` property
+var stripeKey = Resource.Get<string>("StripeKey", "value");
+
+// Info about the current app
+Console.WriteLine($"{Resource.App.Name} / {Resource.App.Stage}");
+```
+
+Each resource is the JSON object described in the _Link_ section of that component's reference docs. You can read it as a whole, as a typed object, or as a raw `JsonElement`.
+
+```csharp
+public sealed record Bucket(string Name, string Arn);
+
+var bucket = Resource.Get<Bucket>("MyBucket");   // camelCase JSON maps to PascalCase properties
+var raw = Resource.Get("MyBucket");              // System.Text.Json.JsonElement
+var nested = Resource.Get<string>("MyApi", "auth", "type");
+
+if (Resource.TryGet("Optional", out var element)) { /* linked */ }
+
+foreach (var (name, value) in Resource.All()) { /* everything linked */ }
+```
+
+A resource that is not linked throws `ResourceNotFoundException`, with a message that names the resource and, on Lambda, the function. If the process was not started through SST at all, the message says so and suggests `sst dev -- <command>`.
+
+### Native AOT
+
+`Resource.Get<T>(name, ...)` uses reflection based deserialization. For Native AOT, pass source generated metadata instead.
+
+```csharp
+[JsonSerializable(typeof(Bucket))]
+internal partial class AppJsonContext : JsonSerializerContext { }
+
+var bucket = Resource.Get(AppJsonContext.Default.Bucket, "MyBucket");
+```
+
+`Resource.Get(name, ...)` returning `JsonElement`, `Resource.App`, `TryGet` and `All` are AOT safe as they are.
+
+## How it works
+
+SST passes linked resources to your code in two ways, and the SDK reads both.
+
+- On `sst deploy`, links are written to an encrypted `resource.enc` file next to your code. `SST_KEY_FILE` names the file and `SST_KEY` holds the AES-256-GCM key.
+- On `sst dev`, and for some components, links arrive as `SST_RESOURCE_{Name}` environment variables holding JSON. On Windows the consolidated `SST_RESOURCES_JSON` variable is used instead.
+
+Resources are read once, on first access, and cached for the life of the process.
+
+## Development
+
+```bash
+cd sdk/csharp
+dotnet test
+```
+
+The tests need the .NET 8 SDK or newer and no AWS access.
+
+## Links
+
+- [SST Documentation](https://sst.dev/docs/)
+- [SDK Reference](https://sst.dev/docs/reference/sdk/#net)
+- [.NET Example](https://github.com/anomalyco/sst/tree/dev/examples/aws-lambda-dotnet)
+- [GitHub](https://github.com/anomalyco/sst)

--- a/sdk/csharp/SST.Sdk.sln
+++ b/sdk/csharp/SST.Sdk.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SST.Sdk", "src\SST.Sdk.csproj", "{0F348FA2-F11E-476E-A62C-B5E2F752DFC6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SST.Sdk.Tests", "tests\SST.Sdk.Tests.csproj", "{511BEA16-9746-4A6D-B018-BF1EE9E24501}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0F348FA2-F11E-476E-A62C-B5E2F752DFC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F348FA2-F11E-476E-A62C-B5E2F752DFC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F348FA2-F11E-476E-A62C-B5E2F752DFC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F348FA2-F11E-476E-A62C-B5E2F752DFC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{511BEA16-9746-4A6D-B018-BF1EE9E24501}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{511BEA16-9746-4A6D-B018-BF1EE9E24501}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{511BEA16-9746-4A6D-B018-BF1EE9E24501}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{511BEA16-9746-4A6D-B018-BF1EE9E24501}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/sdk/csharp/src/Resource.cs
+++ b/sdk/csharp/src/Resource.cs
@@ -1,0 +1,198 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace SST;
+
+/// <summary>
+/// Access the resources linked to your function or container with <c>link: [...]</c>
+/// in <c>sst.config.ts</c>.
+/// </summary>
+/// <example>
+/// <code>
+/// var bucket = Resource.Get&lt;string&gt;("MyBucket", "name");
+/// var secret = Resource.Get&lt;string&gt;("MySecret", "value");
+/// var stage = Resource.App.Stage;
+/// </code>
+/// </example>
+public static class Resource
+{
+    private static readonly object Gate = new();
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+    private static IReadOnlyDictionary<string, JsonElement>? _resources;
+    private static IReadOnlyDictionary<string, string>? _environment;
+
+    /// <summary>
+    /// Info about the current app. Available in every linked function.
+    /// </summary>
+    public static App App
+    {
+        get
+        {
+            var app = Get("App");
+            return new App(
+                app.TryGetProperty("name", out var name) ? name.GetString() ?? "" : "",
+                app.TryGetProperty("stage", out var stage) ? stage.GetString() ?? "" : "");
+        }
+    }
+
+    /// <summary>
+    /// Returns a linked resource, or a property of it, as a raw <see cref="JsonElement"/>.
+    /// </summary>
+    /// <param name="name">The name of the resource in <c>sst.config.ts</c>, for example <c>MyBucket</c>.</param>
+    /// <param name="path">Optional property path, for example <c>"name"</c>.</param>
+    /// <exception cref="ResourceNotFoundException">The resource is not linked or the property does not exist.</exception>
+    public static JsonElement Get(string name, params string[] path)
+    {
+        var resources = Resources;
+        if (!resources.TryGetValue(name, out var current))
+        {
+            throw NotLinked(name);
+        }
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segment, out var next))
+            {
+                throw new ResourceNotFoundException($"\"{name}\" has no property \"{string.Join(".", path)}\"");
+            }
+            current = next;
+        }
+        return current;
+    }
+
+    /// <summary>
+    /// Returns a linked resource, or a property of it, deserialized to <typeparamref name="T"/>.
+    /// Property names are matched case-insensitively so <c>record Bucket(string Name)</c>
+    /// works with the camelCase properties SST produces.
+    /// </summary>
+    /// <exception cref="ResourceNotFoundException">The resource is not linked or the property does not exist.</exception>
+    /// <exception cref="ResourceException">The value is JSON <c>null</c> or cannot be deserialized to <typeparamref name="T"/>.</exception>
+    [RequiresUnreferencedCode("Uses reflection based JSON deserialization. For Native AOT use the overload that takes a JsonTypeInfo.")]
+    [RequiresDynamicCode("Uses reflection based JSON deserialization. For Native AOT use the overload that takes a JsonTypeInfo.")]
+    public static T Get<T>(string name, params string[] path)
+    {
+        var element = Get(name, path);
+        try
+        {
+            return JsonSerializer.Deserialize<T>(element, WebOptions) ?? throw Null(name, path);
+        }
+        catch (JsonException e)
+        {
+            throw new ResourceException($"Failed to deserialize {Describe(name, path)} to {typeof(T).Name}", e);
+        }
+    }
+
+    /// <summary>
+    /// Returns a linked resource, or a property of it, deserialized with source generated
+    /// metadata. Safe for Native AOT.
+    /// </summary>
+    /// <exception cref="ResourceNotFoundException">The resource is not linked or the property does not exist.</exception>
+    /// <exception cref="ResourceException">The value is JSON <c>null</c> or cannot be deserialized to <typeparamref name="T"/>.</exception>
+    public static T Get<T>(JsonTypeInfo<T> typeInfo, string name, params string[] path)
+    {
+        var element = Get(name, path);
+        try
+        {
+            return JsonSerializer.Deserialize(element, typeInfo) ?? throw Null(name, path);
+        }
+        catch (JsonException e)
+        {
+            throw new ResourceException($"Failed to deserialize {Describe(name, path)} to {typeof(T).Name}", e);
+        }
+    }
+
+    /// <summary>
+    /// Returns whether a resource is linked and, if so, its raw value.
+    /// </summary>
+    public static bool TryGet(string name, out JsonElement value) => Resources.TryGetValue(name, out value);
+
+    /// <summary>
+    /// Returns every linked resource keyed by name.
+    /// </summary>
+    public static IReadOnlyDictionary<string, JsonElement> All() => Resources;
+
+    /// <summary>
+    /// Drops the cached resources so the next access reads the environment again.
+    /// </summary>
+    internal static void Reload()
+    {
+        lock (Gate)
+        {
+            _resources = null;
+            _environment = null;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, JsonElement> Resources
+    {
+        get
+        {
+            lock (Gate)
+            {
+                if (_resources == null)
+                {
+                    _environment = ReadEnvironment();
+                    _resources = ResourceLoader.Load(_environment, ReadFile);
+                }
+                return _resources;
+            }
+        }
+    }
+
+    private static ResourceNotFoundException NotLinked(string name)
+    {
+        var env = _environment ?? ReadEnvironment();
+        if (!env.ContainsKey("SST_RESOURCE_App") && !env.ContainsKey("SST_RESOURCES_JSON"))
+        {
+            return new ResourceNotFoundException(
+                "It does not look like SST links are active. If this is in local development and you are not starting this process through the multiplexer, wrap your command with `sst dev -- <command>`");
+        }
+        var message = $"\"{name}\" is not linked in your sst.config.ts";
+        if (env.TryGetValue("AWS_LAMBDA_FUNCTION_NAME", out var function) && !string.IsNullOrEmpty(function))
+        {
+            message += $" to {function}";
+        }
+        return new ResourceNotFoundException(message);
+    }
+
+    private static ResourceException Null(string name, string[] path) =>
+        new($"{Describe(name, path)} is null");
+
+    private static string Describe(string name, string[] path) =>
+        path.Length == 0 ? $"\"{name}\"" : $"\"{name}.{string.Join(".", path)}\"";
+
+    /// <summary>
+    /// SST_KEY_FILE is relative to the function's working directory. Lambda starts in
+    /// /var/task, but fall back to the application directory in case the host does not.
+    /// </summary>
+    private static byte[]? ReadFile(string path)
+    {
+        if (File.Exists(path))
+        {
+            return File.ReadAllBytes(path);
+        }
+        var fallback = Path.Combine(AppContext.BaseDirectory, path);
+        return File.Exists(fallback) ? File.ReadAllBytes(fallback) : null;
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadEnvironment()
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && entry.Value is string value)
+            {
+                result[key] = value;
+            }
+        }
+        return result;
+    }
+}
+
+/// <summary>
+/// The current SST app.
+/// </summary>
+/// <param name="Name">The name of the app.</param>
+/// <param name="Stage">The stage the app is deployed to.</param>
+public sealed record App(string Name, string Stage);

--- a/sdk/csharp/src/ResourceException.cs
+++ b/sdk/csharp/src/ResourceException.cs
@@ -1,0 +1,28 @@
+namespace SST;
+
+/// <summary>
+/// Thrown when linked resources cannot be read or converted.
+/// </summary>
+public class ResourceException : Exception
+{
+    /// <inheritdoc />
+    public ResourceException(string message) : base(message)
+    {
+    }
+
+    /// <inheritdoc />
+    public ResourceException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when a resource is not linked to the function, or a requested property does not exist.
+/// </summary>
+public sealed class ResourceNotFoundException : ResourceException
+{
+    /// <inheritdoc />
+    public ResourceNotFoundException(string message) : base(message)
+    {
+    }
+}

--- a/sdk/csharp/src/ResourceLoader.cs
+++ b/sdk/csharp/src/ResourceLoader.cs
@@ -1,0 +1,143 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace SST;
+
+/// <summary>
+/// Reads linked resources the way SST hands them to the runtime. In order of precedence,
+/// lowest first:
+/// <list type="number">
+/// <item>The AES-256-GCM encrypted file named by <c>SST_KEY_FILE</c>, keyed by <c>SST_KEY</c>. This is
+/// how deployed functions receive links.</item>
+/// <item>Individual <c>SST_RESOURCE_{Name}</c> environment variables holding JSON.</item>
+/// <item>The consolidated <c>SST_RESOURCES_JSON</c> variable, used on Windows where variable
+/// names lose their casing.</item>
+/// </list>
+/// </summary>
+internal static class ResourceLoader
+{
+    internal const string Prefix = "SST_RESOURCE_";
+    private const int TagSize = 16;
+    private const int NonceSize = 12;
+
+    internal static Dictionary<string, JsonElement> Load(
+        IReadOnlyDictionary<string, string> environment,
+        Func<string, byte[]?> readFile)
+    {
+        var result = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        LoadEncryptedFile(result, environment, readFile);
+        LoadEnvironment(result, environment);
+        LoadConsolidated(result, environment);
+        return result;
+    }
+
+    private static void LoadEncryptedFile(
+        Dictionary<string, JsonElement> result,
+        IReadOnlyDictionary<string, string> environment,
+        Func<string, byte[]?> readFile)
+    {
+        if (!environment.TryGetValue("SST_KEY", out var key) || string.IsNullOrEmpty(key)) return;
+        if (!environment.TryGetValue("SST_KEY_FILE", out var file) || string.IsNullOrEmpty(file)) return;
+
+        // A missing file is not an error. Locally the links usually arrive through the
+        // environment instead, and the other SDKs skip it too.
+        var data = readFile(file);
+        if (data == null) return;
+
+        Dictionary<string, JsonElement> parsed;
+        try
+        {
+            parsed = Parse(Decrypt(Convert.FromBase64String(key), data));
+        }
+        catch (Exception e) when (e is FormatException or CryptographicException or JsonException or ArgumentException)
+        {
+            throw new ResourceException(
+                $"Failed to read SST links from {file}. Check that SST_KEY matches the key the file was encrypted with.", e);
+        }
+        foreach (var (name, value) in parsed)
+        {
+            result[name] = value;
+        }
+    }
+
+    private static void LoadEnvironment(
+        Dictionary<string, JsonElement> result,
+        IReadOnlyDictionary<string, string> environment)
+    {
+        foreach (var (name, value) in environment)
+        {
+            if (!name.StartsWith(Prefix, StringComparison.Ordinal) || string.IsNullOrEmpty(value)) continue;
+            try
+            {
+                using var document = JsonDocument.Parse(value);
+                result[name[Prefix.Length..]] = document.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                // Not something SST wrote. The JS SDK ignores these as well.
+            }
+        }
+    }
+
+    private static void LoadConsolidated(
+        Dictionary<string, JsonElement> result,
+        IReadOnlyDictionary<string, string> environment)
+    {
+        if (!environment.TryGetValue("SST_RESOURCES_JSON", out var json) || string.IsNullOrEmpty(json)) return;
+        try
+        {
+            foreach (var (name, value) in Parse(json))
+            {
+                result[name] = value;
+            }
+        }
+        catch (JsonException)
+        {
+            // Matches the other SDKs, which ignore an unparsable consolidated value.
+        }
+    }
+
+    /// <summary>
+    /// SST encrypts the links JSON with AES-256-GCM, a 12 byte zero nonce and the 16 byte
+    /// authentication tag appended to the ciphertext.
+    /// </summary>
+    internal static byte[] Decrypt(byte[] key, byte[] data)
+    {
+        if (data.Length < TagSize)
+        {
+            throw new CryptographicException("Encrypted data is shorter than the authentication tag");
+        }
+        var ciphertext = data.AsSpan(0, data.Length - TagSize);
+        var tag = data.AsSpan(data.Length - TagSize);
+        var plaintext = new byte[ciphertext.Length];
+        using var aes = new AesGcm(key, TagSize);
+        aes.Decrypt(new byte[NonceSize], ciphertext, tag, plaintext);
+        return plaintext;
+    }
+
+    private static Dictionary<string, JsonElement> Parse(byte[] json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return ToDictionary(document.RootElement);
+    }
+
+    private static Dictionary<string, JsonElement> Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return ToDictionary(document.RootElement);
+    }
+
+    private static Dictionary<string, JsonElement> ToDictionary(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("Expected a JSON object of resources");
+        }
+        var result = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var property in root.EnumerateObject())
+        {
+            result[property.Name] = property.Value.Clone();
+        }
+        return result;
+    }
+}

--- a/sdk/csharp/src/SST.Sdk.csproj
+++ b/sdk/csharp/src/SST.Sdk.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>SST</RootNamespace>
+    <AssemblyName>SST.Sdk</AssemblyName>
+    <PackageId>SST.Sdk</PackageId>
+    <Version>0.1.0</Version>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAotCompatible>true</IsAotCompatible>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Description>.NET SDK for SST — access linked resources in your SST app</Description>
+    <Authors>SST</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://sst.dev</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/anomalyco/sst</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>sst;serverless;aws;lambda;infrastructure</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="/" />
+    <InternalsVisibleTo Include="SST.Sdk.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/csharp/tests/Crypto.cs
+++ b/sdk/csharp/tests/Crypto.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SST.Tests;
+
+/// <summary>
+/// Produces files in the same shape as the SST CLI: AES-256-GCM, zero nonce, tag appended.
+/// </summary>
+internal static class Crypto
+{
+    internal static readonly byte[] Key = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+    internal static string KeyBase64 => Convert.ToBase64String(Key);
+
+    internal static byte[] Encrypt(string json, byte[]? key = null)
+    {
+        var plaintext = Encoding.UTF8.GetBytes(json);
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[16];
+        using var aes = new AesGcm(key ?? Key, 16);
+        aes.Encrypt(new byte[12], plaintext, ciphertext, tag);
+        return [.. ciphertext, .. tag];
+    }
+}

--- a/sdk/csharp/tests/ResourceLoaderTests.cs
+++ b/sdk/csharp/tests/ResourceLoaderTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using Xunit;
+
+namespace SST.Tests;
+
+/// <summary>
+/// Exercises the loader with plain dictionaries so nothing here touches the process environment.
+/// </summary>
+public class ResourceLoaderTests
+{
+    private static readonly Func<string, byte[]?> NoFiles = _ => null;
+
+    private static Dictionary<string, JsonElement> Load(Dictionary<string, string> env, Func<string, byte[]?>? readFile = null) =>
+        ResourceLoader.Load(env, readFile ?? NoFiles);
+
+    [Fact]
+    public void LoadsIndividualResourceVariables()
+    {
+        var resources = Load(new()
+        {
+            ["SST_RESOURCE_MyBucket"] = """{"name":"my-bucket","type":"aws.s3.Bucket"}""",
+            ["SST_RESOURCE_MyTable"] = """{"name":"my-table"}""",
+        });
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("my-bucket", resources["MyBucket"].GetProperty("name").GetString());
+        Assert.Equal("my-table", resources["MyTable"].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void IgnoresUnrelatedEmptyAndInvalidVariables()
+    {
+        var resources = Load(new()
+        {
+            ["PATH"] = "/usr/bin",
+            ["NOT_SST"] = """{"name":"nope"}""",
+            ["SST_RESOURCE_Empty"] = "",
+            ["SST_RESOURCE_Broken"] = "not-json",
+            ["SST_RESOURCE_Ok"] = """{"value":"yes"}""",
+        });
+
+        Assert.Single(resources);
+        Assert.Equal("yes", resources["Ok"].GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public void LoadsConsolidatedJson()
+    {
+        var resources = Load(new()
+        {
+            ["SST_RESOURCES_JSON"] = """{"MyBucket":{"name":"my-bucket"},"App":{"name":"app","stage":"dev"}}""",
+        });
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("my-bucket", resources["MyBucket"].GetProperty("name").GetString());
+        Assert.Equal("dev", resources["App"].GetProperty("stage").GetString());
+    }
+
+    [Fact]
+    public void ConsolidatedJsonMergesWithAndOverridesIndividualVariables()
+    {
+        var resources = Load(new()
+        {
+            ["SST_RESOURCE_MyTable"] = """{"name":"my-table"}""",
+            ["SST_RESOURCE_MyBucket"] = """{"name":"from-env-var"}""",
+            ["SST_RESOURCES_JSON"] = """{"MyBucket":{"name":"from-json"}}""",
+        });
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("my-table", resources["MyTable"].GetProperty("name").GetString());
+        Assert.Equal("from-json", resources["MyBucket"].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void InvalidConsolidatedJsonIsIgnored()
+    {
+        var resources = Load(new()
+        {
+            ["SST_RESOURCE_MyTable"] = """{"name":"my-table"}""",
+            ["SST_RESOURCES_JSON"] = "not-json",
+        });
+
+        Assert.Single(resources);
+        Assert.True(resources.ContainsKey("MyTable"));
+    }
+
+    [Fact]
+    public void LoadsEncryptedFile()
+    {
+        var file = Crypto.Encrypt("""{"EncryptedBucket":{"name":"encrypted-bucket"},"EncryptedQueue":{"url":"https://sqs"}}""");
+        var resources = Load(new()
+        {
+            ["SST_KEY"] = Crypto.KeyBase64,
+            ["SST_KEY_FILE"] = "resource.enc",
+        }, path => path == "resource.enc" ? file : null);
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("encrypted-bucket", resources["EncryptedBucket"].GetProperty("name").GetString());
+        Assert.Equal("https://sqs", resources["EncryptedQueue"].GetProperty("url").GetString());
+    }
+
+    [Fact]
+    public void EnvironmentOverridesEncryptedFile()
+    {
+        var file = Crypto.Encrypt("""{"Shared":{"name":"from-file"},"OnlyFile":{"name":"file"}}""");
+        var resources = Load(new()
+        {
+            ["SST_KEY"] = Crypto.KeyBase64,
+            ["SST_KEY_FILE"] = "resource.enc",
+            ["SST_RESOURCE_Shared"] = """{"name":"from-env"}""",
+        }, _ => file);
+
+        Assert.Equal(2, resources.Count);
+        Assert.Equal("from-env", resources["Shared"].GetProperty("name").GetString());
+        Assert.Equal("file", resources["OnlyFile"].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void MissingEncryptedFileIsSkipped()
+    {
+        var resources = Load(new()
+        {
+            ["SST_KEY"] = Crypto.KeyBase64,
+            ["SST_KEY_FILE"] = "resource.enc",
+            ["SST_RESOURCE_MyBucket"] = """{"name":"my-bucket"}""",
+        });
+
+        Assert.Single(resources);
+        Assert.True(resources.ContainsKey("MyBucket"));
+    }
+
+    [Fact]
+    public void OnlyKeyWithoutFileIsSkipped()
+    {
+        var resources = Load(new()
+        {
+            ["SST_KEY"] = Crypto.KeyBase64,
+        }, _ => throw new InvalidOperationException("should not read"));
+
+        Assert.Empty(resources);
+    }
+
+    [Fact]
+    public void WrongKeyThrowsResourceException()
+    {
+        var file = Crypto.Encrypt("""{"MyBucket":{"name":"my-bucket"}}""");
+        var wrongKey = Convert.ToBase64String(new byte[32]);
+
+        var error = Assert.Throws<ResourceException>(() => Load(new()
+        {
+            ["SST_KEY"] = wrongKey,
+            ["SST_KEY_FILE"] = "resource.enc",
+        }, _ => file));
+
+        Assert.Contains("resource.enc", error.Message);
+        Assert.NotNull(error.InnerException);
+    }
+
+    [Fact]
+    public void MalformedKeyThrowsResourceException()
+    {
+        var file = Crypto.Encrypt("""{"MyBucket":{"name":"my-bucket"}}""");
+
+        Assert.Throws<ResourceException>(() => Load(new()
+        {
+            ["SST_KEY"] = "%%not-base64%%",
+            ["SST_KEY_FILE"] = "resource.enc",
+        }, _ => file));
+    }
+
+    [Fact]
+    public void DecryptRoundTrips()
+    {
+        var plaintext = ResourceLoader.Decrypt(Crypto.Key, Crypto.Encrypt("""{"a":1}"""));
+
+        Assert.Equal("""{"a":1}""", System.Text.Encoding.UTF8.GetString(plaintext));
+    }
+
+    [Fact]
+    public void EmptyEnvironmentYieldsNoResources()
+    {
+        Assert.Empty(Load(new()));
+    }
+}

--- a/sdk/csharp/tests/ResourceTests.cs
+++ b/sdk/csharp/tests/ResourceTests.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace SST.Tests;
+
+/// <summary>
+/// Goes through the static <see cref="Resource"/> facade, so these tests set real environment
+/// variables and clean up after themselves. Parallelization is disabled for the assembly.
+/// </summary>
+public sealed class ResourceTests : IDisposable
+{
+    private readonly List<string> _variables = new();
+    private readonly List<string> _files = new();
+
+    public ResourceTests()
+    {
+        // Make sure nothing from the host environment leaks into the tests.
+        foreach (var key in Environment.GetEnvironmentVariables().Keys.OfType<string>())
+        {
+            if (key.StartsWith("SST_", StringComparison.Ordinal) || key == "AWS_LAMBDA_FUNCTION_NAME")
+            {
+                Set(key, null);
+            }
+        }
+        Set("SST_RESOURCE_App", """{"name":"my-app","stage":"dev"}""");
+    }
+
+    private void Set(string name, string? value)
+    {
+        _variables.Add(name);
+        Environment.SetEnvironmentVariable(name, value);
+        Resource.Reload();
+    }
+
+    public void Dispose()
+    {
+        foreach (var name in _variables.Distinct())
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+        foreach (var file in _files)
+        {
+            File.Delete(file);
+        }
+        Resource.Reload();
+    }
+
+    [Fact]
+    public void GetReturnsRawElement()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"my-bucket"}""");
+
+        var bucket = Resource.Get("MyBucket");
+
+        Assert.Equal(JsonValueKind.Object, bucket.ValueKind);
+        Assert.Equal("my-bucket", bucket.GetProperty("name").GetString());
+        Assert.Equal("my-bucket", Resource.Get("MyBucket", "name").GetString());
+    }
+
+    [Fact]
+    public void GetNavigatesNestedProperties()
+    {
+        Set("SST_RESOURCE_MyApi", """{"url":"https://api","auth":{"type":"iam","roles":["a","b"]}}""");
+
+        Assert.Equal("iam", Resource.Get<string>("MyApi", "auth", "type"));
+        Assert.Equal(new[] { "a", "b" }, Resource.Get<string[]>("MyApi", "auth", "roles"));
+    }
+
+    [Fact]
+    public void GetDeserializesTypedValues()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"my-bucket","arn":"arn:aws:s3:::my-bucket"}""");
+        Set("SST_RESOURCE_MyConfig", """{"retries":3,"enabled":true}""");
+
+        var bucket = Resource.Get<Bucket>("MyBucket");
+        Assert.Equal("my-bucket", bucket.Name);
+        Assert.Equal("arn:aws:s3:::my-bucket", bucket.Arn);
+        Assert.Equal(3, Resource.Get<int>("MyConfig", "retries"));
+        Assert.True(Resource.Get<bool>("MyConfig", "enabled"));
+    }
+
+    [Fact]
+    public void GetWithTypeInfoDeserializesWithoutReflection()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"my-bucket","arn":"arn"}""");
+
+        var bucket = Resource.Get(TestJsonContext.Default.Bucket, "MyBucket");
+
+        Assert.Equal("my-bucket", bucket.Name);
+    }
+
+    [Fact]
+    public void SecretsAreReadLikeAnyResource()
+    {
+        Set("SST_RESOURCE_MySecret", """{"value":"s3cret"}""");
+
+        Assert.Equal("s3cret", Resource.Get<string>("MySecret", "value"));
+    }
+
+    [Fact]
+    public void AppExposesNameAndStage()
+    {
+        var app = Resource.App;
+
+        Assert.Equal("my-app", app.Name);
+        Assert.Equal("dev", app.Stage);
+    }
+
+    [Fact]
+    public void TryGetAndAll()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"my-bucket"}""");
+
+        Assert.True(Resource.TryGet("MyBucket", out var bucket));
+        Assert.Equal("my-bucket", bucket.GetProperty("name").GetString());
+        Assert.False(Resource.TryGet("Nope", out _));
+        Assert.Equal(new[] { "App", "MyBucket" }, Resource.All().Keys.OrderBy(k => k));
+    }
+
+    [Fact]
+    public void MissingResourceNamesTheFunction()
+    {
+        Set("AWS_LAMBDA_FUNCTION_NAME", "my-function");
+
+        var error = Assert.Throws<ResourceNotFoundException>(() => Resource.Get("MyBucket"));
+
+        Assert.Equal("\"MyBucket\" is not linked in your sst.config.ts to my-function", error.Message);
+    }
+
+    [Fact]
+    public void MissingResourceWithoutFunctionName()
+    {
+        var error = Assert.Throws<ResourceNotFoundException>(() => Resource.Get<string>("MyBucket", "name"));
+
+        Assert.Equal("\"MyBucket\" is not linked in your sst.config.ts", error.Message);
+    }
+
+    [Fact]
+    public void MissingPropertyIsReported()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"my-bucket"}""");
+
+        var error = Assert.Throws<ResourceNotFoundException>(() => Resource.Get("MyBucket", "arn"));
+
+        Assert.Contains("has no property \"arn\"", error.Message);
+    }
+
+    [Fact]
+    public void NullValueIsReported()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":null}""");
+
+        var error = Assert.Throws<ResourceException>(() => Resource.Get<string>("MyBucket", "name"));
+
+        Assert.Contains("is null", error.Message);
+    }
+
+    [Fact]
+    public void ExplainsWhenLinksAreNotActive()
+    {
+        Set("SST_RESOURCE_App", null);
+
+        var error = Assert.Throws<ResourceNotFoundException>(() => Resource.Get("MyBucket"));
+
+        Assert.StartsWith("It does not look like SST links are active", error.Message);
+    }
+
+    [Fact]
+    public void ConsolidatedJsonCountsAsActiveLinks()
+    {
+        Set("SST_RESOURCE_App", null);
+        Set("SST_RESOURCES_JSON", """{"MyBucket":{"name":"my-bucket"},"App":{"name":"app","stage":"prod"}}""");
+
+        Assert.Equal("my-bucket", Resource.Get<string>("MyBucket", "name"));
+        Assert.Equal("prod", Resource.App.Stage);
+        var error = Assert.Throws<ResourceNotFoundException>(() => Resource.Get("Other"));
+        Assert.Equal("\"Other\" is not linked in your sst.config.ts", error.Message);
+    }
+
+    [Fact]
+    public void ReadsEncryptedKeyFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sst-{Guid.NewGuid():N}.enc");
+        File.WriteAllBytes(path, Crypto.Encrypt("""{"MyBucket":{"name":"encrypted-bucket"}}"""));
+        _files.Add(path);
+        Set("SST_KEY", Crypto.KeyBase64);
+        Set("SST_KEY_FILE", path);
+
+        Assert.Equal("encrypted-bucket", Resource.Get<string>("MyBucket", "name"));
+    }
+
+    [Fact]
+    public void ReadsEncryptedKeyFileRelativeToApplicationDirectory()
+    {
+        var name = $"sst-{Guid.NewGuid():N}.enc";
+        var path = Path.Combine(AppContext.BaseDirectory, name);
+        File.WriteAllBytes(path, Crypto.Encrypt("""{"MyQueue":{"url":"https://sqs"}}"""));
+        _files.Add(path);
+        Set("SST_KEY", Crypto.KeyBase64);
+        Set("SST_KEY_FILE", name);
+
+        Assert.Equal("https://sqs", Resource.Get<string>("MyQueue", "url"));
+    }
+
+    [Fact]
+    public void CachesUntilReloaded()
+    {
+        Set("SST_RESOURCE_MyBucket", """{"name":"first"}""");
+        Assert.Equal("first", Resource.Get<string>("MyBucket", "name"));
+
+        Environment.SetEnvironmentVariable("SST_RESOURCE_MyBucket", """{"name":"second"}""");
+        Assert.Equal("first", Resource.Get<string>("MyBucket", "name"));
+
+        Resource.Reload();
+        Assert.Equal("second", Resource.Get<string>("MyBucket", "name"));
+    }
+
+    public sealed record Bucket(string Name, string Arn);
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ResourceTests.Bucket))]
+internal partial class TestJsonContext : JsonSerializerContext
+{
+}

--- a/sdk/csharp/tests/SST.Sdk.Tests.csproj
+++ b/sdk/csharp/tests/SST.Sdk.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>SST.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../src/SST.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/www/src/content/docs/docs/linking.mdx
+++ b/www/src/content/docs/docs/linking.mdx
@@ -86,10 +86,10 @@ Resource Linking  allows you to access your **infrastructure** in your **runtime
    </Tabs>
 
    :::tip
-   The SDK currently supports JS/TS, Python, Golang, and Rust.
+   The SDK currently supports JS/TS, Python, Golang, Rust, and .NET.
    :::
 
-Learn how to use the SDK in [Python](/docs/reference/sdk/#python), [Golang](/docs/reference/sdk/#golang), and [Rust](/docs/reference/sdk/#rust).
+Learn how to use the SDK in [Python](/docs/reference/sdk/#python), [Golang](/docs/reference/sdk/#golang), [Rust](/docs/reference/sdk/#rust), and [.NET](/docs/reference/sdk/#net).
 
 ---
 

--- a/www/src/content/docs/docs/reference/sdk.mdx
+++ b/www/src/content/docs/docs/reference/sdk.mdx
@@ -11,7 +11,7 @@ You can use the SDK in your **functions**, **frontends**, and **container applic
 Check out the _SDK_ section in a component's API reference doc.
 :::
 
-Currently, the SDK is only available for JS/TS, Python, Golang, and Rust. Support for other languages is on the roadmap.
+Currently, the SDK is only available for JS/TS, Python, Golang, Rust, and .NET. Support for other languages is on the roadmap.
 
 ---
 
@@ -211,3 +211,50 @@ new sst.aws.Function("MyFunction", {
 ```
 
 Client functions are currently **not supported** in the Rust SDK.
+
+---
+
+## .NET
+
+Use the SST .NET SDK in your .NET functions or container applications. Until it's published to NuGet, reference the project from the SST repo.
+
+```xml title="src/MyFunction.csproj"
+<ItemGroup>
+  <ProjectReference Include="../../sdk/csharp/src/SST.Sdk.csproj" />
+</ItemGroup>
+```
+
+In your runtime code, use `Resource.Get` to access the linked resources. Pass a type to get a typed value, or leave it out to get a `JsonElement`.
+
+```csharp title="src/Function.cs"
+using SST;
+
+var bucket = Resource.Get<string>("MyBucket", "name");
+var openaiKey = Resource.Get<string>("OpenaiSecret", "value");
+```
+
+Where `MyBucket` and `OpenaiSecret` are linked to the function.
+
+```ts title="sst.config.ts"
+const bucket = new sst.aws.Bucket("MyBucket");
+const openai = new sst.Secret("OpenaiSecret");
+
+new sst.aws.Function("MyFunction", {
+  handler: "./src",
+  link: [bucket, openai],
+  runtime: "dotnet8"
+});
+```
+
+You can also read a whole resource into a record, and access the current app's info.
+
+```csharp title="src/Function.cs"
+public sealed record Bucket(string Name, string Arn);
+
+var bucket = Resource.Get<Bucket>("MyBucket");
+Console.WriteLine($"{Resource.App.Name} {Resource.App.Stage}");
+```
+
+For Native AOT, pass source generated `JsonTypeInfo` to `Resource.Get` instead of relying on reflection. See the [SDK README](https://github.com/anomalyco/sst/tree/dev/sdk/csharp) for details.
+
+Client functions are currently **not supported** in the .NET SDK.


### PR DESCRIPTION
### .NET support for SST: runtime, SDK, and three examples

SST functions can now run C#. runtime: "dotnet8" or "dotnet10" builds with dotnet publish and deploys to the managed Lambda runtimes, and sst dev runs the same binary locally against the Lambda Runtime API, the same way the Go and Rust runtimes do. The handler points at a project directory, a .csproj, or, with the .NET 10 SDK, a single-file app. Class-library handlers in the classic Assembly::Class::Method style deploy too, written as ./src::My.Namespace.Function::Handler.

Linked resources are read with the new SST.Sdk package, which mirrors the Go and Rust SDKs: it decrypts the resource.enc file on deploy and reads SST_RESOURCE_* in dev, with no dependencies and Native AOT support.

```
const table = new sst.aws.Dynamo("DotnetTable", { /* ... */ });

new sst.aws.Function("DotnetFunction", {
  runtime: "dotnet10",
  handler: "./src/Api.cs",   // or "./src" for a .csproj
  link: [table],
  url: true,
});
```

```
using SST;

var tableName = Resource.Get<string>("DotnetTable", "name");
var stage = Resource.App.Stage;
```

### Gotchas

- You will need the dotnet CLI on your PATH to deploy or run dev. .NET 8 SDK covers dotnet8 projects; file-based apps and net10.0 targets need the .NET 10 SDK. A missing or too-old SDK fails with a clear message instead of a blank build error.

- Live dev only works for executable assemblies, meaning projects bootstrapped with Amazon.Lambda.RuntimeSupport or ASP.NET Core with AddAWSLambdaHosting. Class libraries deploy but won't run locally yet.

- The SDK isn't on NuGet. The examples reference it by project path, which breaks outside this repo.

### Tests

**In the repo:**
- Go unit tests for the runtime cover handler parsing, project and file-based app detection, Web and Worker SDK defaults, publish arguments, rebuild filtering that skips bin/ and obj/, and the class-library and missing-SDK error paths.
- Go integration tests, skipped when the SDK is absent, publish each of the three examples for real, start them in dev mode against a fake Runtime API served by httptest, and assert the round trip: the linked bucket name, the linked table name, and an HTTP API hello world. They also check a deploy publish produces the dll, deps, and runtimeconfig the managed runtime needs, with no stray apphost or web.config.
- 29 xunit tests for the SDK cover load precedence, AES-GCM decryption with good, wrong, and malformed keys, typed and source-generated deserialization, error messages, caching, and dotnet pack output.

**Manual, on deployed stage:**
- The aws-lambda-dotnet example was deployed and its function URL returned the linked bucket name with a 200, warm requests around 250 ms, and the Lambda showing runtime dotnet8 and handler MyFunction.
- The aws-lambda-dotnet-file-based example was also successfully deployed. The curl sequence to validate them is in the example's doc comment, no failures observed through the entire call chain.